### PR TITLE
Fix header value parsing edge case for ARM NEON 🛠️

### DIFF
--- a/src/llhttp/llhttp.c
+++ b/src/llhttp/llhttp.c
@@ -2651,7 +2651,11 @@ static llparse_state_t llhttp__internal__run(
         mask = vorrq_u16(mask, single);
         narrow = vshrn_n_u16(mask, 4);
         match_mask = ~vget_lane_u64(vreinterpret_u64_u8(narrow), 0);
-        match_len = __builtin_ctzll(match_mask) >> 2;
+        if (match_mask == 0) {
+          match_len = 16;  // All characters matched
+        } else {
+          match_len = __builtin_ctzll(match_mask) >> 2;
+        }
         if (match_len != 16) {
           p += match_len;
           goto s_n_llhttp__internal__n_header_value_otherwise;


### PR DESCRIPTION
Running example on OSX I get
```
info(dusty): Listening on 127.0.0.1:8080
thread 56019635 panic: passing zero to ctz(), which is not a valid argument
src/llhttp/llhttp.c:2654:21: 0x10052c8b3 in llhttp__internal__run (/dusty/src/llhttp/llhttp.c)
        match_len = __builtin_ctzll(match_mask) >> 2;
                    ^
src/llhttp/llhttp.c:10080:10: 0x10051fa87 in llhttp__internal_execute (/dusty/src/llhttp/llhttp.c)
  next = llhttp__internal__run(state, (const unsigned char*) p, (const unsigned char*) endp);
         ^
src/llhttp/api.c:126:10: 0x100571f9b in llhttp_execute (/dusty/src/llhttp/api.c)
  return llhttp__internal_execute(parser, data, data + len);
         ^
/dusty/src/parser.zig:96:37: 0x10064686b in feed (basic-example)
        const err = c.llhttp_execute(&self.parser, data.ptr, data.len);
                                    ^
/dusty/src/server.zig:171:36: 0x100638cf7 in handleConnection (basic-example)
                        parser.feed(unparsed) catch |err| switch (err) {
                                   ^
/Users/user/.cache/zig/p/zio-0.4.0-xHbVVDVWHAAprBuo2ZCM5OUO-UbSWXOI2xLolsOuRF2d/src/core/task.zig:401:21: 0x100627e0b in start (basic-example)
                    r.* = @call(.auto, func, a.*);
                    ^
/Users/user/.cache/zig/p/zio-0.4.0-xHbVVDVWHAAprBuo2ZCM5OUO-UbSWXOI2xLolsOuRF2d/src/core/task.zig:301:16: 0x10061501f in startFn (basic-example)
        c.start(context, result);
               ^
/Users/user/.cache/zig/p/zio-0.4.0-xHbVVDVWHAAprBuo2ZCM5OUO-UbSWXOI2xLolsOuRF2d/src/coroutines.zig:483:31: 0x10062e44f in entrypointFn (basic-example)
                coro_data.func(coro, coro_data.userdata);
                              ^
???:?:?: 0x0 in ??? (???)
[1]    63140 abort      ./zig-out/bin/basic-example
```

This happens due to llhttp ARM NEON issue in llhttp.

Issue can be fixed by simple patch

In this PR:
- Handle case where all 16 characters match by setting match_len to 16
- Prevent potential undefined behavior when match_mask is zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an edge case in header parsing that could lead to undefined behavior, ensuring more reliable and stable header processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->