### PR TITLE
Add Zig and OpenSSL setup to Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,5 +55,5 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # Allow Claude to run zig commands and check.sh
-          claude_args: '--allowedTools "Bash(zig:*)" "Bash(./check.sh:*)"'
+          claude_args: '--allowed-tools "Bash(zig:*)" "Bash(./check.sh:*)"'
 


### PR DESCRIPTION
Install Zig 0.15.2 and libssl-dev so Claude can run zig env
and build code that depends on OpenSSL.