### PR TITLE
Start preparing the codebase for std.Io migration

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -3,7 +3,7 @@ const zio = @import("zio");
 const http = @import("dusty");
 
 const AppContext = struct {
-    rt: *zio.Runtime,
+    io: *zio.Runtime,
     counter: usize = 0,
 
     pub fn uncaughtError(self: *AppContext, req: *http.Request, res: *http.Response, err: anyerror) void {
@@ -23,7 +23,7 @@ const AppContext = struct {
 
 fn handleSlow(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {
     _ = req;
-    try ctx.rt.sleep(10);
+    try ctx.io.sleep(10);
     res.body = "Hello World!\n";
 }
 
@@ -143,8 +143,8 @@ fn handleCreateUser(ctx: *AppContext, req: *http.Request, res: *http.Response) !
     }, .{});
 }
 
-pub fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime) !void {
-    var ctx: AppContext = .{ .rt = rt };
+pub fn runServer(allocator: std.mem.Allocator, io: *zio.Runtime) !void {
+    var ctx: AppContext = .{ .io = io };
     const AppServer = http.Server(AppContext);
 
     const config: http.ServerConfig = .{
@@ -176,16 +176,16 @@ pub fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime) !void {
 
     const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
 
-    var task = try rt.spawn(AppServer.listen, .{ &server, rt, addr }, .{});
-    defer task.cancel(rt);
+    var task = try io.spawn(AppServer.listen, .{ &server, io, addr }, .{});
+    defer task.cancel(io);
 
-    const result = try zio.select(rt, .{ .task = &task, .sigint = &sigint, .sigterm = &sigterm });
+    const result = try zio.select(io, .{ .task = &task, .sigint = &sigint, .sigterm = &sigterm });
     switch (result) {
         .task => |r| {
             return r;
         },
         .sigint, .sigterm => {
-            task.cancel(rt);
+            task.cancel(io);
             return;
         },
     }
@@ -196,9 +196,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
+    var io = try zio.Runtime.init(allocator, .{});
+    defer io.deinit();
 
-    var task = try rt.spawn(runServer, .{ allocator, rt }, .{});
-    try task.join(rt);
+    var task = try io.spawn(runServer, .{ allocator, io }, .{});
+    try task.join(io);
 }

--- a/examples/websocket.zig
+++ b/examples/websocket.zig
@@ -3,7 +3,7 @@ const zio = @import("zio");
 const http = @import("dusty");
 
 const AppContext = struct {
-    rt: *zio.Runtime,
+    io: *zio.Runtime,
 };
 
 fn handleWebSocket(_: *AppContext, req: *http.Request, res: *http.Response) !void {
@@ -71,8 +71,8 @@ fn handleIndex(_: *AppContext, _: *http.Request, res: *http.Response) !void {
     ;
 }
 
-pub fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime) !void {
-    var ctx: AppContext = .{ .rt = rt };
+pub fn runServer(allocator: std.mem.Allocator, io: *zio.Runtime) !void {
+    var ctx: AppContext = .{ .io = io };
 
     var server = http.Server(AppContext).init(allocator, .{}, &ctx);
     defer server.deinit();
@@ -83,7 +83,7 @@ pub fn runServer(allocator: std.mem.Allocator, rt: *zio.Runtime) !void {
     const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
 
     std.log.info("WebSocket echo server running at http://127.0.0.1:8080", .{});
-    try server.listen(rt, addr);
+    try server.listen(io, addr);
 }
 
 pub fn main() !void {
@@ -91,9 +91,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
+    var io = try zio.Runtime.init(allocator, .{});
+    defer io.deinit();
 
-    var task = try rt.spawn(runServer, .{ allocator, rt }, .{});
-    try task.join(rt);
+    var task = try io.spawn(runServer, .{ allocator, io }, .{});
+    try task.join(io);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -90,9 +90,9 @@ pub fn Server(comptime Ctx: type) type {
             self.router.deinit();
         }
 
-        pub fn listen(self: *Self, rt: *zio.Runtime, addr: zio.net.IpAddress) !void {
-            const server = try addr.listen(rt, .{ .reuse_address = true });
-            defer server.close(rt);
+        pub fn listen(self: *Self, io: *zio.Runtime, addr: zio.net.IpAddress) !void {
+            const server = try addr.listen(io, .{ .reuse_address = true });
+            defer server.close(io);
 
             self.address = server.socket.address;
             self.ready.set();
@@ -100,17 +100,17 @@ pub fn Server(comptime Ctx: type) type {
             log.info("Listening on {f}", .{self.address});
 
             var group: zio.Group = .init;
-            defer group.cancel(rt);
+            defer group.cancel(io);
 
             while (true) {
-                const stream = server.accept(rt) catch |err| {
+                const stream = server.accept(io) catch |err| {
                     if (err == error.Canceled) {
                         log.info("Graceful shutdown requested", .{});
                         while (true) { // TODO: add graceful shutdown timeout
                             const remaining = self.active_connections.load(.acquire);
                             if (remaining == 0) break;
                             log.info("Waiting for {} remaining connections to close", .{remaining});
-                            try self.last_connection_closed.timedWait(rt, 100 * std.time.ns_per_ms);
+                            try self.last_connection_closed.timedWait(io, 100 * std.time.ns_per_ms);
                         }
                         return err;
                     }
@@ -118,15 +118,15 @@ pub fn Server(comptime Ctx: type) type {
                 };
 
                 _ = self.active_connections.fetchAdd(1, .acq_rel);
-                group.spawn(rt, handleConnection, .{ self, rt, stream }) catch |err| {
+                group.spawn(io, handleConnection, .{ self, io, stream }) catch |err| {
                     log.err("Failed to accept connection: {}", .{err});
                     _ = self.active_connections.fetchSub(1, .acq_rel);
-                    stream.close(rt);
+                    stream.close(io);
                 };
             }
         }
 
-        pub fn handleConnection(self: *Self, rt: *zio.Runtime, stream: zio.net.Stream) !void {
+        pub fn handleConnection(self: *Self, io: *zio.Runtime, stream: zio.net.Stream) !void {
             defer {
                 const v = self.active_connections.fetchSub(1, .acq_rel);
                 if (v == 1) {
@@ -134,17 +134,17 @@ pub fn Server(comptime Ctx: type) type {
                 }
             }
 
-            defer stream.close(rt);
+            defer stream.close(io);
 
             var needs_shutdown = true;
-            defer if (needs_shutdown) stream.shutdown(rt, .both) catch |err| {
+            defer if (needs_shutdown) stream.shutdown(io, .both) catch |err| {
                 log.warn("Failed to shutdown client connection: {}", .{err});
             };
 
-            var reader = stream.reader(rt, &.{});
+            var reader = stream.reader(io, &.{});
 
             var write_buffer: [4096]u8 = undefined;
-            var writer = stream.writer(rt, &write_buffer);
+            var writer = stream.writer(io, &write_buffer);
 
             var arena = std.heap.ArenaAllocator.init(self.allocator);
             defer arena.deinit();
@@ -175,9 +175,9 @@ pub fn Server(comptime Ctx: type) type {
             while (true) {
                 request_count += 1;
 
-                defer timeout.clear(rt);
+                defer timeout.clear(io);
                 if (self.config.timeout.request) |timeout_ms| {
-                    timeout.set(rt, timeout_ms * std.time.ns_per_ms);
+                    timeout.set(io, timeout_ms * std.time.ns_per_ms);
                 }
 
                 // TODO: handle error.Canceled caused by timeout and return 504
@@ -243,7 +243,7 @@ pub fn Server(comptime Ctx: type) type {
 
                 // Activate keepalive timeout
                 if (self.config.timeout.keepalive) |timeout_ms| {
-                    timeout.set(rt, timeout_ms * std.time.ns_per_ms);
+                    timeout.set(io, timeout_ms * std.time.ns_per_ms);
                 }
 
                 // Fill some data here, while the the keepalive timeout is active

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -6,52 +6,52 @@ fn testClientServer(comptime Ctx: type, ctx: *Ctx) !void {
     const TestServer = dusty.Server(Ctx);
 
     const Test = struct {
-        pub fn mainFn(rt: *zio.Runtime, test_ctx: *Ctx) !void {
+        pub fn mainFn(io: *zio.Runtime, test_ctx: *Ctx) !void {
             var server = TestServer.init(std.testing.allocator, .{}, test_ctx);
             defer server.deinit();
 
             try test_ctx.setup(&server);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, &server }, .{});
-            defer server_task.cancel(rt);
+            var server_task = try io.spawn(serverFn, .{ io, &server }, .{});
+            defer server_task.cancel(io);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, &server, test_ctx }, .{});
-            defer client_task.cancel(rt);
+            var client_task = try io.spawn(clientFn, .{ io, &server, test_ctx }, .{});
+            defer client_task.cancel(io);
 
-            try client_task.join(rt);
+            try client_task.join(io);
         }
 
-        pub fn serverFn(rt: *zio.Runtime, server: *TestServer) !void {
+        pub fn serverFn(io: *zio.Runtime, server: *TestServer) !void {
             const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(rt, addr);
+            try server.listen(io, addr);
         }
 
-        pub fn clientFn(rt: *zio.Runtime, server: *TestServer, test_ctx: *Ctx) !void {
-            try server.ready.wait(rt);
+        pub fn clientFn(io: *zio.Runtime, server: *TestServer, test_ctx: *Ctx) !void {
+            try server.ready.wait(io);
 
-            const client = try server.address.connect(rt);
-            defer client.close(rt);
-            defer client.shutdown(rt, .both) catch {};
+            const client = try server.address.connect(io);
+            defer client.close(io);
+            defer client.shutdown(io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(rt, &write_buf);
+            var writer = client.writer(io, &write_buf);
 
             try test_ctx.makeRequest(&writer.interface);
 
             // Read response
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(rt, &read_buf);
+            var reader = client.reader(io, &read_buf);
             const response = try reader.interface.takeDelimiterExclusive('\n');
 
             std.log.info("Response: {s}", .{response});
         }
     };
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    var io = try zio.Runtime.init(std.testing.allocator, .{});
+    defer io.deinit();
 
-    var task = try rt.spawn(Test.mainFn, .{ rt, ctx }, .{});
-    try task.join(rt);
+    var task = try io.spawn(Test.mainFn, .{ io, ctx }, .{});
+    try task.join(io);
 }
 
 test "Server: POST with body" {
@@ -301,39 +301,39 @@ test "Server: WebSocket echo" {
     };
 
     const Test = struct {
-        pub fn mainFn(rt: *zio.Runtime, ctx: *TestContext) !void {
+        pub fn mainFn(io: *zio.Runtime, ctx: *TestContext) !void {
             var server = dusty.Server(TestContext).init(std.testing.allocator, .{}, ctx);
             defer server.deinit();
 
             try ctx.setup(&server);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, &server }, .{});
-            defer server_task.cancel(rt);
+            var server_task = try io.spawn(serverFn, .{ io, &server }, .{});
+            defer server_task.cancel(io);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, &server }, .{});
-            defer client_task.cancel(rt);
+            var client_task = try io.spawn(clientFn, .{ io, &server }, .{});
+            defer client_task.cancel(io);
 
-            try client_task.join(rt);
+            try client_task.join(io);
         }
 
-        pub fn serverFn(rt: *zio.Runtime, server: *dusty.Server(TestContext)) !void {
+        pub fn serverFn(io: *zio.Runtime, server: *dusty.Server(TestContext)) !void {
             const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(rt, addr);
+            try server.listen(io, addr);
         }
 
-        pub fn clientFn(rt: *zio.Runtime, server: *dusty.Server(TestContext)) !void {
-            try server.ready.wait(rt);
+        pub fn clientFn(io: *zio.Runtime, server: *dusty.Server(TestContext)) !void {
+            try server.ready.wait(io);
 
-            const client = try server.address.connect(rt);
-            defer client.close(rt);
-            defer client.shutdown(rt, .both) catch {};
+            const client = try server.address.connect(io);
+            defer client.close(io);
+            defer client.shutdown(io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(rt, &write_buf);
+            var writer = client.writer(io, &write_buf);
             const w = &writer.interface;
 
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(rt, &read_buf);
+            var reader = client.reader(io, &read_buf);
             const r = &reader.interface;
 
             // Send WebSocket upgrade request
@@ -426,11 +426,11 @@ test "Server: WebSocket echo" {
 
     var ctx: TestContext = .{};
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    var io = try zio.Runtime.init(std.testing.allocator, .{});
+    defer io.deinit();
 
-    var task = try rt.spawn(Test.mainFn, .{ rt, &ctx }, .{});
-    try task.join(rt);
+    var task = try io.spawn(Test.mainFn, .{ io, &ctx }, .{});
+    try task.join(io);
 
     try std.testing.expect(ctx.ws_upgraded);
     try std.testing.expect(ctx.message_received);
@@ -439,36 +439,36 @@ test "Server: WebSocket echo" {
 
 test "Server: void context handlers" {
     const Test = struct {
-        pub fn mainFn(rt: *zio.Runtime) !void {
+        pub fn mainFn(io: *zio.Runtime) !void {
             var server = dusty.Server(void).init(std.testing.allocator, .{}, {});
             defer server.deinit();
 
             server.router.get("/test", handleGet);
             server.router.post("/echo", handlePost);
 
-            var server_task = try rt.spawn(serverFn, .{ rt, &server }, .{});
-            defer server_task.cancel(rt);
+            var server_task = try io.spawn(serverFn, .{ io, &server }, .{});
+            defer server_task.cancel(io);
 
-            var client_task = try rt.spawn(clientFn, .{ rt, &server }, .{});
-            defer client_task.cancel(rt);
+            var client_task = try io.spawn(clientFn, .{ io, &server }, .{});
+            defer client_task.cancel(io);
 
-            try client_task.join(rt);
+            try client_task.join(io);
         }
 
-        pub fn serverFn(rt: *zio.Runtime, server: *dusty.Server(void)) !void {
+        pub fn serverFn(io: *zio.Runtime, server: *dusty.Server(void)) !void {
             const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(rt, addr);
+            try server.listen(io, addr);
         }
 
-        pub fn clientFn(rt: *zio.Runtime, server: *dusty.Server(void)) !void {
-            try server.ready.wait(rt);
+        pub fn clientFn(io: *zio.Runtime, server: *dusty.Server(void)) !void {
+            try server.ready.wait(io);
 
-            const client = try server.address.connect(rt);
-            defer client.close(rt);
-            defer client.shutdown(rt, .both) catch {};
+            const client = try server.address.connect(io);
+            defer client.close(io);
+            defer client.shutdown(io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(rt, &write_buf);
+            var writer = client.writer(io, &write_buf);
 
             // Test GET request
             try writer.interface.writeAll("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
@@ -476,7 +476,7 @@ test "Server: void context handlers" {
 
             // Read response - just verify we get something back
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(rt, &read_buf);
+            var reader = client.reader(io, &read_buf);
             const status_line = try reader.interface.takeDelimiterExclusive('\n');
 
             std.log.info("Response: {s}", .{status_line});
@@ -496,9 +496,9 @@ test "Server: void context handlers" {
         }
     };
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    var io = try zio.Runtime.init(std.testing.allocator, .{});
+    defer io.deinit();
 
-    var task = try rt.spawn(Test.mainFn, .{rt}, .{});
-    try task.join(rt);
+    var task = try io.spawn(Test.mainFn, .{io}, .{});
+    try task.join(io);
 }


### PR DESCRIPTION
This makes it easier to migrate to `std.Io` later on, as `std.Io.select` doesn't support anything but tasks.