### PR TITLE
Add optional zio support for request/keepalive timeouts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,11 +4,23 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const use_zio = b.option(bool, "use_zio", "Use zio for timeout support (default: false)") orelse false;
+
+    const options = b.addOptions();
+    options.addOption(bool, "use_zio", use_zio);
+
     const mod = b.addModule("dusty", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
+    mod.addOptions("dusty_options", options);
+    if (b.lazyDependency("zio", .{
+        .target = target,
+        .optimize = optimize,
+    })) |zio| {
+        mod.addImport("zio", zio.module("zio"));
+    }
 
     mod.link_libc = true;
     mod.addCSourceFiles(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,7 +31,13 @@
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
-    .dependencies = .{},
+    .dependencies = .{
+        .zio = .{
+            .url = "git+https://github.com/lalinsky/zio?ref=v0.10.0#cb6b65042d5148078a386fcb41ae193015c7b2f1",
+            .hash = "zio-0.10.0-xHbVVL4_GwD6YOx2dijO51-Uz6hUzCjHsTA1FTgu8Qp0",
+            .lazy = true,
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/server.zig
+++ b/src/server.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+const root = @import("root");
+const dusty_options = if (@hasDecl(root, "dusty_options")) root.dusty_options else @import("dusty_options");
+const zio = if (dusty_options.use_zio) @import("zio") else struct {};
 
 const Router = @import("router.zig").Router;
 const Action = @import("router.zig").Action;
@@ -186,21 +189,32 @@ pub fn Server(comptime Ctx: type) type {
 
             var request_count: usize = 0;
 
+            var timeout: if (dusty_options.use_zio) zio.AutoCancel else void = if (dusty_options.use_zio) .init else {};
+
             // Allocate initial buffer from arena
             reader.interface.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
                 return err;
             };
 
-            if (self.config.timeout.request != null) {
-                @panic("request timeout not implemented");
-            }
-            if (self.config.timeout.keepalive != null) {
-                @panic("keepalive timeout not implemented");
+            if (!dusty_options.use_zio) {
+                if (self.config.timeout.request != null) {
+                    @panic("request timeout requires use_zio");
+                }
+                if (self.config.timeout.keepalive != null) {
+                    @panic("keepalive timeout requires use_zio");
+                }
             }
 
             while (true) {
                 request_count += 1;
+
+                if (dusty_options.use_zio) {
+                    defer timeout.clear();
+                    if (self.config.timeout.request) |timeout_ms| {
+                        timeout.set(.fromMilliseconds(@intCast(timeout_ms)));
+                    }
+                }
 
                 parseHeaders(&reader.interface, &parser) catch |err| switch (err) {
                     error.EndOfStream => {
@@ -288,7 +302,14 @@ pub fn Server(comptime Ctx: type) type {
                 reader.interface.seek = 0;
                 reader.interface.end = 0;
 
-                // Fill some data here
+                // Activate keepalive timeout
+                if (dusty_options.use_zio) {
+                    if (self.config.timeout.keepalive) |timeout_ms| {
+                        timeout.set(.fromMilliseconds(@intCast(timeout_ms)));
+                    }
+                }
+
+                // Fill some data here, while the keepalive timeout is active
                 reader.interface.fillMore() catch |err| switch (err) {
                     error.EndOfStream => {
                         needs_shutdown = false;


### PR DESCRIPTION
## Summary
- Add zio as a lazy dependency for optional timeout support
- Add `use_zio` build option to enable zio.AutoCancel for timeouts
- Users can also set `dusty_options.use_zio` in their root module (similar to std_options)

## Test plan
- [x] `zig build` succeeds without use_zio
- [x] `zig build -Duse_zio=true` succeeds
- [x] All tests pass in both configurations