### PR TITLE
Inject zio as a build-time module import

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,6 +10,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // Default `zio` import — a stub that no-ops `clear` and panics on `set`.
+    // Apps that want real timeouts override this in their own build.zig:
+    //   dusty_mod.addImport("zio", zio_dep.module("zio"));
+    mod.addAnonymousImport("zio", .{
+        .root_source_file = b.path("src/zio_stub.zig"),
+    });
+
     mod.link_libc = true;
     mod.addCSourceFiles(.{
         .files = &[_][]const u8{

--- a/examples/zio/build.zig
+++ b/examples/zio/build.zig
@@ -14,6 +14,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // Override dusty's default `zio` stub with the real module so that
+    // request/keepalive timeouts use zio.AutoCancel.
+    const dusty_mod = dusty.module("dusty");
+    dusty_mod.addImport("zio", zio.module("zio"));
+
     const exe = b.addExecutable(.{
         .name = "server",
         .root_module = b.createModule(.{
@@ -22,7 +27,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    exe.root_module.addImport("dusty", dusty.module("dusty"));
+    exe.root_module.addImport("dusty", dusty_mod);
     exe.root_module.addImport("zio", zio.module("zio"));
 
     b.installArtifact(exe);

--- a/examples/zio/src/main.zig
+++ b/examples/zio/src/main.zig
@@ -10,7 +10,12 @@ pub fn main(init: std.process.Init) !void {
     var rt = try zio.Runtime.init(init.gpa, .{ .executors = .auto });
     defer rt.deinit();
 
-    var server = http.Server(void).init(init.gpa, rt.io(), .{}, {});
+    var server = http.Server(void).init(init.gpa, rt.io(), .{
+        .timeout = .{
+            .request = .fromSeconds(30),
+            .keepalive = .fromSeconds(5),
+        },
+    }, {});
     defer server.deinit();
 
     server.router.get("/", handleRoot);

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,10 +6,10 @@ pub const ServerConfig = struct {
     listen: std.Io.net.IpAddress.ListenOptions = .{ .reuse_address = true, .kernel_backlog = 1024 },
 
     pub const Timeout = struct {
-        /// Maximum time (ms) to receive a complete request
-        request: ?u64 = null,
-        /// Maximum time (ms) to keep idle connections open
-        keepalive: ?u64 = null,
+        /// Maximum time to receive a complete request
+        request: ?std.Io.Duration = null,
+        /// Maximum time to keep idle connections open
+        keepalive: ?std.Io.Duration = null,
         /// Maximum number of requests per keepalive connection
         request_count: ?usize = null,
     };

--- a/src/server.zig
+++ b/src/server.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const zio = @import("zio");
 
 const Router = @import("router.zig").Router;
 const Action = @import("router.zig").Action;
@@ -187,21 +188,21 @@ pub fn Server(comptime Ctx: type) type {
 
             var request_count: usize = 0;
 
+            var timeout: zio.AutoCancel = .init;
+            defer timeout.clear();
+
             // Allocate initial buffer from arena
             reader.interface.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
                 return err;
             };
 
-            if (self.config.timeout.request != null) {
-                @panic("request timeout not implemented");
-            }
-            if (self.config.timeout.keepalive != null) {
-                @panic("keepalive timeout not implemented");
-            }
-
             while (true) {
                 request_count += 1;
+
+                if (self.config.timeout.request) |duration| {
+                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                }
 
                 parseHeaders(&reader.interface, &parser) catch |err| switch (err) {
                     error.EndOfStream => {
@@ -305,7 +306,11 @@ pub fn Server(comptime Ctx: type) type {
                 reader.interface.seek = 0;
                 reader.interface.end = 0;
 
-                // Fill some data here
+                if (self.config.timeout.keepalive) |duration| {
+                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                }
+
+                // Fill some data here, under the keepalive timeout
                 reader.interface.fillMore() catch |err| switch (err) {
                     error.EndOfStream => {
                         needs_shutdown = false;

--- a/src/zio_stub.zig
+++ b/src/zio_stub.zig
@@ -1,0 +1,23 @@
+// Stub `zio` module: provides the minimal API surface dusty needs to compile
+// and run without depending on the real zio package. Downstream apps that want
+// real timeouts override this import in their build.zig:
+//
+//     const zio_dep = b.dependency("zio", .{});
+//     const dusty_mod = b.dependency("dusty", .{}).module("dusty");
+//     dusty_mod.addImport("zio", zio_dep.module("zio"));
+
+pub const Duration = struct {
+    pub fn fromMilliseconds(_: i64) Duration {
+        return .{};
+    }
+};
+
+pub const AutoCancel = struct {
+    pub const init: AutoCancel = .{};
+
+    pub fn set(_: *AutoCancel, _: Duration) void {
+        @panic("dusty: timeout configured but no `zio` module injected; override in build.zig via `dusty_mod.addImport(\"zio\", zio_dep.module(\"zio\"))`");
+    }
+
+    pub fn clear(_: *AutoCancel) void {}
+};


### PR DESCRIPTION
## Summary

- Dusty no longer declares zio as its own dependency. `@import("zio")` in dusty resolves to a local stub by default (`src/zio_stub.zig`), which no-ops `AutoCancel.clear` and panics on `AutoCancel.set` with a message pointing the user at the build.zig override.
- Downstream apps that want real timeouts inject the real module in their build.zig:
  ```zig
  const dusty_mod = b.dependency("dusty", .{}).module("dusty");
  dusty_mod.addImport("zio", zio_dep.module("zio"));
  ```
- Switches the request/keepalive timeout config fields from `?u64` (ms) to `?std.Io.Duration`.
- `examples/zio` is updated to do the injection and to configure `.request = .fromSeconds(30)` / `.keepalive = .fromSeconds(5)`, exercising the real `zio.AutoCancel` path.

The call site `timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())))` works against both the stub and real zio via enum-literal inference: the stub's `Duration.fromMilliseconds` returns `Duration`, real zio's `Timeout.fromMilliseconds` returns `Timeout`, and `AutoCancel.set` accepts whichever its own implementation expects.

## Test plan

- [x] `./check.sh` — 173/173 tests pass
- [x] `examples/zio` builds and serves a request end-to-end with timeouts configured