### PR TITLE
Add DNS resolution support for HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ pub fn main() !void {
     var client = http.Client.init(allocator, .{});
     defer client.deinit();
 
-    var response = try client.fetch(rt, "http://example.com/api", .{});
+    var response = try client.fetch(rt, "http://httpbin.org/get", .{});
     defer response.deinit();
 
-    std.debug.print("Status: {d}\n", .{@intFromEnum(response.status())});
+    std.debug.print("Status: {t}\n", .{response.status()});
 
     if (try response.body()) |body| {
         std.debug.print("Body: {s}\n", .{body});

--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,7 @@ pub fn build(b: *std.Build) void {
 
     const example_files = [_][]const u8{
         "basic",
+        "client",
         "sse",
         "websocket",
     };

--- a/examples/client.zig
+++ b/examples/client.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const zio = @import("zio");
+const http = @import("dusty");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var rt = try zio.Runtime.init(allocator, .{});
+    defer rt.deinit();
+
+    var client = http.Client.init(allocator, .{});
+    defer client.deinit();
+
+    var response = try client.fetch(rt, "http://httpbin.org/get", .{});
+    defer response.deinit();
+
+    std.debug.print("Status: {t}\n", .{response.status()});
+
+    std.debug.print("Headers:\n", .{});
+    var it = response.headers().iterator();
+    while (it.next()) |entry| {
+        std.debug.print("  {s}: {s}\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+    }
+
+    if (try response.body()) |body| {
+        std.debug.print("Body: {s}\n", .{body});
+    }
+}

--- a/src/client.zig
+++ b/src/client.zig
@@ -381,8 +381,7 @@ pub const Client = struct {
         // Try to get a connection from the pool
         const conn = self.pool.acquire(rt, host, port) orelse blk: {
             // No pooled connection, create a new one
-            const addr = try zio.net.IpAddress.parseIp(host, port);
-            const stream = try addr.connect(rt);
+            const stream = try zio.net.tcpConnectToHost(rt, host, port);
             errdefer stream.close(rt);
 
             const new_conn = try self.allocator.create(Connection);


### PR DESCRIPTION
## Summary
- Replace `IpAddress.parseIp` with `tcpConnectToHost` to enable DNS resolution for domain names
- Add client example demonstrating fetch from httpbin.org
- Update README with working httpbin.org example

Closes #31