### PR TITLE
Harden HTTP framing and fix multipart OOB read

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -679,6 +679,9 @@ pub const Client = struct {
             };
         } else null;
 
+        // Reject any CRLF/NUL smuggled in via the URL host.
+        try http.validateHeaderValue(host);
+
         // Acquire or create a connection
         const conn = try self.acquireConnection(host, info.port, info.protocol, ca_bundle, options.unix_socket_path);
         errdefer {
@@ -720,6 +723,8 @@ pub const Client = struct {
                 if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Connection")) continue;
                 if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Sec-WebSocket-Key")) continue;
                 if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Sec-WebSocket-Version")) continue;
+                try http.validateHeaderName(entry.key_ptr.*);
+                try http.validateHeaderValue(entry.value_ptr.*);
                 try conn.writer.print("{s}: {s}\r\n", .{ entry.key_ptr.*, entry.value_ptr.* });
             }
         }
@@ -747,13 +752,10 @@ pub const Client = struct {
             return error.WebSocketUpgradeFailed;
         }
 
-        var ws = WebSocket.init(conn.writer, conn.reader, conn.allocator);
+        var seed: u64 = undefined;
+        self.io.random(std.mem.asBytes(&seed));
+        var ws = WebSocket.init(conn.writer, conn.reader, conn.allocator, seed);
         ws.is_client = true;
-        ws.prng = std.Random.DefaultPrng.init(blk: {
-            var seed: u64 = undefined;
-            self.io.random(std.mem.asBytes(&seed));
-            break :blk seed;
-        });
         return .{ .ws = ws, .conn = conn };
     }
 
@@ -861,6 +863,10 @@ const WriteRequestOptions = struct {
 };
 
 fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
+    // Reject any CRLF/NUL smuggled in via the URL host (a URL like
+    // "http://foo%0d%0aX-Evil:1/" would otherwise inject a header).
+    try http.validateHeaderValue(opts.host);
+
     // Request line - path with query
     const path = uriPath(opts.uri);
     if (opts.uri.query) |query| {
@@ -891,6 +897,8 @@ fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
             if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Length")) continue;
             if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Accept-Encoding")) has_accept_encoding = true;
 
+            try http.validateHeaderName(entry.key_ptr.*);
+            try http.validateHeaderValue(entry.value_ptr.*);
             try writer.print("{s}: {s}\r\n", .{ entry.key_ptr.*, entry.value_ptr.* });
         }
     }

--- a/src/http.zig
+++ b/src/http.zig
@@ -253,13 +253,25 @@ test "Headers: put/get case insenstive" {
 }
 
 // Bytes that would break "Name: Value\r\n" framing on the wire.
-// Names additionally reject whitespace and ':' per RFC 7230 tchar.
 const invalid_header_value_bytes = "\r\n\x00";
