### PR TITLE
Migrate to std.Io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /zig-out
 /.zig-cache
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -4,21 +4,13 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const zio_backend = b.option([]const u8, "zio_backend", "Override zio event loop backend (io_uring, epoll, kqueue, iocp, poll)");
-
-    const zio = b.dependency("zio", .{
-        .target = target,
-        .optimize = optimize,
-        .backend = zio_backend,
-    });
-
     const mod = b.addModule("dusty", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
-    mod.addImport("zio", zio.module("zio"));
 
+    mod.link_libc = true;
     mod.addCSourceFiles(.{
         .files = &[_][]const u8{
             "src/llhttp/llhttp.c",
@@ -50,7 +42,6 @@ pub fn build(b: *std.Build) void {
             }),
         });
         example.root_module.addImport("dusty", mod);
-        example.root_module.addImport("zio", zio.module("zio"));
         const install = b.addInstallArtifact(example, .{});
         examples_step.dependOn(&install.step);
         // Add to default install step so examples are built with plain `zig build`

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,12 +31,7 @@
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
-    .dependencies = .{
-        .zio = .{
-            .url = "git+https://github.com/lalinsky/zio?ref=v0.10.0#aff2715955aaf9ff47570fcbd0451e42ff9bac6c",
-            .hash = "zio-0.10.0-xHbVVPZLGwB4J2qkJSFbd54q1LZHbEUpFPcxlpUi1_84",
-        },
-    },
+    .dependencies = .{},
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -178,7 +178,7 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
     var sigterm = try zio.Signal.init(.terminate);
     defer sigterm.deinit();
 
-    const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
     var task = try zio.spawn(AppServer.listen, .{ &server, addr });
     defer task.cancel();
@@ -196,10 +196,5 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
-
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
-
-    try runServer(allocator, rt.io());
+    try runServer(init.gpa, init.io);
 }

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 const AppContext = struct {
@@ -172,27 +171,10 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
     server.router.get("/api/users/:id", handleApiUser);
     server.router.post("/api/users", handleCreateUser);
 
-    var sigint = try zio.Signal.init(.interrupt);
-    defer sigint.deinit();
-
-    var sigterm = try zio.Signal.init(.terminate);
-    defer sigterm.deinit();
-
     const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
-    var task = try zio.spawn(AppServer.listen, .{ &server, addr });
-    defer task.cancel();
-
-    const result = try zio.select(.{ .task = &task, .sigint = &sigint, .sigterm = &sigterm });
-    switch (result) {
-        .task => |r| {
-            return r;
-        },
-        .sigint, .sigterm => {
-            task.cancel();
-            return;
-        },
-    }
+    std.log.info("Starting server on http://127.0.0.1:8080", .{});
+    try server.listen(addr);
 }
 
 pub fn main(init: std.process.Init) !void {

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -142,14 +142,7 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
     var ctx: AppContext = .{};
     const AppServer = http.Server(AppContext);
 
-    const config: http.ServerConfig = .{
-        .timeout = .{
-            .request = 60 * std.time.ms_per_s,
-            .keepalive = 300 * std.time.ms_per_s,
-        },
-    };
-
-    var server = AppServer.init(allocator, io, config, &ctx);
+    var server = AppServer.init(allocator, io, .{}, &ctx);
     defer server.deinit();
 
     const cors = try server.middleware(http.middleware.Cors, .{

--- a/examples/client.zig
+++ b/examples/client.zig
@@ -1,9 +1,9 @@
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
+    const io = init.io;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len < 2) {
@@ -14,10 +14,7 @@ pub fn main(init: std.process.Init) !void {
 
     const url = args[1];
 
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
-
-    var client = http.Client.init(allocator, rt.io(), .{});
+    var client = http.Client.init(allocator, io, .{});
     defer client.deinit();
 
     var response = try client.fetch(url, .{});
@@ -35,7 +32,7 @@ pub fn main(init: std.process.Init) !void {
 
     const body_reader = response.reader();
     var write_buf: [8192]u8 = undefined;
-    var out = zio.stdout().writer(&write_buf);
+    var out = std.Io.File.stdout().writer(io, &write_buf);
     const total_bytes = try body_reader.streamRemaining(&out.interface);
     try out.interface.flush();
     std.debug.print("Total bytes: {d}\n", .{total_bytes});

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 const AppContext = struct {

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -103,7 +103,7 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io, upstream_url: []const
     // Catch-all route - proxy everything for all common HTTP methods
     server.router.any("/*", handleProxy);
 
-    const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
     std.log.info("Reverse proxy server running at http://127.0.0.1:8080", .{});
     std.log.info("Forwarding all requests to: {s}", .{upstream_url});
@@ -115,7 +115,6 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io, upstream_url: []const
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     const upstream_url = if (args.len > 1)
@@ -123,8 +122,5 @@ pub fn main(init: std.process.Init) !void {
     else
         "https://httpbin.org";
 
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
-
-    try runServer(allocator, rt.io(), upstream_url);
+    try runServer(init.gpa, init.io, upstream_url);
 }

--- a/examples/sse.zig
+++ b/examples/sse.zig
@@ -17,9 +17,9 @@ fn handleEvents(ctx: *AppContext, req: *http.Request, res: *http.Response) !void
             last_seen = current;
             var buf: [64]u8 = undefined;
             const msg = try std.fmt.bufPrint(&buf, "tick {d}", .{current});
-            stream.send(msg, .{ .event = "tick" }) catch break;
+            try stream.send(msg, .{ .event = "tick" });
         }
-        req.io.sleep(.fromMilliseconds(100), .real) catch break;
+        try req.io.sleep(.fromMilliseconds(100), .real);
     }
 }
 
@@ -40,7 +40,7 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
     var ticker_future = try io.concurrent(struct {
         fn run(counter: *std.atomic.Value(u64), _io: std.Io) !void {
             while (true) {
-                _io.sleep(.fromMilliseconds(1000), .real) catch break;
+                try _io.sleep(.fromMilliseconds(1000), .real);
                 _ = counter.fetchAdd(1, .release);
             }
         }

--- a/examples/sse.zig
+++ b/examples/sse.zig
@@ -52,7 +52,7 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
 
     server.router.get("/events", handleEvents);
 
-    const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
     var ticker_task = try zio.spawn(ticker, .{&channel});
     defer ticker_task.cancel();
@@ -61,10 +61,5 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
-
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
-
-    try runServer(allocator, rt.io());
+    try runServer(init.gpa, init.io);
 }

--- a/examples/sse.zig
+++ b/examples/sse.zig
@@ -1,51 +1,30 @@
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
-const BroadcastChannel = zio.BroadcastChannel;
-
 const AppContext = struct {
-    channel: *BroadcastChannel(u64),
+    counter: std.atomic.Value(u64),
 };
 
-fn handleEvents(ctx: *AppContext, _: *http.Request, res: *http.Response) !void {
+fn handleEvents(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {
     var stream = try res.startEventStream();
-
-    var consumer: BroadcastChannel(u64).Consumer = .{};
-    ctx.channel.subscribe(&consumer);
-    defer ctx.channel.unsubscribe(&consumer);
 
     try stream.send("connected", .{});
 
-    var buf: [64]u8 = undefined;
+    var last_seen: u64 = 0;
     while (true) {
-        const count = ctx.channel.receive(&consumer) catch |err| switch (err) {
-            error.Closed => break,
-            error.Lagged => continue,
-            else => return err,
-        };
-        const msg = try std.fmt.bufPrint(&buf, "tick {d}", .{count});
-        try stream.send(msg, .{ .event = "tick" });
-    }
-}
-
-fn ticker(channel: *BroadcastChannel(u64)) !void {
-    var count: u64 = 0;
-    while (true) {
-        try zio.sleep(.fromMilliseconds(1000));
-        count += 1;
-
-        channel.send(count) catch |err| switch (err) {
-            error.Closed => break,
-        };
+        const current = ctx.counter.load(.acquire);
+        if (current != last_seen) {
+            last_seen = current;
+            var buf: [64]u8 = undefined;
+            const msg = try std.fmt.bufPrint(&buf, "tick {d}", .{current});
+            stream.send(msg, .{ .event = "tick" }) catch break;
+        }
+        req.io.sleep(.fromMilliseconds(100), .real) catch break;
     }
 }
 
 pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
-    var channel_buffer: [16]u64 = undefined;
-    var channel = BroadcastChannel(u64).init(&channel_buffer);
-
-    var ctx: AppContext = .{ .channel = &channel };
+    var ctx: AppContext = .{ .counter = std.atomic.Value(u64).init(0) };
 
     var server = http.Server(AppContext).init(allocator, io, .{}, &ctx);
     defer server.deinit();
@@ -54,8 +33,19 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
 
     const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
-    var ticker_task = try zio.spawn(ticker, .{&channel});
-    defer ticker_task.cancel();
+    std.log.info("SSE server running at http://127.0.0.1:8080", .{});
+    std.log.info("Try: curl http://127.0.0.1:8080/events", .{});
+
+    // Run ticker in background
+    var ticker_future = try io.concurrent(struct {
+        fn run(counter: *std.atomic.Value(u64), _io: std.Io) !void {
+            while (true) {
+                _io.sleep(.fromMilliseconds(1000), .real) catch break;
+                _ = counter.fetchAdd(1, .release);
+            }
+        }
+    }.run, .{ &ctx.counter, io });
+    defer ticker_future.cancel(io) catch {};
 
     try server.listen(addr);
 }

--- a/examples/websocket.zig
+++ b/examples/websocket.zig
@@ -78,17 +78,12 @@ pub fn runServer(allocator: std.mem.Allocator, io: std.Io) !void {
     server.router.get("/", handleIndex);
     server.router.get("/ws", handleWebSocket);
 
-    const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
 
     std.log.info("WebSocket echo server running at http://127.0.0.1:8080", .{});
     try server.listen(addr);
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
-
-    var rt = try zio.Runtime.init(allocator, .{});
-    defer rt.deinit();
-
-    try runServer(allocator, rt.io());
+    try runServer(init.gpa, init.io);
 }

--- a/examples/websocket.zig
+++ b/examples/websocket.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 const AppContext = struct {};

--- a/src/client.zig
+++ b/src/client.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
-const zio = @import("zio");
 const Uri = std.Uri;
+
+const unix_path_max = 108;
 
 const http = @import("http.zig");
 const Method = http.Method;
@@ -162,26 +163,26 @@ pub const ConnectionPool = struct {
     pub fn deinit(self: *ConnectionPool) void {
         // Close and free all idle connections
         while (self.idle.popFirst()) |node| {
-            const conn: *Connection = @fieldParentPtr("pool_node", node);
+            const conn: *Connection = @alignCast(@fieldParentPtr("pool_node", node));
             conn.deinit();
             self.allocator.destroy(conn);
         }
     }
 
     /// Try to acquire an existing connection for the given host:port, protocol, and optional unix socket path.
-    pub fn acquire(self: *ConnectionPool, remote_host: []const u8, remote_port: u16, protocol: Protocol, unix_socket_path: ?[]const u8) ?*Connection {
-        const now = zio.Timestamp.now(.monotonic);
+    pub fn acquire(self: *ConnectionPool, io: std.Io, remote_host: []const u8, remote_port: u16, protocol: Protocol, unix_socket_path: ?[]const u8) ?*Connection {
+        const now = std.Io.Timestamp.now(io, .awake);
 
         // Search from end (most recently used)
         var node = self.idle.last;
         while (node) |n| {
-            const conn: *Connection = @fieldParentPtr("pool_node", n);
+            const conn: *Connection = @alignCast(@fieldParentPtr("pool_node", n));
             node = n.prev;
 
             if (conn.matches(remote_host, remote_port, protocol, unix_socket_path)) {
                 // Check if connection has expired due to idle timeout
                 if (conn.idle_deadline) |deadline| {
-                    if (now.value >= deadline.value) {
+                    if (now.nanoseconds >= deadline.nanoseconds) {
                         // Connection expired, remove and close it
                         self.idle.remove(n);
                         self.idle_len -= 1;
@@ -211,7 +212,7 @@ pub const ConnectionPool = struct {
         // If pool is full, close the oldest connection
         if (self.idle_len >= self.max_idle) {
             if (self.idle.popFirst()) |old_node| {
-                const old: *Connection = @fieldParentPtr("pool_node", old_node);
+                const old: *Connection = @alignCast(@fieldParentPtr("pool_node", old_node));
                 old.deinit();
                 self.allocator.destroy(old);
                 self.idle_len -= 1;
@@ -229,7 +230,7 @@ pub const ConnectionPool = struct {
 pub const Connection = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
-    stream: zio.net.Stream,
+    stream: std.Io.net.Stream,
     arena: std.heap.ArenaAllocator,
     parser: ResponseParser,
     parsed_response: ParsedResponse,
@@ -238,8 +239,8 @@ pub const Connection = struct {
 
     // Protocol and TLS
     protocol: Protocol,
-    tcp_reader: zio.net.Stream.Reader,
-    tcp_writer: zio.net.Stream.Writer,
+    tcp_reader: std.Io.net.Stream.Reader,
+    tcp_writer: std.Io.net.Stream.Writer,
 
     // TLS TCP layer buffers (allocated from main allocator, persist across requests)
     tls_tcp_read_buffer: []u8,
@@ -260,13 +261,14 @@ pub const Connection = struct {
     host_len: u8 = 0,
     port: u16 = 0,
     closing: bool = false,
-    // Unix socket address (null means TCP connection)
-    unix_addr: ?zio.net.UnixAddress = null,
+    // Unix socket path (empty means TCP connection)
+    unix_path_buffer: [unix_path_max]u8 = undefined,
+    unix_path_len: u8 = 0,
 
     // Keep-Alive tracking
     request_count: u16 = 0,
     keep_alive: KeepAliveParams = .{},
-    idle_deadline: ?zio.Timestamp = null,
+    idle_deadline: ?std.Io.Timestamp = null,
 
     /// Initialize the connection in place (required because parser stores internal pointers).
     pub fn init(
@@ -274,7 +276,7 @@ pub const Connection = struct {
         allocator: std.mem.Allocator,
         io: std.Io,
         pool: *ConnectionPool,
-        stream: zio.net.Stream,
+        stream: std.Io.net.Stream,
         remote_host: []const u8,
         remote_port: u16,
         buffer_size: usize,
@@ -301,8 +303,15 @@ pub const Connection = struct {
         self.host_len = len;
         self.port = remote_port;
 
-        // Store unix socket address for connection pooling
-        self.unix_addr = if (unix_socket_path) |path| try zio.net.UnixAddress.init(path) else null;
+        // Store unix socket path for connection pooling
+        if (unix_socket_path) |path| {
+            if (path.len > unix_path_max) return error.NameTooLong;
+            const plen: u8 = @intCast(path.len);
+            @memcpy(self.unix_path_buffer[0..plen], path[0..plen]);
+            self.unix_path_len = plen;
+        } else {
+            self.unix_path_len = 0;
+        }
 
         self.parsed_response = .{ .arena = self.arena.allocator() };
         self.parser.init(&self.parsed_response);
@@ -325,8 +334,8 @@ pub const Connection = struct {
             self.tls_tcp_write_buffer = try allocator.alloc(u8, tls_buffer_size);
             errdefer allocator.free(self.tls_tcp_write_buffer);
 
-            self.tcp_reader = stream.reader(self.tls_tcp_read_buffer);
-            self.tcp_writer = stream.writer(self.tls_tcp_write_buffer);
+            self.tcp_reader = stream.reader(io, self.tls_tcp_read_buffer);
+            self.tcp_writer = stream.writer(io, self.tls_tcp_write_buffer);
 
             var entropy: [std.crypto.tls.Client.Options.entropy_len]u8 = undefined;
             self.io.random(&entropy);
@@ -362,8 +371,8 @@ pub const Connection = struct {
             self.write_buffer = try allocator.alloc(u8, 1024);
             errdefer allocator.free(self.write_buffer);
 
-            self.tcp_reader = stream.reader(self.read_buffer);
-            self.tcp_writer = stream.writer(self.write_buffer);
+            self.tcp_reader = stream.reader(io, self.read_buffer);
+            self.tcp_writer = stream.writer(io, self.write_buffer);
 
             self.reader = &self.tcp_reader.interface;
             self.writer = &self.tcp_writer.interface;
@@ -371,7 +380,7 @@ pub const Connection = struct {
     }
 
     pub fn deinit(self: *Connection) void {
-        self.stream.close();
+        self.stream.close(self.io);
         if (self.protocol == .https) {
             self.allocator.free(self.tls_tcp_read_buffer);
             self.allocator.free(self.tls_tcp_write_buffer);
@@ -409,10 +418,8 @@ pub const Connection = struct {
     }
 
     pub fn unixPath(self: *const Connection) ?[]const u8 {
-        if (self.unix_addr) |*addr| {
-            return std.mem.sliceTo(&addr.un.path, 0);
-        }
-        return null;
+        if (self.unix_path_len == 0) return null;
+        return self.unix_path_buffer[0..self.unix_path_len];
     }
 
     /// Check if this connection matches the given host, port, protocol, and transport.
@@ -420,7 +427,7 @@ pub const Connection = struct {
         if (unix_socket_path) |path| {
             return self.protocol == protocol and std.mem.eql(u8, self.unixPath() orelse return false, path);
         }
-        if (self.unix_addr != null) return false;
+        if (self.unix_path_len != 0) return false;
         return self.protocol == protocol and self.port == match_port and std.ascii.eqlIgnoreCase(self.host(), match_host);
     }
 
@@ -442,7 +449,7 @@ pub const Connection = struct {
 
             // Update idle deadline after each request
             if (self.keep_alive.timeout) |timeout| {
-                self.idle_deadline = zio.Timestamp.now(.monotonic).addDuration(.fromMilliseconds(timeout));
+                self.idle_deadline = std.Io.Timestamp.now(self.io, .awake).addDuration(.fromMilliseconds(@as(i64, timeout)));
             }
 
             // Check if we've reached max requests
@@ -582,7 +589,6 @@ pub const Client = struct {
     ca_bundle_lock: std.Io.RwLock,
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, config: ClientConfig) Client {
-        _ = zio.Runtime.fromIo(io);
         return .{
             .allocator = allocator,
             .io = io,
@@ -620,13 +626,15 @@ pub const Client = struct {
         unix_socket_path: ?[]const u8,
     ) !*Connection {
         // Try to get a connection from the pool
-        const conn = self.pool.acquire(host, port, protocol, unix_socket_path) orelse blk: {
+        const conn = self.pool.acquire(self.io, host, port, protocol, unix_socket_path) orelse blk: {
             // No pooled connection, create a new one
             const stream = if (unix_socket_path) |path| unix: {
-                const unix_addr = try zio.net.UnixAddress.init(path);
-                break :unix try unix_addr.connect(.{});
-            } else try zio.net.tcpConnectToHost(host, port, .{});
-            errdefer stream.close();
+                const unix_addr = try std.Io.net.UnixAddress.init(path);
+                break :unix try unix_addr.connect(self.io);
+            } else if (std.Io.net.IpAddress.parse(host, port)) |addr| tcp: {
+                break :tcp try addr.connect(self.io, .{ .mode = .stream });
+            } else |_| try (try std.Io.net.HostName.init(host)).connect(self.io, port, .{ .mode = .stream });
+            errdefer stream.close(self.io);
 
             const new_conn = try self.allocator.create(Connection);
             errdefer self.allocator.destroy(new_conn);

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -14,19 +14,19 @@ test "Client: simple GET request" {
         }
     }.handle);
 
-    const server_future = try io.concurrent(struct {
+    var server_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void)) !void {
             const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
             try s.listen(addr);
         }
     }.run, .{&server});
-    defer server_future.cancel(io);
+    defer server_future.cancel(io) catch {};
 
-    const client_future = try io.concurrent(struct {
+    var client_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void), _io: std.Io) !void {
             try s.ready.wait(_io);
 
-            const port = s.address.ip.port();
+            const port = s.address.ip.getPort();
 
             const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
             defer stream.close(_io);
@@ -63,19 +63,19 @@ test "Client: fetch GET request" {
         }
     }.handle);
 
-    const server_future = try io.concurrent(struct {
+    var server_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void)) !void {
             const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
             try s.listen(addr);
         }
     }.run, .{&server});
-    defer server_future.cancel(io);
+    defer server_future.cancel(io) catch {};
 
-    const client_future = try io.concurrent(struct {
+    var client_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void), _io: std.Io) !void {
             try s.ready.wait(_io);
 
-            const port = s.address.ip.port();
+            const port = s.address.ip.getPort();
 
             var url_buf: [64]u8 = undefined;
             const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api", .{port});
@@ -115,19 +115,19 @@ test "Client: connection pooling" {
         }
     }.handle);
 
-    const server_future = try io.concurrent(struct {
+    var server_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void)) !void {
             const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
             try s.listen(addr);
         }
     }.run, .{&server});
-    defer server_future.cancel(io);
+    defer server_future.cancel(io) catch {};
 
-    const client_future = try io.concurrent(struct {
+    var client_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void), _io: std.Io) !void {
             try s.ready.wait(_io);
 
-            const port = s.address.ip.port();
+            const port = s.address.ip.getPort();
 
             var url_buf: [64]u8 = undefined;
             const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/test", .{port});
@@ -195,19 +195,19 @@ test "Client: WebSocket upgrade" {
         }
     }.handle);
 
-    const server_future = try io.concurrent(struct {
+    var server_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void)) !void {
             const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
             try s.listen(addr);
         }
     }.run, .{&server});
-    defer server_future.cancel(io);
+    defer server_future.cancel(io) catch {};
 
-    const client_future = try io.concurrent(struct {
+    var client_future = try io.concurrent(struct {
         fn run(s: *dusty.Server(void), _io: std.Io) !void {
             try s.ready.wait(_io);
 
-            const port = s.address.ip.port();
+            const port = s.address.ip.getPort();
 
             var url_buf: [64]u8 = undefined;
             const url = try std.fmt.bufPrint(&url_buf, "ws://127.0.0.1:{d}/ws", .{port});
@@ -244,16 +244,16 @@ test "Client: unix socket fetch" {
 
     var path_buf: [64]u8 = undefined;
     const socket_path = try std.fmt.bufPrint(&path_buf, "/tmp/dusty-client-test-unix-{d}.sock", .{std.c.getpid()});
-    std.fs.cwd().deleteFile(socket_path) catch {};
+    std.Io.Dir.cwd().deleteFile(io, socket_path) catch {};
 
     var ready: std.Io.Event = .unset;
 
-    const server_future = try io.concurrent(struct {
+    var server_future = try io.concurrent(struct {
         fn run(path: []const u8, r: *std.Io.Event, _io: std.Io) !void {
             const unix_addr = try std.Io.net.UnixAddress.init(path);
             var server = try unix_addr.listen(_io, .{});
             defer server.deinit(_io);
-            defer std.fs.cwd().deleteFile(path) catch {};
+            defer std.Io.Dir.cwd().deleteFile(_io, path) catch {};
 
             r.set(_io);
 
@@ -281,9 +281,9 @@ test "Client: unix socket fetch" {
             try writer.interface.flush();
         }
     }.run, .{ socket_path, &ready, io });
-    defer server_future.cancel(io);
+    defer server_future.cancel(io) catch {};
 
-    const client_future = try io.concurrent(struct {
+    var client_future = try io.concurrent(struct {
         fn run(path: []const u8, r: *std.Io.Event, _io: std.Io) !void {
             try r.wait(_io);
 

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -1,102 +1,88 @@
 const std = @import("std");
-const zio = @import("zio");
 const dusty = @import("root.zig");
 
 test "Client: simple GET request" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.get("/test", handleGet);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{&server});
-            defer client_task.cancel();
-
-            try client_task.join();
-        }
-
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
-
-        pub fn clientFn(server: *dusty.Server(void)) !void {
-            try server.ready.wait();
-
-            // Connect directly like server_test.zig does
-            const stream = try server.address.connect(.{});
-            defer stream.close();
-            defer stream.shutdown(.both) catch {};
-
-            var write_buf: [1024]u8 = undefined;
-            var writer = stream.writer(&write_buf);
-
-            // Send GET request
-            try writer.interface.writeAll("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
-            try writer.interface.flush();
-
-            // Read response
-            var read_buf: [1024]u8 = undefined;
-            var reader = stream.reader(&read_buf);
-            const status_line = try reader.interface.takeDelimiterExclusive('\n');
-
-            std.log.info("Response: {s}", .{status_line});
-            try std.testing.expect(std.mem.indexOf(u8, status_line, "200 OK") != null);
-        }
-
-        fn handleGet(req: *dusty.Request, res: *dusty.Response) !void {
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             _ = req;
             res.body = "Hello from test!\n";
         }
-    };
+    }.handle);
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    const server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io);
 
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    const client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const port = s.address.ip.port();
+
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+
+            try writer.interface.writeAll("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            try writer.interface.flush();
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+
+            std.log.info("Response: {s} (port {})", .{ status_line, port });
+            try std.testing.expect(std.mem.indexOf(u8, status_line, "200 OK") != null);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
 }
 
 test "Client: fetch GET request" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.get("/api", handleGet);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{ &server, io });
-            defer client_task.cancel();
-
-            try client_task.join();
+    server.router.get("/api", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "Hello from API!\n";
         }
+    }.handle);
 
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
+    const server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
         }
+    }.run, .{&server});
+    defer server_future.cancel(io);
 
-        pub fn clientFn(server: *dusty.Server(void), io: std.Io) !void {
-            try server.ready.wait();
+    const client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
 
-            // Get the port
-            const port = std.mem.bigToNative(u16, server.address.ip.in.port);
+            const port = s.address.ip.port();
 
-            // Build URL
             var url_buf: [64]u8 = undefined;
             const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/api", .{port});
 
             std.log.info("Making request to: {s}", .{url});
 
-            // Use our client
-            var client = dusty.Client.init(std.testing.allocator, io, .{});
+            var client = dusty.Client.init(std.testing.allocator, _io, .{});
             defer client.deinit();
 
             var response = try client.fetch(url, .{});
@@ -111,51 +97,42 @@ test "Client: fetch GET request" {
             try std.testing.expect(body != null);
             try std.testing.expectEqualStrings("Hello from API!\n", body.?);
         }
+    }.run, .{ &server, io });
 
-        fn handleGet(req: *dusty.Request, res: *dusty.Response) !void {
-            _ = req;
-            res.body = "Hello from API!\n";
-        }
-    };
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    try client_future.await(io);
 }
 
 test "Client: connection pooling" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.get("/test", handleGet);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{ &server, io });
-            defer client_task.cancel();
-
-            try client_task.join();
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "OK";
         }
+    }.handle);
 
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
+    const server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
         }
+    }.run, .{&server});
+    defer server_future.cancel(io);
 
-        pub fn clientFn(server: *dusty.Server(void), io: std.Io) !void {
-            try server.ready.wait();
+    const client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
 
-            const port = std.mem.bigToNative(u16, server.address.ip.in.port);
+            const port = s.address.ip.port();
 
             var url_buf: [64]u8 = undefined;
             const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/test", .{port});
 
-            var client = dusty.Client.init(std.testing.allocator, io, .{});
+            var client = dusty.Client.init(std.testing.allocator, _io, .{});
             defer client.deinit();
 
             // Pool should be empty initially
@@ -185,83 +162,26 @@ test "Client: connection pooling" {
             // Connection should be back in pool
             try std.testing.expectEqual(@as(usize, 1), client.pool.idle_len);
         }
+    }.run, .{ &server, io });
 
-        fn handleGet(req: *dusty.Request, res: *dusty.Response) !void {
-            _ = req;
-            res.body = "OK";
-        }
-    };
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    try client_future.await(io);
 }
 
 test "Client: WebSocket upgrade" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.get("/ws", handleWebSocket);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{ &server, io });
-            defer client_task.cancel();
-
-            try client_task.join();
-        }
-
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
-
-        pub fn clientFn(server: *dusty.Server(void), io: std.Io) !void {
-            try server.ready.wait();
-
-            const port = std.mem.bigToNative(u16, server.address.ip.in.port);
-
-            var url_buf: [64]u8 = undefined;
-            const url = try std.fmt.bufPrint(&url_buf, "ws://127.0.0.1:{d}/ws", .{port});
-
-            var client = dusty.Client.init(std.testing.allocator, io, .{});
-            defer client.deinit();
-
-            var ws = try client.connectWebSocket(url, .{});
-            defer ws.deinit();
-
-            // Server sends "Welcome!" first
-            const welcome = try ws.receive();
-            try std.testing.expectEqual(.text, welcome.type);
-            try std.testing.expectEqualStrings("Welcome!", welcome.data);
-
-            // Send a message
-            try ws.send(.text, "Hello WebSocket!");
-
-            // Receive echo
-            const echo = try ws.receive();
-            try std.testing.expectEqual(.text, echo.type);
-            try std.testing.expectEqualStrings("Hello WebSocket!", echo.data);
-
-            // Close
-            try ws.close(.normal, "done");
-        }
-
-        fn handleWebSocket(req: *dusty.Request, res: *dusty.Response) !void {
+    server.router.get("/ws", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             var ws = try res.upgradeWebSocket(req) orelse {
                 res.status = .bad_request;
                 return;
             };
 
-            // Send welcome
             try ws.send(.text, "Welcome!");
 
-            // Echo loop
             while (true) {
                 const msg = ws.receive() catch |err| switch (err) {
                     error.EndOfStream => return,
@@ -273,62 +193,84 @@ test "Client: WebSocket upgrade" {
                 }
             }
         }
-    };
+    }.handle);
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    const server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io);
 
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    const client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const port = s.address.ip.port();
+
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "ws://127.0.0.1:{d}/ws", .{port});
+
+            var client = dusty.Client.init(std.testing.allocator, _io, .{});
+            defer client.deinit();
+
+            var ws = try client.connectWebSocket(url, .{});
+            defer ws.deinit();
+
+            const welcome = try ws.receive();
+            try std.testing.expectEqual(.text, welcome.type);
+            try std.testing.expectEqualStrings("Welcome!", welcome.data);
+
+            try ws.send(.text, "Hello WebSocket!");
+
+            const echo = try ws.receive();
+            try std.testing.expectEqual(.text, echo.type);
+            try std.testing.expectEqualStrings("Hello WebSocket!", echo.data);
+
+            try ws.close(.normal, "done");
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
 }
 
 test "Client: unix socket fetch" {
     const builtin = @import("builtin");
     if (builtin.os.tag == .windows) return error.SkipZigTest;
-    if (!zio.net.has_unix_sockets) return error.SkipZigTest;
+    if (!std.Io.net.has_unix_sockets) return error.SkipZigTest;
 
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var path_buf: [64]u8 = undefined;
-            const socket_path = try std.fmt.bufPrint(&path_buf, "/tmp/dusty-client-test-unix-{d}.sock", .{std.c.getpid()});
-            zio.Dir.cwd().deleteFile(socket_path) catch {};
+    const io = std.testing.io;
 
-            var ready_buf: [1]bool = undefined;
-            var ready_ch = zio.Channel(bool).init(&ready_buf);
+    var path_buf: [64]u8 = undefined;
+    const socket_path = try std.fmt.bufPrint(&path_buf, "/tmp/dusty-client-test-unix-{d}.sock", .{std.c.getpid()});
+    std.fs.cwd().deleteFile(socket_path) catch {};
 
-            var server_task = try zio.spawn(serverFn, .{ socket_path, &ready_ch });
-            defer server_task.cancel();
+    var ready: std.Io.Event = .unset;
 
-            var client_task = try zio.spawn(clientFn, .{ socket_path, &ready_ch, io });
-            defer client_task.cancel();
+    const server_future = try io.concurrent(struct {
+        fn run(path: []const u8, r: *std.Io.Event, _io: std.Io) !void {
+            const unix_addr = try std.Io.net.UnixAddress.init(path);
+            var server = try unix_addr.listen(_io, .{});
+            defer server.deinit(_io);
+            defer std.fs.cwd().deleteFile(path) catch {};
 
-            try client_task.join();
-        }
+            r.set(_io);
 
-        pub fn serverFn(socket_path: []const u8, ready: *zio.Channel(bool)) !void {
-            const unix_addr = try zio.net.UnixAddress.init(socket_path);
-            const server = try unix_addr.listen(.{});
-            defer server.close();
-            defer zio.Dir.cwd().deleteFile(socket_path) catch {};
+            const stream = try server.accept(_io);
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
 
-            try ready.send(true);
-
-            const stream = try server.accept(.{});
-            defer stream.close();
-            defer stream.shutdown(.both) catch {};
-
-            // Consume request headers
             var read_buf: [4096]u8 = undefined;
-            var reader = stream.reader(&read_buf);
+            var reader = stream.reader(_io, &read_buf);
             while (true) {
                 const line = try reader.interface.takeDelimiterExclusive('\n');
                 reader.interface.toss(1);
                 if (std.mem.trimEnd(u8, line, "\r").len == 0) break;
             }
 
-            // Write a minimal HTTP response
             var write_buf: [512]u8 = undefined;
-            var writer = stream.writer(&write_buf);
+            var writer = stream.writer(_io, &write_buf);
             try writer.interface.writeAll(
                 "HTTP/1.1 200 OK\r\n" ++
                     "Content-Length: 14\r\n" ++
@@ -338,15 +280,18 @@ test "Client: unix socket fetch" {
             );
             try writer.interface.flush();
         }
+    }.run, .{ socket_path, &ready, io });
+    defer server_future.cancel(io);
 
-        pub fn clientFn(socket_path: []const u8, ready: *zio.Channel(bool), io: std.Io) !void {
-            _ = try ready.receive();
+    const client_future = try io.concurrent(struct {
+        fn run(path: []const u8, r: *std.Io.Event, _io: std.Io) !void {
+            try r.wait(_io);
 
-            var client = dusty.Client.init(std.testing.allocator, io, .{});
+            var client = dusty.Client.init(std.testing.allocator, _io, .{});
             defer client.deinit();
 
             var response = try client.fetch("http://localhost/test", .{
-                .unix_socket_path = socket_path,
+                .unix_socket_path = path,
             });
             defer response.deinit();
 
@@ -356,11 +301,7 @@ test "Client: unix socket fetch" {
             try std.testing.expect(b != null);
             try std.testing.expectEqualStrings("Hello, Docker!", b.?);
         }
-    };
+    }.run, .{ socket_path, &ready, io });
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    try client_future.await(io);
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,9 +1,9 @@
-const zio = @import("zio");
+const std = @import("std");
 
 pub const ServerConfig = struct {
     timeout: Timeout = .{},
     request: Request = .{},
-    listen: zio.net.IpAddress.ListenOptions = .{ .reuse_address = true, .kernel_backlog = 1024 },
+    listen: std.Io.net.IpAddress.ListenOptions = .{ .reuse_address = true, .kernel_backlog = 1024 },
 
     pub const Timeout = struct {
         /// Maximum time (ms) to receive a complete request

--- a/src/cookie.zig
+++ b/src/cookie.zig
@@ -3,7 +3,6 @@
 // Copyright (c) 2024 Karl Seguin.
 
 const std = @import("std");
-const zio = @import("zio");
 
 /// Cookie parser for reading cookies from a request.
 /// Lazily parses the Cookie header on demand.
@@ -35,7 +34,7 @@ pub const Cookie = struct {
 pub const CookieOpts = struct {
     path: []const u8 = "",
     domain: []const u8 = "",
-    max_age: ?zio.Duration = null,
+    max_age: ?std.Io.Duration = null,
     secure: bool = false,
     http_only: bool = false,
     partitioned: bool = false,

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 const Request = @import("request.zig").Request;
 const Response = @import("response.zig").Response;
 const Action = @import("router.zig").Action;

--- a/src/middleware/Session.zig
+++ b/src/middleware/Session.zig
@@ -104,7 +104,7 @@ pub fn execute(self: *const Session, req: *Request, res: *Response, executor: an
             delete_opts.max_age = .zero;
             try res.setCookie(self.config.cookie_name, "", delete_opts);
         } else {
-            const signed = try self.signSession(req.arena, &req.session, std.Io.Timestamp.now(req.io, .real));
+            const signed = try self.signSession(req.arena, &req.session, .now(req.io, .real));
             var opts = self.config.cookie_opts;
             if (self.config.max_age) |ma| {
                 opts.max_age = ma;
@@ -285,7 +285,7 @@ test "Session: sign and load round-trip" {
     try s.set("user_id", "42");
     try s.set("role", "admin");
 
-    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
+    const signed = try session.signSession(arena.allocator(), &s, .now(std.testing.io, .real));
 
     var s2 = SessionData{};
     try session.load(arena.allocator(), &s2, signed, std.testing.io);
@@ -308,7 +308,7 @@ test "Session: sign and load round-trip with max_age" {
     var s = SessionData{};
     try s.set("user_id", "42");
 
-    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
+    const signed = try session.signSession(arena.allocator(), &s, .now(std.testing.io, .real));
 
     var s2 = SessionData{};
     try session.load(arena.allocator(), &s2, signed, std.testing.io);
@@ -347,7 +347,7 @@ test "Session: load rejects tampered payload" {
 
     var s = SessionData{};
     try s.set("user_id", "42");
-    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
+    const signed = try session.signSession(arena.allocator(), &s, .now(std.testing.io, .real));
 
     var tampered = try arena.allocator().dupe(u8, signed);
     // Tamper near the end (payload region) to avoid corrupting the header/version
@@ -367,7 +367,7 @@ test "Session: load rejects wrong key" {
 
     var s = SessionData{};
     try s.set("data", "test");
-    const signed = try session1.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
+    const signed = try session1.signSession(arena.allocator(), &s, .now(std.testing.io, .real));
 
     var s2 = SessionData{};
     try testing.expectError(error.InvalidSignature, session2.load(arena.allocator(), &s2, signed, std.testing.io));
@@ -396,7 +396,7 @@ test "Session: empty session round-trip" {
     const session = Session{ .config = .{ .secret_key = "key", .cookie_name = "s" } };
 
     var s = SessionData{};
-    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
+    const signed = try session.signSession(arena.allocator(), &s, .now(std.testing.io, .real));
 
     var s2 = SessionData{};
     try session.load(arena.allocator(), &s2, signed, std.testing.io);

--- a/src/middleware/Session.zig
+++ b/src/middleware/Session.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 const Request = @import("../request.zig").Request;
 const Response = @import("../response.zig").Response;
 const CookieOpts = @import("../cookie.zig").CookieOpts;
@@ -67,7 +66,7 @@ pub const SessionData = struct {
 pub const Config = struct {
     secret_key: []const u8,
     cookie_name: []const u8 = "session",
-    max_age: ?zio.Duration = null,
+    max_age: ?std.Io.Duration = null,
     cookie_opts: CookieOpts = .{
         .path = "/",
         .http_only = true,
@@ -87,7 +86,7 @@ pub fn init(config: Config) !Session {
 pub fn execute(self: *const Session, req: *Request, res: *Response, executor: anytype) !void {
     const cookie_value = req.cookies().get(self.config.cookie_name);
     if (cookie_value) |raw| {
-        self.load(req.arena, &req.session, raw) catch |err| switch (err) {
+        self.load(req.arena, &req.session, raw, req.io) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             else => |e| log.debug("session load failed: {}", .{e}),
         };
@@ -105,7 +104,7 @@ pub fn execute(self: *const Session, req: *Request, res: *Response, executor: an
             delete_opts.max_age = .zero;
             try res.setCookie(self.config.cookie_name, "", delete_opts);
         } else {
-            const signed = try self.signSession(req.arena, &req.session, .now(.realtime));
+            const signed = try self.signSession(req.arena, &req.session, std.Io.Timestamp.now(req.io, .real));
             var opts = self.config.cookie_opts;
             if (self.config.max_age) |ma| {
                 opts.max_age = ma;
@@ -128,7 +127,7 @@ const overhead = header_size + sig_size;
 /// Load a signed cookie value into a SessionData.
 /// Decodes the base64, verifies HMAC, then parses entries.
 /// Format: base64url([Header: 8 bytes][signature: 32 bytes][key\0value\0...])
-fn load(self: *const Session, arena: std.mem.Allocator, session: *SessionData, raw: []const u8) !void {
+fn load(self: *const Session, arena: std.mem.Allocator, session: *SessionData, raw: []const u8, io: std.Io) !void {
     const decoded_len = base64url.Decoder.calcSizeForSlice(raw) catch return error.InvalidEncoding;
     if (decoded_len < overhead) return error.InvalidEncoding;
     const decoded = try arena.alloc(u8, decoded_len);
@@ -151,7 +150,7 @@ fn load(self: *const Session, arena: std.mem.Allocator, session: *SessionData, r
 
     // Check expiry
     if (header.expires_at != 0) {
-        const now: u32 = @intCast(zio.Timestamp.now(.realtime).toNanoseconds() / 1_000_000_000);
+        const now: u32 = @intCast(@divTrunc(std.Io.Timestamp.now(io, .real).nanoseconds, std.time.ns_per_s));
         if (header.expires_at < now) return error.Expired;
     }
 
@@ -167,7 +166,7 @@ fn load(self: *const Session, arena: std.mem.Allocator, session: *SessionData, r
 
 /// Serialize session entries, sign, and base64-encode.
 /// Format: base64url([Header: 8 bytes][signature: 32 bytes][key\0value\0...])
-fn signSession(self: *const Session, arena: std.mem.Allocator, session: *const SessionData, now: zio.Timestamp) ![]const u8 {
+fn signSession(self: *const Session, arena: std.mem.Allocator, session: *const SessionData, now: std.Io.Timestamp) ![]const u8 {
     // Calculate payload size
     var payload_size: usize = 0;
     for (session.items()) |entry| {
@@ -179,8 +178,9 @@ fn signSession(self: *const Session, arena: std.mem.Allocator, session: *const S
 
     // Write header
     const expires_at: u32 = if (self.config.max_age) |ma| blk: {
-        const expires_s = now.addDuration(ma).toNanoseconds() / 1_000_000_000;
-        break :blk @min(expires_s, std.math.maxInt(u32));
+        const expires_ns = now.addDuration(ma).nanoseconds;
+        const expires_s: i64 = @intCast(@divTrunc(expires_ns, std.time.ns_per_s));
+        break :blk @intCast(@min(expires_s, std.math.maxInt(u32)));
     } else 0;
 
     const header = Header{ .expires_at = expires_at };
@@ -285,10 +285,10 @@ test "Session: sign and load round-trip" {
     try s.set("user_id", "42");
     try s.set("role", "admin");
 
-    const signed = try session.signSession(arena.allocator(), &s, .now(.realtime));
+    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
 
     var s2 = SessionData{};
-    try session.load(arena.allocator(), &s2, signed);
+    try session.load(arena.allocator(), &s2, signed, std.testing.io);
 
     try testing.expectEqualStrings("42", s2.get("user_id").?);
     try testing.expectEqualStrings("admin", s2.get("role").?);
@@ -308,10 +308,10 @@ test "Session: sign and load round-trip with max_age" {
     var s = SessionData{};
     try s.set("user_id", "42");
 
-    const signed = try session.signSession(arena.allocator(), &s, .now(.realtime));
+    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
 
     var s2 = SessionData{};
-    try session.load(arena.allocator(), &s2, signed);
+    try session.load(arena.allocator(), &s2, signed, std.testing.io);
 
     try testing.expectEqualStrings("42", s2.get("user_id").?);
 }
@@ -333,7 +333,7 @@ test "Session: load rejects expired session" {
     const signed = try session.signSession(arena.allocator(), &s, .fromNanoseconds(1000 * 1_000_000_000));
 
     var s2 = SessionData{};
-    try testing.expectError(error.Expired, session.load(arena.allocator(), &s2, signed));
+    try testing.expectError(error.Expired, session.load(arena.allocator(), &s2, signed, std.testing.io));
 }
 
 test "Session: load rejects tampered payload" {
@@ -347,7 +347,7 @@ test "Session: load rejects tampered payload" {
 
     var s = SessionData{};
     try s.set("user_id", "42");
-    const signed = try session.signSession(arena.allocator(), &s, .now(.realtime));
+    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
 
     var tampered = try arena.allocator().dupe(u8, signed);
     // Tamper near the end (payload region) to avoid corrupting the header/version
@@ -355,7 +355,7 @@ test "Session: load rejects tampered payload" {
     tampered[idx] = if (tampered[idx] == 'A') 'B' else 'A';
 
     var s2 = SessionData{};
-    try testing.expectError(error.InvalidSignature, session.load(arena.allocator(), &s2, tampered));
+    try testing.expectError(error.InvalidSignature, session.load(arena.allocator(), &s2, tampered, std.testing.io));
 }
 
 test "Session: load rejects wrong key" {
@@ -367,10 +367,10 @@ test "Session: load rejects wrong key" {
 
     var s = SessionData{};
     try s.set("data", "test");
-    const signed = try session1.signSession(arena.allocator(), &s, .now(.realtime));
+    const signed = try session1.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
 
     var s2 = SessionData{};
-    try testing.expectError(error.InvalidSignature, session2.load(arena.allocator(), &s2, signed));
+    try testing.expectError(error.InvalidSignature, session2.load(arena.allocator(), &s2, signed, std.testing.io));
 }
 
 test "Session: load rejects garbage" {
@@ -380,13 +380,13 @@ test "Session: load rejects garbage" {
     const session = Session{ .config = .{ .secret_key = "key", .cookie_name = "s" } };
 
     var s = SessionData{};
-    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, ""));
+    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, "", std.testing.io));
 
     s = .{};
-    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, "!!!invalid-base64!!!"));
+    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, "!!!invalid-base64!!!", std.testing.io));
 
     s = .{};
-    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, "AAAA"));
+    try testing.expectError(error.InvalidEncoding, session.load(arena.allocator(), &s, "AAAA", std.testing.io));
 }
 
 test "Session: empty session round-trip" {
@@ -396,10 +396,10 @@ test "Session: empty session round-trip" {
     const session = Session{ .config = .{ .secret_key = "key", .cookie_name = "s" } };
 
     var s = SessionData{};
-    const signed = try session.signSession(arena.allocator(), &s, .now(.realtime));
+    const signed = try session.signSession(arena.allocator(), &s, std.Io.Timestamp.now(std.testing.io, .real));
 
     var s2 = SessionData{};
-    try session.load(arena.allocator(), &s2, signed);
+    try session.load(arena.allocator(), &s2, signed, std.testing.io);
     try testing.expectEqual(0, s2.len);
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const Server = @import("server.zig").Server;
+pub const Address = @import("server.zig").Address;
 pub const ServerConfig = @import("config.zig").ServerConfig;
 pub const Router = @import("router.zig").Router;
 pub const Action = @import("router.zig").Action;

--- a/src/server.zig
+++ b/src/server.zig
@@ -192,10 +192,15 @@ pub fn Server(comptime Ctx: type) type {
                 return err;
             };
 
+            if (self.config.timeout.request != null) {
+                @panic("request timeout not implemented");
+            }
+            if (self.config.timeout.keepalive != null) {
+                @panic("keepalive timeout not implemented");
+            }
+
             while (true) {
                 request_count += 1;
-
-                // TODO: implement request timeout (was zio.AutoCancel)
 
                 parseHeaders(&reader.interface, &parser) catch |err| switch (err) {
                     error.EndOfStream => {
@@ -283,7 +288,6 @@ pub fn Server(comptime Ctx: type) type {
                 reader.interface.seek = 0;
                 reader.interface.end = 0;
 
-                // TODO: implement keepalive timeout (was zio.AutoCancel)
                 // Fill some data here
                 reader.interface.fillMore() catch |err| switch (err) {
                     error.EndOfStream => {

--- a/src/server.zig
+++ b/src/server.zig
@@ -128,7 +128,7 @@ pub fn Server(comptime Ctx: type) type {
                             const remaining = self.active_connections.load(.acquire);
                             if (remaining == 0) break;
                             log.info("Waiting for {} remaining connections to close", .{remaining});
-                            self.last_connection_closed.waitTimeout(self.io, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } }) catch {};
+                            try self.last_connection_closed.waitTimeout(self.io, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } });
                         }
                         return err;
                     }
@@ -136,7 +136,7 @@ pub fn Server(comptime Ctx: type) type {
                 };
 
                 _ = self.active_connections.fetchAdd(1, .acq_rel);
-                group.async(self.io, handleConnectionWrapper, .{ self, stream });
+                try group.concurrent(self.io, handleConnectionWrapper, .{ self, stream });
             }
         }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const zio = @import("zio");
 
 const Router = @import("router.zig").Router;
 const Action = @import("router.zig").Action;
@@ -13,6 +12,18 @@ const Middleware = @import("middleware.zig").Middleware;
 const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
 
 const log = std.log.scoped(.dusty);
+
+pub const Address = union(enum) {
+    ip: std.Io.net.IpAddress,
+    unix: std.Io.net.UnixAddress,
+
+    pub fn format(self: Address, w: *std.Io.Writer) std.Io.Writer.Error!void {
+        switch (self) {
+            .ip => |ip| try ip.format(w),
+            .unix => |unix| try w.writeAll(unix.path),
+        }
+    }
+};
 
 pub fn Server(comptime Ctx: type) type {
     const MiddlewareItem = struct {
@@ -30,13 +41,12 @@ pub fn Server(comptime Ctx: type) type {
         config: ServerConfig,
         shutting_down: std.atomic.Value(bool),
         active_connections: std.atomic.Value(usize),
-        address: zio.net.Address,
-        ready: zio.ResetEvent,
-        last_connection_closed: zio.Notify,
+        address: Address,
+        ready: std.Io.Event,
+        last_connection_closed: std.Io.Event,
         _middleware_registry: std.SinglyLinkedList,
 
         pub fn init(allocator: std.mem.Allocator, io: std.Io, config: ServerConfig, ctx: if (Ctx == void) void else *Ctx) Self {
-            _ = zio.Runtime.fromIo(io);
             return .{
                 .allocator = allocator,
                 .io = io,
@@ -46,8 +56,8 @@ pub fn Server(comptime Ctx: type) type {
                 .shutting_down = std.atomic.Value(bool).init(false),
                 .active_connections = std.atomic.Value(usize).init(0),
                 .address = undefined,
-                .ready = .init,
-                .last_connection_closed = .init,
+                .ready = .unset,
+                .last_connection_closed = .unset,
                 ._middleware_registry = .{},
             };
         }
@@ -88,23 +98,29 @@ pub fn Server(comptime Ctx: type) type {
             return mw;
         }
 
-        pub fn listen(self: *Self, addr: zio.net.IpAddress) !void {
-            const server = try addr.listen(self.config.listen);
-            defer server.close();
+        pub fn listen(self: *Self, addr: Address) !void {
+            var server = switch (addr) {
+                .ip => |ip| try ip.listen(self.io, self.config.listen),
+                .unix => |unix| try unix.listen(self.io, .{}),
+            };
+            defer server.deinit(self.io);
 
-            self.address = server.socket.address;
-            self.ready.set();
+            self.address = switch (addr) {
+                .ip => .{ .ip = server.socket.address },
+                .unix => |unix| .{ .unix = unix },
+            };
+            self.ready.set(self.io);
 
             log.info("Listening on {f}", .{self.address});
 
-            var group: zio.Group = .init;
+            var group: std.Io.Group = .init;
             defer {
                 self.shutting_down.store(true, .release);
-                group.cancel();
+                group.cancel(self.io);
             }
 
             while (true) {
-                const stream = server.accept(.{}) catch |err| {
+                const stream = server.accept(self.io) catch |err| {
                     if (err == error.Canceled) {
                         log.info("Graceful shutdown requested", .{});
                         self.shutting_down.store(true, .release);
@@ -112,7 +128,7 @@ pub fn Server(comptime Ctx: type) type {
                             const remaining = self.active_connections.load(.acquire);
                             if (remaining == 0) break;
                             log.info("Waiting for {} remaining connections to close", .{remaining});
-                            try self.last_connection_closed.timedWait(.fromMilliseconds(100));
+                            self.last_connection_closed.waitTimeout(self.io, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } }) catch {};
                         }
                         return err;
                     }
@@ -120,33 +136,36 @@ pub fn Server(comptime Ctx: type) type {
                 };
 
                 _ = self.active_connections.fetchAdd(1, .acq_rel);
-                group.spawn(handleConnection, .{ self, stream }) catch |err| {
-                    log.err("Failed to accept connection: {}", .{err});
-                    _ = self.active_connections.fetchSub(1, .acq_rel);
-                    stream.close();
-                };
+                group.async(self.io, handleConnectionWrapper, .{ self, stream });
             }
         }
 
-        pub fn handleConnection(self: *Self, stream: zio.net.Stream) !void {
+        fn handleConnectionWrapper(self: *Self, stream: std.Io.net.Stream) std.Io.Cancelable!void {
+            handleConnection(self, stream) catch |err| {
+                if (err == error.Canceled) return error.Canceled;
+                log.err("Connection error: {}", .{err});
+            };
+        }
+
+        pub fn handleConnection(self: *Self, stream: std.Io.net.Stream) !void {
             defer {
                 const v = self.active_connections.fetchSub(1, .acq_rel);
                 if (v == 1) {
-                    self.last_connection_closed.broadcast();
+                    self.last_connection_closed.set(self.io);
                 }
             }
 
-            defer stream.close();
+            defer stream.close(self.io);
 
             var needs_shutdown = true;
-            defer if (needs_shutdown) stream.shutdown(.both) catch |err| {
+            defer if (needs_shutdown) stream.shutdown(self.io, .both) catch |err| {
                 log.warn("Failed to shutdown client connection: {}", .{err});
             };
 
-            var reader = stream.reader(&.{});
+            var reader = stream.reader(self.io, &.{});
 
             var write_buffer: [4096]u8 = undefined;
-            var writer = stream.writer(&write_buffer);
+            var writer = stream.writer(self.io, &write_buffer);
 
             var arena = std.heap.ArenaAllocator.init(self.allocator);
             defer arena.deinit();
@@ -167,8 +186,6 @@ pub fn Server(comptime Ctx: type) type {
 
             var request_count: usize = 0;
 
-            var timeout = zio.AutoCancel.init;
-
             // Allocate initial buffer from arena
             reader.interface.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
@@ -178,12 +195,7 @@ pub fn Server(comptime Ctx: type) type {
             while (true) {
                 request_count += 1;
 
-                defer timeout.clear();
-                if (self.config.timeout.request) |timeout_ms| {
-                    timeout.set(.fromMilliseconds(timeout_ms));
-                }
-
-                // TODO: handle error.Canceled caused by timeout and return 504
+                // TODO: implement request timeout (was zio.AutoCancel)
 
                 parseHeaders(&reader.interface, &parser) catch |err| switch (err) {
                     error.EndOfStream => {
@@ -271,12 +283,8 @@ pub fn Server(comptime Ctx: type) type {
                 reader.interface.seek = 0;
                 reader.interface.end = 0;
 
-                // Activate keepalive timeout
-                if (self.config.timeout.keepalive) |timeout_ms| {
-                    timeout.set(.fromMilliseconds(timeout_ms));
-                }
-
-                // Fill some data here, while the the keepalive timeout is active
+                // TODO: implement keepalive timeout (was zio.AutoCancel)
+                // Fill some data here
                 reader.interface.fillMore() catch |err| switch (err) {
                     error.EndOfStream => {
                         needs_shutdown = false;

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1,54 +1,45 @@
 const std = @import("std");
-const zio = @import("zio");
 const dusty = @import("root.zig");
 
-fn testClientServer(comptime Ctx: type, ctx: *Ctx, io: std.Io) !void {
+fn testClientServer(comptime Ctx: type, ctx: *Ctx) !void {
+    const io = std.testing.io;
     const TestServer = dusty.Server(Ctx);
 
-    const Test = struct {
-        pub fn mainFn(test_ctx: *Ctx, test_io: std.Io) !void {
-            var server = TestServer.init(std.testing.allocator, test_io, .{}, test_ctx);
-            defer server.deinit();
+    var server = TestServer.init(std.testing.allocator, io, .{}, ctx);
+    defer server.deinit();
 
-            try test_ctx.setup(&server);
+    try ctx.setup(&server);
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{ &server, test_ctx });
-            defer client_task.cancel();
-
-            try client_task.join();
+    var server_future = try io.concurrent(struct {
+        fn run(s: *TestServer) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
         }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
 
-        pub fn serverFn(server: *TestServer) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
+    var client_future = try io.concurrent(struct {
+        fn run(s: *TestServer, test_ctx: *Ctx, _io: std.Io) !void {
+            try s.ready.wait(_io);
 
-        pub fn clientFn(server: *TestServer, test_ctx: *Ctx) !void {
-            try server.ready.wait();
-
-            const client = try server.address.connect(.{});
-            defer client.close();
-            defer client.shutdown(.both) catch {};
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(&write_buf);
+            var writer = stream.writer(_io, &write_buf);
 
             try test_ctx.makeRequest(&writer.interface);
 
-            // Read response
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(&read_buf);
+            var reader = stream.reader(_io, &read_buf);
             const response = try reader.interface.takeDelimiterExclusive('\n');
 
             std.log.info("Response: {s}", .{response});
         }
-    };
+    }.run, .{ &server, ctx, io });
 
-    var task = try zio.spawn(Test.mainFn, .{ ctx, io });
-    try task.join();
+    try client_future.await(io);
 }
 
 test "Server: POST with body" {
@@ -74,7 +65,6 @@ test "Server: POST with body" {
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
             var reader = req.reader();
 
-            // Read all body data using streamRemaining
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
 
@@ -88,11 +78,7 @@ test "Server: POST with body" {
     };
 
     var ctx: TestContext = .{};
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    try testClientServer(TestContext, &ctx, rt.io());
+    try testClientServer(TestContext, &ctx);
 
     try std.testing.expect(ctx.body_received);
     try std.testing.expectEqualStrings("Hello from test!", ctx.received_body[0..ctx.received_len]);
@@ -113,30 +99,24 @@ test "Server: POST with chunked encoding" {
 
         pub fn makeRequest(ctx: *Self, writer: *std.Io.Writer) !void {
             _ = ctx;
-            // Send chunked encoded request in separate packets:
-            // Headers
             try writer.writeAll("POST /chunked HTTP/1.1\r\n");
             try writer.writeAll("Host: localhost\r\n");
             try writer.writeAll("Transfer-Encoding: chunked\r\n");
             try writer.writeAll("\r\n");
             try writer.flush();
 
-            // Chunk 1: "Hello " (6 bytes = 0x6)
             try writer.writeAll("6\r\n");
             try writer.writeAll("Hello \r\n");
             try writer.flush();
 
-            // Chunk 2: "from " (5 bytes = 0x5)
             try writer.writeAll("5\r\n");
             try writer.writeAll("from \r\n");
             try writer.flush();
 
-            // Chunk 3: "chunked test!" (13 bytes = 0xD)
             try writer.writeAll("D\r\n");
             try writer.writeAll("chunked test!\r\n");
             try writer.flush();
 
-            // Final chunk: 0
             try writer.writeAll("0\r\n");
             try writer.writeAll("\r\n");
             try writer.flush();
@@ -145,7 +125,6 @@ test "Server: POST with chunked encoding" {
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
             var reader = req.reader();
 
-            // Read all body data using streamRemaining
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
 
@@ -159,11 +138,7 @@ test "Server: POST with chunked encoding" {
     };
 
     var ctx: TestContext = .{};
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    try testClientServer(TestContext, &ctx, rt.io());
+    try testClientServer(TestContext, &ctx);
 
     try std.testing.expect(ctx.body_received);
     try std.testing.expectEqualStrings("Hello from chunked test!", ctx.received_body[0..ctx.received_len]);
@@ -190,11 +165,9 @@ test "Server: GET with no body" {
         fn handleGet(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
             var reader = req.reader();
 
-            // Try to read body - should get 0 bytes since GET has no body
             var body_buf: [256]u8 = undefined;
             var writer = std.Io.Writer.fixed(&body_buf);
             const n = reader.interface.streamRemaining(&writer) catch |err| blk: {
-                // EndOfStream is expected for empty body
                 if (err == error.EndOfStream) break :blk 0;
                 return err;
             };
@@ -209,11 +182,7 @@ test "Server: GET with no body" {
     };
 
     var ctx: TestContext = .{};
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    try testClientServer(TestContext, &ctx, rt.io());
+    try testClientServer(TestContext, &ctx);
 
     try std.testing.expect(ctx.reader_tested);
     try std.testing.expectEqual(0, ctx.read_len);
@@ -234,7 +203,6 @@ test "Server: HTTP/1.0 GET request" {
 
         pub fn makeRequest(ctx: *Self, writer: *std.Io.Writer) !void {
             _ = ctx;
-            // HTTP/1.0 request - no Host header required, connection closes after response
             try writer.writeAll("GET /http10 HTTP/1.0\r\n\r\n");
             try writer.flush();
         }
@@ -249,11 +217,7 @@ test "Server: HTTP/1.0 GET request" {
     };
 
     var ctx: TestContext = .{};
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    try testClientServer(TestContext, &ctx, rt.io());
+    try testClientServer(TestContext, &ctx);
 
     try std.testing.expect(ctx.request_handled);
     try std.testing.expectEqual(1, ctx.version_major);
@@ -261,6 +225,8 @@ test "Server: HTTP/1.0 GET request" {
 }
 
 test "Server: WebSocket echo" {
+    const io = std.testing.io;
+
     const TestContext = struct {
         const Self = @This();
 
@@ -274,19 +240,6 @@ test "Server: WebSocket echo" {
             server.router.get("/ws", handleWebSocket);
         }
 
-        pub fn makeRequest(ctx: *Self, writer: *std.Io.Writer) !void {
-            _ = ctx;
-            // Send WebSocket upgrade request
-            try writer.writeAll("GET /ws HTTP/1.1\r\n");
-            try writer.writeAll("Host: localhost\r\n");
-            try writer.writeAll("Upgrade: websocket\r\n");
-            try writer.writeAll("Connection: Upgrade\r\n");
-            try writer.writeAll("Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n");
-            try writer.writeAll("Sec-WebSocket-Version: 13\r\n");
-            try writer.writeAll("\r\n");
-            try writer.flush();
-        }
-
         fn handleWebSocket(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
             var ws = try res.upgradeWebSocket(req) orelse {
                 res.status = .bad_request;
@@ -295,10 +248,8 @@ test "Server: WebSocket echo" {
 
             ctx.ws_upgraded = true;
 
-            // Send welcome message
             try ws.send(.text, "Welcome!");
 
-            // Receive one message and echo it
             const msg = ws.receive() catch |err| switch (err) {
                 error.EndOfStream => return,
                 else => return err,
@@ -313,43 +264,37 @@ test "Server: WebSocket echo" {
         }
     };
 
-    const Test = struct {
-        pub fn mainFn(ctx: *TestContext, io: std.Io) !void {
-            var server = dusty.Server(TestContext).init(std.testing.allocator, io, .{}, ctx);
-            defer server.deinit();
+    var ctx: TestContext = .{};
 
-            try ctx.setup(&server);
+    var server = dusty.Server(TestContext).init(std.testing.allocator, io, .{}, &ctx);
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
+    try ctx.setup(&server);
 
-            var client_task = try zio.spawn(clientFn, .{&server});
-            defer client_task.cancel();
-
-            try client_task.join();
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(TestContext)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
         }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
 
-        pub fn serverFn(server: *dusty.Server(TestContext)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(TestContext), _io: std.Io) !void {
+            try s.ready.wait(_io);
 
-        pub fn clientFn(server: *dusty.Server(TestContext)) !void {
-            try server.ready.wait();
-
-            const client = try server.address.connect(.{});
-            defer client.close();
-            defer client.shutdown(.both) catch {};
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(&write_buf);
+            var writer = stream.writer(_io, &write_buf);
             const w = &writer.interface;
 
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(&read_buf);
+            var reader = stream.reader(_io, &read_buf);
             const r = &reader.interface;
 
-            // Send WebSocket upgrade request
             try w.writeAll("GET /ws HTTP/1.1\r\n");
             try w.writeAll("Host: localhost\r\n");
             try w.writeAll("Upgrade: websocket\r\n");
@@ -359,7 +304,6 @@ test "Server: WebSocket echo" {
             try w.writeAll("\r\n");
             try w.flush();
 
-            // Read upgrade response headers until we see \r\n\r\n
             var response_buf: [512]u8 = undefined;
             var response_len: usize = 0;
             while (response_len < response_buf.len - 1) {
@@ -368,7 +312,6 @@ test "Server: WebSocket echo" {
                     response_buf[response_len] = buffered[0];
                     r.toss(1);
                     response_len += 1;
-                    // Check for end of headers
                     if (response_len >= 4 and
                         response_buf[response_len - 4] == '\r' and
                         response_buf[response_len - 3] == '\n' and
@@ -385,7 +328,6 @@ test "Server: WebSocket echo" {
             try std.testing.expect(std.mem.indexOf(u8, response_str, "101") != null);
             try std.testing.expect(std.mem.indexOf(u8, response_str, "Sec-WebSocket-Accept") != null);
 
-            // Helper to read exact bytes
             const readExact = struct {
                 fn read(rdr: *std.Io.Reader, dest: []u8) !void {
                     var filled: usize = 0;
@@ -403,30 +345,33 @@ test "Server: WebSocket echo" {
                 }
             }.read;
 
-            // Read welcome message frame
             var frame_header: [2]u8 = undefined;
             try readExact(r, &frame_header);
-            try std.testing.expectEqual(0x81, frame_header[0]); // FIN + text
+            try std.testing.expectEqual(0x81, frame_header[0]);
             const welcome_len = frame_header[1] & 0x7F;
             const welcome = try std.testing.allocator.alloc(u8, welcome_len);
             defer std.testing.allocator.free(welcome);
             try readExact(r, welcome);
             try std.testing.expectEqualStrings("Welcome!", welcome);
 
-            // Send a masked text frame: "Hello"
-            // Mask key: 0x37, 0xfa, 0x21, 0x3d
             const masked_hello = [_]u8{
-                0x81, // FIN + text
-                0x85, // masked + length 5
-                0x37, 0xfa, 0x21, 0x3d, // mask key
-                'H' ^ 0x37, 'e' ^ 0xfa, 'l' ^ 0x21, 'l' ^ 0x3d, 'o' ^ 0x37, // masked "Hello"
+                0x81,
+                0x85,
+                0x37,
+                0xfa,
+                0x21,
+                0x3d,
+                'H' ^ 0x37,
+                'e' ^ 0xfa,
+                'l' ^ 0x21,
+                'l' ^ 0x3d,
+                'o' ^ 0x37,
             };
             try w.writeAll(&masked_hello);
             try w.flush();
 
-            // Read echo response
             try readExact(r, &frame_header);
-            try std.testing.expectEqual(0x81, frame_header[0]); // FIN + text
+            try std.testing.expectEqual(0x81, frame_header[0]);
             const echo_len = frame_header[1] & 0x7F;
             const echo = try std.testing.allocator.alloc(u8, echo_len);
             defer std.testing.allocator.free(echo);
@@ -435,15 +380,9 @@ test "Server: WebSocket echo" {
 
             std.log.info("WebSocket test passed: received echo '{s}'", .{echo});
         }
-    };
+    }.run, .{ &server, io });
 
-    var ctx: TestContext = .{};
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var task = try zio.spawn(Test.mainFn, .{ &ctx, rt.io() });
-    try task.join();
+    try client_future.await(io);
 
     try std.testing.expect(ctx.ws_upgraded);
     try std.testing.expect(ctx.message_received);
@@ -451,194 +390,158 @@ test "Server: WebSocket echo" {
 }
 
 test "Server: void context handlers" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.get("/test", handleGet);
-            server.router.post("/echo", handlePost);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{&server});
-            defer client_task.cancel();
-
-            try client_task.join();
-        }
-
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
-
-        pub fn clientFn(server: *dusty.Server(void)) !void {
-            try server.ready.wait();
-
-            const client = try server.address.connect(.{});
-            defer client.close();
-            defer client.shutdown(.both) catch {};
-
-            var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(&write_buf);
-
-            // Test GET request
-            try writer.interface.writeAll("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
-            try writer.interface.flush();
-
-            // Read response - just verify we get something back
-            var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(&read_buf);
-            const status_line = try reader.interface.takeDelimiterExclusive('\n');
-
-            std.log.info("Response: {s}", .{status_line});
-            // Just verify we got a 200 OK response
-            try std.testing.expect(std.mem.indexOf(u8, status_line, "200 OK") != null);
-        }
-
-        fn handleGet(req: *dusty.Request, res: *dusty.Response) !void {
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             _ = req;
             res.body = "Hello from void context!\n";
         }
+    }.handle);
 
-        fn handlePost(req: *dusty.Request, res: *dusty.Response) !void {
+    server.router.post("/echo", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             var reader = req.reader();
             const body = try reader.interface.allocRemaining(req.arena, .limited(1024));
             res.body = try std.fmt.allocPrint(res.arena, "Echo: {s}\n", .{body});
         }
-    };
+    }.handle);
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
 
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+
+            try writer.interface.writeAll("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n");
+            try writer.interface.flush();
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+
+            std.log.info("Response: {s}", .{status_line});
+            try std.testing.expect(std.mem.indexOf(u8, status_line, "200 OK") != null);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
 }
 
 test "Server: 100-continue" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.post("/upload", handlePost);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{&server});
-            defer client_task.cancel();
-
-            try client_task.join();
+    server.router.post("/upload", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            const body = try req.body();
+            res.body = body orelse "";
         }
+    }.handle);
 
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
         }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
 
-        pub fn clientFn(server: *dusty.Server(void)) !void {
-            try server.ready.wait();
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
 
-            const client = try server.address.connect(.{});
-            defer client.close();
-            defer client.shutdown(.both) catch {};
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
 
             var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(&write_buf);
+            var writer = stream.writer(_io, &write_buf);
 
             var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(&read_buf);
+            var reader = stream.reader(_io, &read_buf);
 
-            // Send headers with Expect: 100-continue, but don't send body yet
             const body = "Hello, World!";
             try writer.interface.print("POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: {d}\r\nExpect: 100-continue\r\n\r\n", .{body.len});
             try writer.interface.flush();
 
-            // Read 100 Continue response
             const continue_line = try reader.interface.takeDelimiterExclusive('\n');
             try std.testing.expect(std.mem.indexOf(u8, continue_line, "100 Continue") != null);
-            reader.interface.toss(1); // skip \n
-            _ = try reader.interface.takeDelimiterExclusive('\n'); // empty line
+            reader.interface.toss(1);
+            _ = try reader.interface.takeDelimiterExclusive('\n');
             reader.interface.toss(1);
 
-            // Now send the body
             try writer.interface.writeAll(body);
             try writer.interface.flush();
 
-            // Read final response
             const status_line = try reader.interface.takeDelimiterExclusive('\n');
             try std.testing.expect(std.mem.indexOf(u8, status_line, "200 OK") != null);
         }
+    }.run, .{ &server, io });
 
-        fn handlePost(req: *dusty.Request, res: *dusty.Response) !void {
-            // Reading the body triggers 100 Continue
-            const body = try req.body();
-            res.body = body orelse "";
-        }
-    };
-
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
-
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    try client_future.await(io);
 }
 
 test "Server: 417 Expectation Failed for unknown Expect value" {
-    const Test = struct {
-        pub fn mainFn(io: std.Io) !void {
-            var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
-            defer server.deinit();
+    const io = std.testing.io;
 
-            server.router.post("/upload", handlePost);
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
 
-            var server_task = try zio.spawn(serverFn, .{&server});
-            defer server_task.cancel();
-
-            var client_task = try zio.spawn(clientFn, .{&server});
-            defer client_task.cancel();
-
-            try client_task.join();
-        }
-
-        pub fn serverFn(server: *dusty.Server(void)) !void {
-            const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 0);
-            try server.listen(addr);
-        }
-
-        pub fn clientFn(server: *dusty.Server(void)) !void {
-            try server.ready.wait();
-
-            const client = try server.address.connect(.{});
-            defer client.close();
-            defer client.shutdown(.both) catch {};
-
-            var write_buf: [1024]u8 = undefined;
-            var writer = client.writer(&write_buf);
-
-            var read_buf: [1024]u8 = undefined;
-            var reader = client.reader(&read_buf);
-
-            // Send request with unknown Expect value
-            try writer.interface.writeAll("POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nExpect: unknown-value\r\n\r\n");
-            try writer.interface.flush();
-
-            // Should get 417 Expectation Failed
-            const status_line = try reader.interface.takeDelimiterExclusive('\n');
-            try std.testing.expect(std.mem.indexOf(u8, status_line, "417") != null);
-        }
-
-        fn handlePost(req: *dusty.Request, res: *dusty.Response) !void {
+    server.router.post("/upload", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             const body = try req.body();
             res.body = body orelse "";
         }
-    };
+    }.handle);
 
-    var rt = try zio.Runtime.init(std.testing.allocator, .{});
-    defer rt.deinit();
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
 
-    var task = try zio.spawn(Test.mainFn, .{rt.io()});
-    try task.join();
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+
+            try writer.interface.writeAll("POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\nExpect: unknown-value\r\n\r\n");
+            try writer.interface.flush();
+
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+            try std.testing.expect(std.mem.indexOf(u8, status_line, "417") != null);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
 }

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -187,6 +187,10 @@ pub fn main(init: std.process.Init) !void {
 
         current_test = friendly_name;
         std.testing.allocator_instance = .{};
+        std.testing.io_instance = .init(gpa, .{
+            .argv0 = .init(init.minimal.args),
+            .environ = init.minimal.environ,
+        });
 
         if (env.do_log_capture) {
             log_buffer.clearRetainingCapacity();
@@ -214,6 +218,8 @@ pub fn main(init: std.process.Init) !void {
             leak += 1;
             Printer.status(.fail, "\n{s}\n\"{s}\" - Memory Leak\n{s}\n", .{ BORDER, friendly_name, BORDER });
         }
+
+        std.testing.io_instance.deinit();
 
         var fail_err: ?anyerror = null;
         if (result) |_| {


### PR DESCRIPTION
Migrate from the zio's native API to `std.Io`. It's still preferred to use this via zio's `std.Io` instance.

Because `std.Io` doesn't support timeouts, we lost some functionality. I'll probably add some comptime hooks that allow using zio-specific functionality.

https://codeberg.org/ziglang/zig/issues/32166
https://codeberg.org/ziglang/zig/issues/31098