### PR TITLE
Add gzip/deflate decompression support for HTTP client

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -409,3 +409,28 @@ test "ContentType: parse from file extension" {
     try std.testing.expectEqual(ContentType.jpeg, ContentType.fromExtension(".jpeg"));
     try std.testing.expectEqual(ContentType.unknown, ContentType.fromExtension(""));
 }
+
+pub const ContentEncoding = enum {
+    identity,
+    gzip,
+    deflate,
+    unknown,
+
+    pub fn fromString(value: []const u8) ContentEncoding {
+        if (std.ascii.eqlIgnoreCase(value, "gzip")) return .gzip;
+        if (std.ascii.eqlIgnoreCase(value, "x-gzip")) return .gzip;
+        if (std.ascii.eqlIgnoreCase(value, "deflate")) return .deflate;
+        if (std.ascii.eqlIgnoreCase(value, "identity")) return .identity;
+        return .unknown;
+    }
+};
+
+test "ContentEncoding: fromString" {
+    try std.testing.expectEqual(ContentEncoding.identity, ContentEncoding.fromString("identity"));
+    try std.testing.expectEqual(ContentEncoding.gzip, ContentEncoding.fromString("gzip"));
+    try std.testing.expectEqual(ContentEncoding.gzip, ContentEncoding.fromString("x-gzip"));
+    try std.testing.expectEqual(ContentEncoding.gzip, ContentEncoding.fromString("GZIP"));
+    try std.testing.expectEqual(ContentEncoding.deflate, ContentEncoding.fromString("deflate"));
+    try std.testing.expectEqual(ContentEncoding.unknown, ContentEncoding.fromString("br"));
+    try std.testing.expectEqual(ContentEncoding.unknown, ContentEncoding.fromString("zstd"));
+}

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -8,6 +8,7 @@ const Method = @import("http.zig").Method;
 const Status = @import("http.zig").Status;
 const Headers = @import("http.zig").Headers;
 const ContentType = @import("http.zig").ContentType;
+const ContentEncoding = @import("http.zig").ContentEncoding;
 const Request = @import("request.zig").Request;
 
 pub const ParseError = error{
@@ -258,6 +259,7 @@ pub const ParsedResponse = struct {
     version_minor: u8 = 0,
     headers: Headers = .{},
     content_type: ?ContentType = null,
+    content_encoding: ContentEncoding = .identity,
     arena: std.mem.Allocator,
 };
 
@@ -426,6 +428,10 @@ pub const ResponseParser = struct {
 
         if (self.response.headers.get("Content-Type")) |content_type| {
             self.response.content_type = ContentType.fromContentType(content_type);
+        }
+
+        if (self.response.headers.get("Content-Encoding")) |content_encoding| {
+            self.response.content_encoding = ContentEncoding.fromString(content_encoding);
         }
 
         self.state.headers_complete = true;


### PR DESCRIPTION
## Summary
- Add `ContentEncoding` enum with `gzip`, `deflate`, `identity`, `unknown` variants
- Parse `Content-Encoding` response header automatically
- Add `decompress: bool = true` option to `FetchOptions`
- Send `Accept-Encoding: gzip, deflate` header when decompression enabled
- `ClientResponse.reader()` transparently decompresses response body
- Fail early with `UnsupportedContentEncoding` error for unknown encodings (e.g., brotli, zstd)
- Refactor `writeRequest()` to use `WriteRequestOptions` struct for cleaner API

## Test plan
- [x] Unit tests for gzip decompression (enabled and disabled)
- [x] Unit tests for ContentEncoding parsing
- [x] All existing tests pass (129 tests)

Fixes https://github.com/lalinsky/dusty/issues/40