### PR TITLE
Add Connection.flush() to centralize HTTPS two-layer flushing

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -82,7 +82,11 @@ pub const WebSocketClient = struct {
     }
 
     pub fn receive(self: *WebSocketClient) !WebSocket.Message {
-        return self.ws.receive();
+        const msg = try self.ws.receive();
+        if (self.ws.auto_responded) {
+            try self.conn.flush();
+        }
+        return msg;
     }
 
     pub fn ping(self: *WebSocketClient, data: []const u8) !void {

--- a/src/client.zig
+++ b/src/client.zig
@@ -82,7 +82,13 @@ pub const WebSocketClient = struct {
     }
 
     pub fn receive(self: *WebSocketClient) !WebSocket.Message {
-        const msg = try self.ws.receive();
+        const msg = self.ws.receive() catch |err| {
+            if (self.ws.auto_responded) {
+                // Best effort: flush queued control-frame reply before bubbling error.
+                self.conn.flush() catch {};
+            }
+            return err;
+        };
         if (self.ws.auto_responded) {
             try self.conn.flush();
         }

--- a/src/client.zig
+++ b/src/client.zig
@@ -889,8 +889,6 @@ fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
     if (opts.body) |b| {
         try writer.writeAll(b);
     }
-
-    try writer.flush();
 }
 
 /// Parse HTTP response headers from a reader.

--- a/src/client.zig
+++ b/src/client.zig
@@ -78,9 +78,7 @@ pub const WebSocketClient = struct {
 
     pub fn send(self: *WebSocketClient, msg_type: WebSocket.MessageType, data: []const u8) !void {
         try self.ws.send(msg_type, data);
-        if (self.conn.protocol == .https) {
-            try self.conn.tcp_writer.interface.flush();
-        }
+        try self.conn.flush();
     }
 
     pub fn receive(self: *WebSocketClient) !WebSocket.Message {
@@ -89,10 +87,12 @@ pub const WebSocketClient = struct {
 
     pub fn ping(self: *WebSocketClient, data: []const u8) !void {
         try self.ws.ping(data);
+        try self.conn.flush();
     }
 
     pub fn close(self: *WebSocketClient, code: WebSocket.CloseCode, reason: []const u8) !void {
         try self.ws.close(code, reason);
+        try self.conn.flush();
     }
 
     pub fn deinit(self: *WebSocketClient) void {
@@ -365,6 +365,13 @@ pub const Connection = struct {
         self.reader.buffer = self.read_buffer;
         self.reader.seek = 0;
         self.reader.end = buffered.len;
+    }
+
+    pub fn flush(self: *Connection) !void {
+        try self.writer.flush();
+        if (self.protocol == .https) {
+            try self.tcp_writer.interface.flush();
+        }
     }
 
     pub fn host(self: *const Connection) []const u8 {
@@ -693,12 +700,7 @@ pub const Client = struct {
         }
 
         try conn.writer.writeAll("\r\n");
-        try conn.writer.flush();
-
-        // For HTTPS, flush the TCP writer
-        if (info.protocol == .https) {
-            try conn.tcp_writer.interface.flush();
-        }
+        try conn.flush();
 
         // Parse response headers
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {
@@ -766,10 +768,7 @@ pub const Client = struct {
             .decompress = options.decompress,
         });
 
-        // For HTTPS, flush the TCP writer to send encrypted data over network
-        if (protocol == .https) {
-            try conn.tcp_writer.interface.flush();
-        }
+        try conn.flush();
 
         // Parse response headers
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -8,6 +8,7 @@ pub const WebSocket = struct {
     prng: std.Random.DefaultPrng = std.Random.DefaultPrng.init(0),
     max_message_size: usize = default_max_message_size,
     closed: bool = false,
+    auto_responded: bool = false,
     fragmented_type: ?MessageType = null,
     fragmented_data: std.ArrayListUnmanaged(u8) = .{},
 
@@ -72,6 +73,7 @@ pub const WebSocket = struct {
     /// Ping frames are handled automatically (pong sent).
     /// Pong frames are ignored.
     pub fn receive(self: *WebSocket) !Message {
+        self.auto_responded = false;
         while (true) {
             const frame = try self.readFrame();
 
@@ -79,6 +81,7 @@ pub const WebSocket = struct {
                 .ping => {
                     // Auto-respond with pong
                     try self.writeFrame(.pong, frame.payload, true);
+                    self.auto_responded = true;
                     continue;
                 },
                 .pong => {
@@ -96,6 +99,7 @@ pub const WebSocket = struct {
                     }
                     // Echo close frame back
                     try self.writeCloseFrame(close_code orelse .normal, reason);
+                    self.auto_responded = true;
                     return .{ .type = .close, .data = reason, .close_code = close_code };
                 },
                 .continuation => {


### PR DESCRIPTION
## Summary
- Adds `Connection.flush()` that flushes both the TLS writer and underlying TCP writer for HTTPS (or just the writer for HTTP)
- Fixes WebSocket `ping` and `close` hanging over `wss://` due to missing TCP writer flush
- Replaces scattered inline HTTPS flush logic in `websocketUpgrade` and `fetchInternal`

## Test plan
- [x] All 171 existing tests pass
- [ ] Verify WebSocket ping/close work over wss:// connections