### PR TITLE
Migrate from @cImport to addTranslateC build step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,14 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/zio_stub.zig"),
     });
 
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("src/llhttp/llhttp.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    translate_c.addIncludePath(b.path("src/llhttp"));
+    mod.addImport("llhttp", translate_c.createModule());
+
     mod.link_libc = true;
     mod.addCSourceFiles(.{
         .files = &[_][]const u8{

--- a/src/http.zig
+++ b/src/http.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
-const c = @cImport({
-    @cInclude("llhttp.h");
-});
+const c = @import("llhttp");
 
 pub const Method = enum(c.llhttp_method_t) {
     delete = c.HTTP_DELETE,

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
-const c = @cImport({
-    @cInclude("llhttp.h");
-});
+const c = @import("llhttp");
 
 const Method = @import("http.zig").Method;
 const Status = @import("http.zig").Status;


### PR DESCRIPTION
Zig 0.16 deprecates `@cImport`. This replaces the two usages in `src/http.zig` and `src/parser.zig` with the recommended `addTranslateC` build step approach.

- `build.zig`: adds a `TranslateC` step for `llhttp.h` and exposes the result as the `"llhttp"` module import
- `src/http.zig`, `src/parser.zig`: replace `@cImport({ @cInclude("llhttp.h"); })` with `@import("llhttp")`