### PR TITLE
Support void context type for stateless handlers

### DIFF
--- a/src/router.zig
+++ b/src/router.zig
@@ -38,7 +38,10 @@ pub fn Router(comptime Ctx: type) type {
     return struct {
         const Self = @This();
 
-        pub const Handler = fn (*Ctx, *Request, *Response) anyerror!void;
+        pub const Handler = if (Ctx == void)
+            fn (*Request, *Response) anyerror!void
+        else
+            fn (*Ctx, *Request, *Response) anyerror!void;
 
         arena: std.heap.ArenaAllocator,
         // Each HTTP method has its own radix tree


### PR DESCRIPTION
## Summary

Adds support for using `void` as the Context type, allowing handlers to be defined without a context parameter. This is useful for simple, stateless HTTP servers that don't need shared state.

## Changes

- **Router Handler signature** (`src/router.zig`): Made conditional based on Context type
  - When `Ctx == void`: `fn (*Request, *Response) anyerror!void`
  - Otherwise: `fn (*Ctx, *Request, *Response) anyerror!void`

- **Server context field and init** (`src/server.zig`): Made conditional to support void
  - `ctx` field is `void` when `Ctx == void`, otherwise `*Ctx`
  - `init()` parameter matches the field type

- **Handler calls** (`src/server.zig`): Conditionally pass context only when non-void
  - Added compile-time checks for `Ctx != void` before accessing context
  - Handlers called without context parameter when `Ctx == void`

- **Test coverage** (`src/server_test.zig`): Added test for void context handlers

## Example Usage

```zig
// Before: required context even if unused
const Context = struct {};
var ctx: Context = .{};
var server = Server(Context).init(allocator, .{}, &ctx);

fn handler(ctx: *Context, req: *Request, res: *Response) !void {
    _ = ctx; // unused
    res.body = "Hello!\n";
}

// After: no context needed
var server = Server(void).init(allocator, .{}, {});

fn handler(req: *Request, res: *Response) !void {
    res.body = "Hello!\n";
}
```

## Test Results

All 59 tests pass, including:
- 58 existing tests with non-void contexts (unchanged)
- 1 new test verifying void context functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for context-free request handlers, enabling simplified server setup for applications without application state.

* **Tests**
  * Added comprehensive test coverage for void context server operations, including multi-task handling and HTTP workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->