### PR TITLE
Add parseHeaders helper and Request.body test

### DIFF
--- a/src/request.zig
+++ b/src/request.zig
@@ -245,3 +245,65 @@ pub const BodyReader = struct {
         }
     }
 };
+
+/// Parse HTTP headers from a reader and prepare for body reading.
+/// Returns error.EndOfStream if connection closed cleanly with no data.
+/// Returns error.IncompleteRequest if connection closed mid-request.
+pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) !void {
+    var parsed_len: usize = 0;
+    while (!parser.state.headers_complete) {
+        const buffered = reader.buffered();
+        const unparsed = buffered[parsed_len..];
+        if (unparsed.len > 0) {
+            parser.feed(unparsed) catch |err| switch (err) {
+                error.Paused => {
+                    const consumed = parser.getConsumedBytes(unparsed.ptr);
+                    parsed_len += consumed;
+                    continue;
+                },
+                else => return err,
+            };
+            parsed_len += unparsed.len;
+            continue;
+        }
+        reader.fillMore() catch |err| switch (err) {
+            error.EndOfStream => {
+                if (parsed_len == 0) return error.EndOfStream;
+                return error.IncompleteRequest;
+            },
+            else => return err,
+        };
+    }
+    reader.toss(parsed_len);
+    parser.resumeParsing();
+
+    // Feed empty buffer to advance state machine for bodyless requests
+    parser.feed(&.{}) catch |err| switch (err) {
+        error.Paused => {},
+        else => return err,
+    };
+}
+
+test "Request.body: basic POST" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello";
+    var reader = std.Io.Reader.fixed(raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .conn = &reader,
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    const body = try req.body();
+    try std.testing.expectEqualStrings("hello", body.?);
+}


### PR DESCRIPTION
## Summary
- Extract header parsing logic from server.zig into reusable `parseHeaders()` function in request.zig
- Add unit test for `Request.body()` using the new test fixture pattern
- Enables testing Request methods with raw HTTP data via `std.Io.Reader.fixed()`

## Test plan
- [x] All 71 tests pass
- [x] Server behavior unchanged (refactor only)