### PR TITLE
Add req.json() support for parsing JSON request bodies

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -1,0 +1,18 @@
+pub const ServerConfig = struct {
+    timeout: Timeout = .{},
+    request: Request = .{},
+
+    pub const Timeout = struct {
+        /// Maximum time (ms) to receive a complete request
+        request: ?u64 = null,
+        /// Maximum time (ms) to keep idle connections open
+        keepalive: ?u64 = null,
+        /// Maximum number of requests per keepalive connection
+        request_count: ?usize = null,
+    };
+
+    pub const Request = struct {
+        /// Maximum size (bytes) for request body
+        max_body_size: usize = 1_048_576, // 1MB default
+    };
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 pub const Server = @import("server.zig").Server;
-pub const ServerConfig = @import("server.zig").ServerConfig;
+pub const ServerConfig = @import("config.zig").ServerConfig;
 pub const Router = @import("router.zig").Router;
 pub const Request = @import("request.zig").Request;
 pub const Response = @import("response.zig").Response;

--- a/src/server.zig
+++ b/src/server.zig
@@ -5,6 +5,7 @@ const Router = @import("router.zig").Router;
 const RequestParser = @import("parser.zig").RequestParser;
 const Request = @import("request.zig").Request;
 const Response = @import("response.zig").Response;
+const ServerConfig = @import("config.zig").ServerConfig;
 
 const log = std.log.scoped(.dusty);
 
@@ -20,19 +21,6 @@ fn defaultNotFound(req: *Request, res: *Response) void {
     res.status = .not_found;
     res.body = "404 Not Found\n";
 }
-
-pub const ServerConfig = struct {
-    timeout: Timeout = .{},
-
-    pub const Timeout = struct {
-        /// Maximum time (ms) to receive a complete request
-        request: ?u64 = null,
-        /// Maximum time (ms) to keep idle connections open
-        keepalive: ?u64 = null,
-        /// Maximum number of requests per keepalive connection
-        request_count: ?usize = null,
-    };
-};
 
 pub fn Server(comptime Ctx: type) type {
     return struct {
@@ -152,6 +140,7 @@ pub fn Server(comptime Ctx: type) type {
                 .arena = arena.allocator(),
                 .conn = &reader.interface,
                 .parser = undefined,
+                .config = self.config.request,
             };
 
             var parser: RequestParser = undefined;


### PR DESCRIPTION
Implements JSON body parsing following http.zig's approach:

- Add ServerConfig.Request.max_body_size (default 1MB)
- Add Request.body() method that reads and caches entire body
- Add Request.json(T) to parse JSON into typed structs
- Add Request.jsonValue() for generic JSON values
- Add Request.jsonObject() for JSON objects
- Smart reader() that returns cached body if already read
- Add demo in examples/basic.zig showing usage

All body reading respects max_body_size limit and returns error.BodyTooBig when exceeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added POST /api/users endpoint for user creation with auto-generated IDs and timestamps.
  * Introduced server configuration options for request timeouts, keepalive settings, and maximum body size limits.
  * Added request body caching with built-in JSON parsing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->