-const invalid_header_name_bytes = "\r\n\x00\t :";
+
+// RFC 7230 token chars (tchar): the only bytes allowed in a header field-name.
+const allowed_header_name_bytes = "!#$%&'*+-.^_`|~" ++
+    "0123456789" ++
+    "abcdefghijklmnopqrstuvwxyz" ++
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+const tchar_table: [256]bool = blk: {
+    var table = [_]bool{false} ** 256;
+    for (allowed_header_name_bytes) |byte| table[byte] = true;
+    break :blk table;
+};
 
 pub fn validateHeaderName(name: []const u8) error{InvalidHeaderName}!void {
     if (name.len == 0) return error.InvalidHeaderName;
-    if (std.mem.indexOfAny(u8, name, invalid_header_name_bytes) != null) return error.InvalidHeaderName;
+    for (name) |byte| {
+        if (!tchar_table[byte]) return error.InvalidHeaderName;
+    }
 }
 
 pub fn validateHeaderValue(value: []const u8) error{InvalidHeaderValue}!void {
@@ -279,6 +291,8 @@ test "validateHeaderName: rejects empty, whitespace, colon, control" {
     try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X-Foo:"));
     try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X Foo"));
     try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X-Foo\r"));
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X(Foo)"));
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X,Foo"));
     try validateHeaderName("X-Custom-Header");
 }
 

--- a/src/http.zig
+++ b/src/http.zig
@@ -252,6 +252,36 @@ test "Headers: put/get case insenstive" {
     try std.testing.expectEqualStrings("bar", val.?);
 }
 
+// Bytes that would break "Name: Value\r\n" framing on the wire.
+// Names additionally reject whitespace and ':' per RFC 7230 tchar.
+const invalid_header_value_bytes = "\r\n\x00";
+const invalid_header_name_bytes = "\r\n\x00\t :";
+
+pub fn validateHeaderName(name: []const u8) error{InvalidHeaderName}!void {
+    if (name.len == 0) return error.InvalidHeaderName;
+    if (std.mem.indexOfAny(u8, name, invalid_header_name_bytes) != null) return error.InvalidHeaderName;
+}
+
+pub fn validateHeaderValue(value: []const u8) error{InvalidHeaderValue}!void {
+    if (std.mem.indexOfAny(u8, value, invalid_header_value_bytes) != null) return error.InvalidHeaderValue;
+}
+
+test "validateHeaderValue: rejects CR/LF/NUL" {
+    try std.testing.expectError(error.InvalidHeaderValue, validateHeaderValue("a\rb"));
+    try std.testing.expectError(error.InvalidHeaderValue, validateHeaderValue("a\nb"));
+    try std.testing.expectError(error.InvalidHeaderValue, validateHeaderValue("a\x00b"));
+    try validateHeaderValue("safe value with spaces and !@#$%");
+    try validateHeaderValue("");
+}
+
+test "validateHeaderName: rejects empty, whitespace, colon, control" {
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName(""));
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X-Foo:"));
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X Foo"));
+    try std.testing.expectError(error.InvalidHeaderName, validateHeaderName("X-Foo\r"));
+    try validateHeaderName("X-Custom-Header");
+}
+
 pub const ContentType = enum(u32) {
     text,
     html,

--- a/src/request.zig
+++ b/src/request.zig
@@ -402,7 +402,8 @@ const MultipartForm = struct {
                 while (pos < fields.len) {
                     switch (fields[pos]) {
                         '\\' => {
-                            if (pos == fields.len) {
+                            // Trailing backslash with no character to escape.
+                            if (pos + 1 >= fields.len) {
                                 return error.InvalidMultiPartEncoding;
                             }
                             // supposedly MSIE doesn't always escape \, so if the \ isn't escape
@@ -709,4 +710,40 @@ test "Request.multiFormData: entry with filename" {
 
     const form_data = try req.multiFormData();
     try std.testing.expectEqualStrings("foo.txt", form_data.get("foo").?.filename.?);
+}
+
+test "Request.multiFormData: trailing backslash in quoted attribute (regression)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Quoted name value ends with a backslash and no closing quote — the parser
+    // currently looks at fields[pos+1] without bounds-checking, panicking on
+    // safety-checked builds. Should return InvalidMultiPartEncoding instead.
+    const body = "----b\r\nContent-Disposition: form-data; name=\"x\\\r\n\r\nval\r\n----b--\r\n";
+    var cl_buf: [16]u8 = undefined;
+    const cl = try std.fmt.bufPrint(&cl_buf, "{d}", .{body.len});
+
+    var req_buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer req_buf.deinit(std.testing.allocator);
+    try req_buf.appendSlice(std.testing.allocator, "POST /t HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=--b\r\nContent-Length: ");
+    try req_buf.appendSlice(std.testing.allocator, cl);
+    try req_buf.appendSlice(std.testing.allocator, "\r\n\r\n");
+    try req_buf.appendSlice(std.testing.allocator, body);
+
+    var reader = std.Io.Reader.fixed(req_buf.items);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .conn = &reader,
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    try std.testing.expectError(error.InvalidMultiPartEncoding, req.multiFormData());
 }

--- a/src/request.zig
+++ b/src/request.zig
@@ -392,7 +392,10 @@ const MultipartForm = struct {
 
             var value: []const u8 = undefined;
             if (fields[value_start] != '"') {
-                const value_end = std.mem.indexOfScalarPos(u8, fields, pos, ';') orelse fields.len;
+                // Search from value_start, not pos: a stray ';' inside the
+                // field name (malformed input the parser doesn't reject)
+                // would otherwise place value_end before value_start.
+                const value_end = std.mem.indexOfScalarPos(u8, fields, value_start, ';') orelse fields.len;
                 pos = value_end;
                 value = fields[value_start..value_end];
             } else blk: {
@@ -710,6 +713,44 @@ test "Request.multiFormData: entry with filename" {
 
     const form_data = try req.multiFormData();
     try std.testing.expectEqualStrings("foo.txt", form_data.get("foo").?.filename.?);
+}
+
+test "Request.multiFormData: semicolon in attribute name (regression)" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Content-Disposition attribute name containing ';' — the parser
+    // searched for the value-terminating ';' from the field-name start
+    // instead of from the value start, so value_end could land before
+    // value_start and slice [value_start..value_end] panicked.
+    const body = "----b\r\nContent-Disposition: form-data; name;x=v\r\n\r\nval\r\n----b--\r\n";
+    var cl_buf: [16]u8 = undefined;
+    const cl = try std.fmt.bufPrint(&cl_buf, "{d}", .{body.len});
+
+    var req_buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer req_buf.deinit(std.testing.allocator);
+    try req_buf.appendSlice(std.testing.allocator, "POST /t HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=--b\r\nContent-Length: ");
+    try req_buf.appendSlice(std.testing.allocator, cl);
+    try req_buf.appendSlice(std.testing.allocator, "\r\n\r\n");
+    try req_buf.appendSlice(std.testing.allocator, body);
+
+    var reader = std.Io.Reader.fixed(req_buf.items);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .conn = &reader,
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // Should error out cleanly, not panic.
+    _ = req.multiFormData() catch {};
 }
 
 test "Request.multiFormData: trailing backslash in quoted attribute (regression)" {

--- a/src/response.zig
+++ b/src/response.zig
@@ -15,9 +15,10 @@ pub const EventStream = struct {
     };
 
     pub fn send(self: EventStream, data: []const u8, opts: Options) !void {
-        if (std.debug.runtime_safety) {
-            std.debug.assert(std.mem.indexOfScalar(u8, data, '\n') == null); // data must not contain newlines
-        }
+        if (std.mem.indexOfAny(u8, data, "\r\n") != null) return error.InvalidEventField;
+        if (opts.event) |e| if (std.mem.indexOfAny(u8, e, "\r\n") != null) return error.InvalidEventField;
+        if (opts.id) |id| if (std.mem.indexOfAny(u8, id, "\r\n") != null) return error.InvalidEventField;
+
         if (opts.event) |e| try self.conn.print("event: {s}\n", .{e});
         if (opts.id) |id| try self.conn.print("id: {s}\n", .{id});
         if (opts.retry) |r| try self.conn.print("retry: {d}\n", .{r});
@@ -49,6 +50,8 @@ pub const Response = struct {
     }
 
     pub fn header(self: *Response, name: []const u8, value: []const u8) !void {
+        try http.validateHeaderName(name);
+        try http.validateHeaderValue(value);
         try self.headers.put(self.arena, name, value);
     }
 
@@ -127,7 +130,9 @@ pub const Response = struct {
         try self.writeHeader();
         try self.conn.flush();
 
-        return WebSocket.init(self.conn, req.conn, self.arena);
+        var seed: u64 = undefined;
+        req.io.random(std.mem.asBytes(&seed));
+        return WebSocket.init(self.conn, req.conn, self.arena, seed);
     }
 
     pub fn writeHeader(self: *Response) !void {
@@ -755,4 +760,52 @@ test "Response: setCookie with options" {
 
     const written = conn_writer.buffered();
     try std.testing.expect(std.mem.indexOf(u8, written, "Set-Cookie: auth=token123; Path=/; HttpOnly; Secure; SameSite=Strict\r\n") != null);
+}
+
+test "Response: header() rejects CRLF in value" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var response = Response.init(arena.allocator(), &conn_writer);
+    try std.testing.expectError(error.InvalidHeaderValue, response.header("Location", "/ok\r\nX-Evil: 1"));
+    try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\nbaz"));
+    try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\x00baz"));
+}
+
+test "Response: header() rejects invalid name" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var response = Response.init(arena.allocator(), &conn_writer);
+    try std.testing.expectError(error.InvalidHeaderName, response.header("", "value"));
+    try std.testing.expectError(error.InvalidHeaderName, response.header("X-Bad\r\n", "value"));
+    try std.testing.expectError(error.InvalidHeaderName, response.header("X: Bad", "value"));
+    try std.testing.expectError(error.InvalidHeaderName, response.header("X Bad", "value"));
+}
+
+test "Response: setCookie rejects CRLF via header()" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var response = Response.init(arena.allocator(), &conn_writer);
+    try std.testing.expectError(error.InvalidHeaderValue, response.setCookie("session", "abc\r\nSet-Cookie: evil=1", .{}));
+}
+
+test "EventStream: rejects newline in data" {
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    const stream = EventStream{ .conn = &conn_writer };
+    try std.testing.expectError(error.InvalidEventField, stream.send("line1\nline2", .{}));
+    try std.testing.expectError(error.InvalidEventField, stream.send("ok", .{ .event = "bad\nevent" }));
+    try std.testing.expectError(error.InvalidEventField, stream.send("ok", .{ .id = "bad\rid" }));
 }

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -5,7 +5,7 @@ pub const WebSocket = struct {
     reader: *std.Io.Reader,
     msg_arena: std.heap.ArenaAllocator,
     is_client: bool = false,
-    prng: std.Random.DefaultPrng = std.Random.DefaultPrng.init(0),
+    prng: std.Random.DefaultPrng,
     max_message_size: usize = default_max_message_size,
     closed: bool = false,
     auto_responded: bool = false,
@@ -57,11 +57,12 @@ pub const WebSocket = struct {
 
     const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-    pub fn init(conn: *std.Io.Writer, reader: *std.Io.Reader, gpa: std.mem.Allocator) WebSocket {
+    pub fn init(conn: *std.Io.Writer, reader: *std.Io.Reader, gpa: std.mem.Allocator, seed: u64) WebSocket {
         return .{
             .conn = conn,
             .reader = reader,
             .msg_arena = std.heap.ArenaAllocator.init(gpa),
+            .prng = std.Random.DefaultPrng.init(seed),
         };
     }
 
@@ -306,7 +307,7 @@ test "WebSocket: writeFrame text" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeFrame(.text, "Hello", true);
 
@@ -324,7 +325,7 @@ test "WebSocket: writeFrame binary with medium length" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
 
     const payload = "x" ** 200;
@@ -344,7 +345,7 @@ test "WebSocket: writeCloseFrame" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeCloseFrame(.normal, "goodbye");
 
@@ -373,7 +374,7 @@ test "WebSocket: readFrame unmasked" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     const frame = try ws.readFrame();
 
@@ -398,7 +399,7 @@ test "WebSocket: readFrame masked" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     const frame = try ws.readFrame();
 
@@ -422,7 +423,7 @@ test "WebSocket: receive handles ping automatically" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     const msg = try ws.receive();
 
@@ -451,7 +452,7 @@ test "WebSocket: readFrame rejects RSV bits" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try std.testing.expectError(WebSocket.Error.ReservedFlags, ws.readFrame());
 }
@@ -469,7 +470,7 @@ test "WebSocket: readFrame rejects large control frame" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try std.testing.expectError(WebSocket.Error.LargeControlFrame, ws.readFrame());
 }
@@ -479,7 +480,7 @@ test "WebSocket: writeFrame masked (client mode)" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator);
+    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try ws.writeFrame(.text, "Hello", true);


### PR DESCRIPTION
## Summary

Security audit pass on the HTTP layer. Two commits:

### 1. Fix OOB read in multipart Content-Disposition parser

`getContentDispositionAttributes` had a dead bounds check inside `while (pos < fields.len)` — `if (pos == fields.len)` can never be true there — so `fields[pos + 1]` was read past the end of the buffer whenever a backslash was the last byte of a quoted attribute value.

A single `Content-Disposition: form-data; name=\"x\\` (backslash before the trailing CRLF) panics the worker on safety-checked builds. Any unauthenticated handler reachable by a `multipart/form-data` POST that calls `req.multiFormData()` can be crashed.

Fixed to `pos + 1 >= fields.len`, regression test added.

### 2. Harden HTTP framing against header injection

Defense-in-depth so callers can't accidentally split a request/response across CRLF, and so WebSocket masking keys can't silently inherit a constant seed:

- **Header CRLF validation.** New `http.validateHeaderName` / `http.validateHeaderValue`. `Response.header()` validates both, which covers `setCookie` too. Client `writeRequest` and `connectWebSocket` validate the URL host and every caller-supplied header before emitting them — a URL like `http://foo%0d%0aX-Evil:1/` would otherwise inject after `std.Uri` host decoding.
- **EventStream.** The newline check on `data` was gated on `runtime_safety` and vanished in `ReleaseFast`; `event`/`id` weren't checked at all. All three now validated unconditionally and return `InvalidEventField` instead of asserting.
- **WebSocket masking key seed.** The `prng` field defaulted to `init(0)`. The client upgrade path reseeded after init, but any other caller that flipped `is_client = true` silently used the constant state-0 mask key stream (RFC 6455 §5.3 violation). Removed the default and made `seed: u64` a required `WebSocket.init` parameter. Server upgrade now pulls a seed from `req.io.random`; client upgrade folds its existing reseed into the init call.

## Test plan

- [x] `./check.sh` — 180/180 tests pass (regression test for the multipart OOB plus four new validation tests).
- [ ] Optional follow-up: drop sensitive headers on cross-origin redirects in the client, and add an SSRF guard against loopback/private destinations.