### PR TITLE
Add standalone zio example

### DIFF
--- a/examples/zio/build.zig
+++ b/examples/zio/build.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const dusty = b.dependency("dusty", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const zio = b.dependency("zio", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "server",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    exe.root_module.addImport("dusty", dusty.module("dusty"));
+    exe.root_module.addImport("zio", zio.module("zio"));
+
+    b.installArtifact(exe);
+
+    const run = b.addRunArtifact(exe);
+    const run_step = b.step("run", "Run the server");
+    run_step.dependOn(&run.step);
+}

--- a/examples/zio/build.zig.zon
+++ b/examples/zio/build.zig.zon
@@ -1,0 +1,20 @@
+.{
+    .name = .dusty_zio_example,
+    .fingerprint = 0x36721edac7724861,
+    .version = "0.0.0",
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .dusty = .{
+            .path = "../..",
+        },
+        .zio = .{
+            .url = "git+https://github.com/lalinsky/zio?ref=v0.11.0#53abdf9ce5e6279e29703a39180ce1cedd8ac4ca",
+            .hash = "zio-0.11.0-xHbVVEqQGwDz0MYoQ0j7Ke0Y9E_iZVe5eLAWK4gd9U0i",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/examples/zio/src/main.zig
+++ b/examples/zio/src/main.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const zio = @import("zio");
+const http = @import("dusty");
+
+fn handleRoot(_: *http.Request, res: *http.Response) !void {
+    res.body = "Hello World!\n";
+}
+
+pub fn main(init: std.process.Init) !void {
+    var rt = try zio.Runtime.init(init.gpa, .{});
+    defer rt.deinit();
+
+    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
+    defer server.deinit();
+
+    server.router.get("/", handleRoot);
+
+    const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
+    std.log.info("Starting server on http://127.0.0.1:8080", .{});
+    try server.listen(addr);
+}


### PR DESCRIPTION
Adds `examples/zio/` — a self-contained project that uses dusty via a local path dependency and zio v0.11.0 as the I/O runtime.