### PR TITLE
Don't pool connections with unread response bodies

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -820,6 +820,7 @@ pub const Client = struct {
 
         // Check for unsupported content encoding
         if (state.options.decompress and conn.parsed_response.content_encoding == .unknown) {
+            if (!conn.parser.isBodyComplete()) conn.closing = true;
             return error.UnsupportedContentEncoding;
         }
 
@@ -835,8 +836,10 @@ pub const Client = struct {
                 const redirect_uri = Uri.resolveInPlace(state.uri, location.len, &aux_buf) catch return error.InvalidUrl;
                 const redirect_info = try uriPortAndProtocol(redirect_uri);
 
-                // Release current connection back to pool
-                conn.closing = !conn.parser.shouldKeepAlive();
+                // Release current connection back to pool.
+                // If the redirect response has an unread body, closing the connection
+                // is safer than pooling it with leftover bytes on the socket.
+                conn.closing = !conn.parser.isBodyComplete() or !conn.parser.shouldKeepAlive();
                 self.pool.release(conn);
 
                 // For 303, always use GET and clear body


### PR DESCRIPTION
## Summary

Two paths in `fetchInternal` were returning early after parsing headers — `UnsupportedContentEncoding` error and the redirect path — while potentially leaving unread body bytes on the socket. The connection could then go back into the pool and the next request would read garbage.

- **`UnsupportedContentEncoding`**: sets `conn.closing = true` before returning, so the `errdefer` closes the connection instead of pooling it with a dirty socket.
- **Redirect**: ORs `!conn.parser.isBodyComplete()` into the closing condition. Bodyless redirects (where the state machine already advances past `message_complete` during header parsing) continue to be pooled; redirects with a body are closed cleanly.

Reported by @coderabbitai. Stacked on #90.