### PR TITLE
Update README to use std.Io instead of zio

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,47 +29,6 @@ const dusty = b.dependency("dusty", .{
 exe.root_module.addImport("dusty", dusty.module("dusty"));
 ```
 
-## Selecting the I/O Backend
-
-By default, dusty uses the threaded I/O provided by `std.process.Init`. This is suitable for small servers and scripts that don't have long-running tasks.
-
-For production use, it's recommended to use [zio](https://github.com/lalinsky/zio), which provides a high-performance coroutine-based async runtime. Add it as a dependency:
-
-```sh
-zig fetch --save "git+https://github.com/lalinsky/zio#v0.10.0"
-```
-
-In `build.zig`, add the zio module:
-
-```zig
-const zio = b.dependency("zio", .{
-    .target = target,
-    .optimize = optimize,
-});
-exe.root_module.addImport("zio", zio.module("zio"));
-```
-
-Then initialize zio's runtime and pass it to dusty:
-
-```zig
-const std = @import("std");
-const zio = @import("zio");
-const http = @import("dusty");
-
-pub fn main(init: std.process.Init) !void {
-    var rt = try zio.Runtime.init(init.gpa, .{});
-    defer rt.deinit();
-
-    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
-    defer server.deinit();
-
-    // ... router setup ...
-
-    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
-    try server.listen(addr);
-}
-```
-
 ## Server Example
 
 ```zig
@@ -123,4 +82,45 @@ var response = try client.fetch("http://localhost/v1.41/info", .{
     .unix_socket_path = "/var/run/docker.sock",
 });
 defer response.deinit();
+```
+
+## Selecting the I/O Backend
+
+The examples above use `init.io`, the threaded I/O provided by `std.process.Init`. This is suitable for small servers and scripts without long-running tasks.
+
+For production use, it's recommended to use [zio](https://github.com/lalinsky/zio), which provides a high-performance coroutine-based async runtime. Add it as a dependency:
+
+```sh
+zig fetch --save "git+https://github.com/lalinsky/zio#v0.10.0"
+```
+
+In `build.zig`, add the zio module:
+
+```zig
+const zio = b.dependency("zio", .{
+    .target = target,
+    .optimize = optimize,
+});
+exe.root_module.addImport("zio", zio.module("zio"));
+```
+
+Then initialize zio's runtime and pass it to dusty:
+
+```zig
+const std = @import("std");
+const zio = @import("zio");
+const http = @import("dusty");
+
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
+    defer rt.deinit();
+
+    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
+    defer server.deinit();
+
+    // ... router setup ...
+
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
+    try server.listen(addr);
+}
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,47 @@ const dusty = b.dependency("dusty", .{
 exe.root_module.addImport("dusty", dusty.module("dusty"));
 ```
 
+## Selecting the I/O Backend
+
+By default, dusty uses the threaded I/O provided by `std.process.Init`. This is suitable for small servers and scripts that don't have long-running tasks.
+
+For production use, it's recommended to use [zio](https://github.com/lalinsky/zio), which provides a high-performance coroutine-based async runtime. Add it as a dependency:
+
+```sh
+zig fetch --save "git+https://github.com/lalinsky/zio#v0.10.0"
+```
+
+In `build.zig`, add the zio module:
+
+```zig
+const zio = b.dependency("zio", .{
+    .target = target,
+    .optimize = optimize,
+});
+exe.root_module.addImport("zio", zio.module("zio"));
+```
+
+Then initialize zio's runtime and pass it to dusty:
+
+```zig
+const std = @import("std");
+const zio = @import("zio");
+const http = @import("dusty");
+
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
+    defer rt.deinit();
+
+    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
+    defer server.deinit();
+
+    // ... router setup ...
+
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
+    try server.listen(addr);
+}
+```
+
 ## Server Example
 
 ```zig

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Dusty is a HTTP client/server library built on top of [zio](https://github.com/lalinsky/zio) (coroutine/async engine) and [llhttp](https://github.com/nodejs/llhttp) (HTTP parser from NodeJS).
-The server API is inspired by Karl Seguin's [http.zig](https://github.com/karlseguin/http.zig), and tries to be as compatible as possible. By using a coroutine scheduler under the hood, it's very easy to efficiently wait for a HTTP client request in a HTTP server handler, or perhaps have a long-runing WebSocket session and don't worry about state management between callbacks.
+Dusty is a HTTP client/server library built on top of Zig's standard library async I/O (`std.Io`) and [llhttp](https://github.com/nodejs/llhttp) (HTTP parser from NodeJS).
+The server API is inspired by Karl Seguin's [http.zig](https://github.com/karlseguin/http.zig), and tries to be as compatible as possible. By using coroutines under the hood, it's very easy to efficiently wait for a HTTP client request in a HTTP server handler, or perhaps have a long-running WebSocket session and not worry about state management between callbacks.
 
 ## Features
 - Asynchronous I/O for multiple concurrent connections on a single CPU thread
@@ -17,29 +17,22 @@ The server API is inspired by Karl Seguin's [http.zig](https://github.com/karlse
 
 ```sh
 zig fetch --save "git+https://github.com/lalinsky/dusty#v0.2.0"
-zig fetch --save "git+https://github.com/lalinsky/zio#v0.10.0"
 ```
 
-Then in your `build.zig`, add the modules as dependencies:
+Then in your `build.zig`, add the module as a dependency:
 
 ```zig
 const dusty = b.dependency("dusty", .{
     .target = target,
     .optimize = optimize,
 });
-const zio = b.dependency("zio", .{
-    .target = target,
-    .optimize = optimize,
-});
 exe.root_module.addImport("dusty", dusty.module("dusty"));
-exe.root_module.addImport("zio", zio.module("zio"));
 ```
 
 ## Server Example
 
 ```zig
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 fn handleUser(req: *http.Request, res: *http.Response) !void {
@@ -49,15 +42,12 @@ fn handleUser(req: *http.Request, res: *http.Response) !void {
 }
 
 pub fn main(init: std.process.Init) !void {
-    var rt = try zio.Runtime.init(init.gpa, .{});
-    defer rt.deinit();
-
-    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
+    var server = http.Server(void).init(init.gpa, init.io, .{}, {});
     defer server.deinit();
 
     server.router.get("/user/:id", handleUser);
 
-    const addr = try zio.net.IpAddress.parseIp("127.0.0.1", 8080);
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
     try server.listen(addr);
 }
 ```
@@ -66,20 +56,16 @@ pub fn main(init: std.process.Init) !void {
 
 ```zig
 const std = @import("std");
-const zio = @import("zio");
 const http = @import("dusty");
 
 pub fn main(init: std.process.Init) !void {
-    var rt = try zio.Runtime.init(init.gpa, .{});
-    defer rt.deinit();
-
-    var client = http.Client.init(init.gpa, rt.io(), .{});
+    var client = http.Client.init(init.gpa, init.io, .{});
     defer client.deinit();
 
     var response = try client.fetch("http://httpbin.org/get", .{});
     defer response.deinit();
 
-    std.debug.print("Status: {t}\n", .{response.status()});
+    std.debug.print("Status: {any}\n", .{response.status()});
 
     if (try response.body()) |body| {
         std.debug.print("Body: {s}\n", .{body});
@@ -97,4 +83,3 @@ var response = try client.fetch("http://localhost/v1.41/info", .{
 });
 defer response.deinit();
 ```
-


### PR DESCRIPTION
Updates README examples and description to use `std.Io` (Zig's standard library async I/O) instead of the external `zio` dependency.

Closes #67

