### PR TITLE
Normalize method to GET on 301/302/303 redirects

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -839,11 +839,16 @@ pub const Client = struct {
                 conn.closing = !conn.parser.shouldKeepAlive();
                 self.pool.release(conn);
 
-                // For 303, always use GET and clear body
+                // 301/302/303 with a non-GET/HEAD method: switch to GET and drop body.
+                // 307/308 preserve the original method and body.
                 var redirect_options = state.options;
-                if (status_code == 303) {
-                    redirect_options.method = .get;
-                    redirect_options.body = null;
+                if (status_code == 301 or status_code == 302 or status_code == 303) {
+                    if (redirect_options.method != .get and redirect_options.method != .head) {
+                        redirect_options.method = .get;
+                        redirect_options.body = null;
+                    } else if (status_code == 303) {
+                        redirect_options.body = null;
+                    }
                 }
 
                 // Strip sensitive headers when crossing to a different domain/host.


### PR DESCRIPTION
## Summary

- 301/302/303 redirects with a non-GET/HEAD method now switch to GET and drop the body, matching browser and Go `net/http` behavior
- GET and HEAD requests are unaffected
- 307/308 continue to preserve the original method and body

## Background

RFC 7231 permits clients to keep the original method on 301/302, but every major client (browsers, Go, curl, requests) switches non-GET/HEAD to GET because that is what servers universally expect. 307/308 were introduced precisely to signal "really keep the method."

Stacked on #90.