### PR TITLE
Replace Headers with pre-allocated parallel arrays supporting multiple values per key

### DIFF
--- a/examples/client.zig
+++ b/examples/client.zig
@@ -25,7 +25,7 @@ pub fn main(init: std.process.Init) !void {
     std.debug.print("Headers:\n", .{});
     var it = response.headers().iterator();
     while (it.next()) |entry| {
-        std.debug.print("  {s}: {s}\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+        std.debug.print("  {s}: {s}\n", .{ entry.key, entry.value });
     }
 
     std.debug.print("\n", .{});

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -18,11 +18,11 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     };
 
     // Forward request headers (excluding hop-by-hop headers)
-    var headers: http.Headers = .{};
+    var headers = try http.Headers.init(req.arena, req.headers.count());
     var it = req.headers.iterator();
     while (it.next()) |entry| {
-        const key = entry.key_ptr.*;
-        const value = entry.value_ptr.*;
+        const key = entry.key;
+        const value = entry.value;
 
         // Skip hop-by-hop headers that shouldn't be forwarded
         if (std.ascii.eqlIgnoreCase(key, "connection") or
@@ -35,7 +35,7 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
             continue;
         }
 
-        try headers.put(req.arena, key, value);
+        try headers.put(key, value);
     }
     upstream_req.headers = &headers;
 
@@ -63,8 +63,8 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     var upstream_headers = upstream_res.headers();
     var upstream_it = upstream_headers.iterator();
     while (upstream_it.next()) |entry| {
-        const key = entry.key_ptr.*;
-        const value = entry.value_ptr.*;
+        const key = entry.key;
+        const value = entry.value;
 
         // Skip hop-by-hop headers
         if (std.ascii.eqlIgnoreCase(key, "connection") or

--- a/src/client.zig
+++ b/src/client.zig
@@ -48,6 +48,8 @@ pub const ClientConfig = struct {
     buffer_size: usize = 4096,
     /// Use system CA bundle for HTTPS connections.
     use_system_ca_bundle: bool = true,
+    /// Maximum number of headers allowed in a response.
+    max_response_header_count: usize = 64,
 };
 
 /// Options for a single fetch request.
@@ -220,7 +222,11 @@ pub const ConnectionPool = struct {
         }
 
         // Reset and add to pool
-        conn.reset();
+        conn.reset() catch {
+            conn.deinit();
+            self.allocator.destroy(conn);
+            return;
+        };
         self.idle.append(&conn.pool_node);
         self.idle_len += 1;
     }
@@ -235,6 +241,7 @@ pub const Connection = struct {
     parser: ResponseParser,
     parsed_response: ParsedResponse,
     buffer_size: usize,
+    max_response_headers: usize,
     pool: *ConnectionPool,
 
     // Protocol and TLS
@@ -280,6 +287,7 @@ pub const Connection = struct {
         remote_host: []const u8,
         remote_port: u16,
         buffer_size: usize,
+        max_response_headers: usize,
         protocol: Protocol,
         ca_bundle: ?CaBundleRef,
         unix_socket_path: ?[]const u8,
@@ -291,6 +299,7 @@ pub const Connection = struct {
         self.pool = pool;
         self.closing = false;
         self.buffer_size = buffer_size;
+        self.max_response_headers = max_response_headers;
 
         // Keep-Alive tracking
         self.request_count = 0;
@@ -314,7 +323,7 @@ pub const Connection = struct {
         }
 
         self.parsed_response = .{ .arena = self.arena.allocator() };
-        self.parser.init(&self.parsed_response);
+        try self.parser.init(&self.parsed_response, self.max_response_headers);
 
         // Protocol and TLS initialization
         self.protocol = protocol;
@@ -390,12 +399,12 @@ pub const Connection = struct {
         self.arena.deinit();
     }
 
-    pub fn reset(self: *Connection) void {
+    pub fn reset(self: *Connection) !void {
         // Reset for reuse (connection pooling)
         _ = self.arena.reset(.retain_capacity);
         self.parsed_response = .{ .arena = self.arena.allocator() };
         self.parser.reset();
-        self.parser.init(&self.parsed_response);
+        try self.parser.init(&self.parsed_response, self.max_response_headers);
         self.closing = false;
 
         // As part of reading body, we shrank the buffer
@@ -671,6 +680,7 @@ pub const Client = struct {
                 host,
                 port,
                 self.config.buffer_size,
+                self.config.max_response_header_count,
                 protocol,
                 ca_bundle,
                 unix_socket_path,
@@ -739,14 +749,14 @@ pub const Client = struct {
         if (options.headers) |h| {
             var it = h.iterator();
             while (it.next()) |entry| {
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Host")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Upgrade")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Connection")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Sec-WebSocket-Key")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Sec-WebSocket-Version")) continue;
-                try http.validateHeaderName(entry.key_ptr.*);
-                try http.validateHeaderValue(entry.value_ptr.*);
-                try conn.writer.print("{s}: {s}\r\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+                if (std.ascii.eqlIgnoreCase(entry.key, "Host")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Upgrade")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Connection")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Sec-WebSocket-Key")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Sec-WebSocket-Version")) continue;
+                try http.validateHeaderName(entry.key);
+                try http.validateHeaderValue(entry.value);
+                try conn.writer.print("{s}: {s}\r\n", .{ entry.key, entry.value });
             }
         }
 
@@ -987,29 +997,29 @@ fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
         var it = h.iterator();
         while (it.next()) |entry| {
             // Skip headers we already set
-            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Host")) continue;
-            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Length")) continue;
-            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Accept-Encoding")) has_accept_encoding = true;
-            if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Referer")) has_referer = true;
+            if (std.ascii.eqlIgnoreCase(entry.key, "Host")) continue;
+            if (std.ascii.eqlIgnoreCase(entry.key, "Content-Length")) continue;
+            if (std.ascii.eqlIgnoreCase(entry.key, "Accept-Encoding")) has_accept_encoding = true;
+            if (std.ascii.eqlIgnoreCase(entry.key, "Referer")) has_referer = true;
 
             if (opts.strip_sensitive_headers) {
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Authorization")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Www-Authenticate")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Cookie")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Cookie2")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Proxy-Authorization")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Proxy-Authenticate")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Authorization")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Www-Authenticate")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Cookie")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Cookie2")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Proxy-Authorization")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Proxy-Authenticate")) continue;
             }
             if (opts.strip_body_headers) {
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Encoding")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Language")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Location")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key_ptr.*, "Content-Type")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Encoding")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Language")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Location")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Type")) continue;
             }
 
-            try http.validateHeaderName(entry.key_ptr.*);
-            try http.validateHeaderValue(entry.value_ptr.*);
-            try writer.print("{s}: {s}\r\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+            try http.validateHeaderName(entry.key);
+            try http.validateHeaderValue(entry.value);
+            try writer.print("{s}: {s}\r\n", .{ entry.key, entry.value });
         }
     }
 
@@ -1201,7 +1211,7 @@ test "ClientResponse.body: basic response" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1227,7 +1237,7 @@ test "ClientResponse.body: large body over 128 bytes" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1253,7 +1263,7 @@ test "ClientResponse.body: no body" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1279,7 +1289,7 @@ test "ClientResponse.reader: streaming read" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1314,7 +1324,7 @@ test "ClientResponse.reader: after body() returns cached data" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1347,7 +1357,7 @@ test "ClientResponse.body: gzip decompression" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1375,7 +1385,7 @@ test "ClientResponse.body: gzip decompression disabled" {
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
-    parser.init(&parsed);
+    try parser.init(&parsed, 64);
 
     try parseResponseHeaders(&reader, &parser);
 
@@ -1471,9 +1481,9 @@ test "writeRequest: does not override user-provided Referer" {
     var buf: [4096]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
-    var headers: Headers = .{};
+    var headers = try Headers.init(std.testing.allocator, 4);
     defer headers.deinit(std.testing.allocator);
-    try headers.put(std.testing.allocator, "Referer", "http://custom.example.com/");
+    try headers.put("Referer", "http://custom.example.com/");
 
     const uri = try parseUrl("http://example.com/new");
     try writeRequest(&writer, .{
@@ -1514,11 +1524,11 @@ test "writeRequest: strips sensitive headers on cross-origin redirect" {
     var buf: [4096]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
-    var headers: Headers = .{};
+    var headers = try Headers.init(std.testing.allocator, 4);
     defer headers.deinit(std.testing.allocator);
-    try headers.put(std.testing.allocator, "Authorization", "Bearer secret");
-    try headers.put(std.testing.allocator, "Cookie", "session=abc");
-    try headers.put(std.testing.allocator, "X-Custom", "keep-me");
+    try headers.put("Authorization", "Bearer secret");
+    try headers.put("Cookie", "session=abc");
+    try headers.put("X-Custom", "keep-me");
 
     const uri = try parseUrl("http://other.com/path");
     try writeRequest(&writer, .{
@@ -1543,10 +1553,10 @@ test "redirect: strips sensitive headers on https to http downgrade" {
     var buf: [4096]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
-    var headers: Headers = .{};
+    var headers = try Headers.init(std.testing.allocator, 4);
     defer headers.deinit(std.testing.allocator);
-    try headers.put(std.testing.allocator, "Authorization", "Bearer secret");
-    try headers.put(std.testing.allocator, "X-Custom", "keep-me");
+    try headers.put("Authorization", "Bearer secret");
+    try headers.put("X-Custom", "keep-me");
 
     const uri = try parseUrl("http://example.com/path");
     try writeRequest(&writer, .{
@@ -1569,10 +1579,10 @@ test "redirect: once stripping triggered it persists across hops" {
     var buf: [4096]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
-    var headers: Headers = .{};
+    var headers = try Headers.init(std.testing.allocator, 4);
     defer headers.deinit(std.testing.allocator);
-    try headers.put(std.testing.allocator, "Authorization", "Bearer secret");
-    try headers.put(std.testing.allocator, "X-Custom", "keep-me");
+    try headers.put("Authorization", "Bearer secret");
+    try headers.put("X-Custom", "keep-me");
 
     // Simulate a hop that is back on the original host but already has strip=true.
     const uri = try parseUrl("http://example.com/new-path");
@@ -1595,11 +1605,11 @@ test "writeRequest: strips body headers when body removed" {
     var buf: [4096]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
-    var headers: Headers = .{};
+    var headers = try Headers.init(std.testing.allocator, 4);
     defer headers.deinit(std.testing.allocator);
-    try headers.put(std.testing.allocator, "Content-Type", "application/json");
-    try headers.put(std.testing.allocator, "Content-Language", "en");
-    try headers.put(std.testing.allocator, "X-Custom", "keep-me");
+    try headers.put("Content-Type", "application/json");
+    try headers.put("Content-Language", "en");
+    try headers.put("X-Custom", "keep-me");
 
     const uri = try parseUrl("http://example.com/path");
     try writeRequest(&writer, .{

--- a/src/http.zig
+++ b/src/http.zig
@@ -217,12 +217,18 @@ pub const Headers = struct {
     const slice_size = @sizeOf([]const u8);
     const slice_align = @alignOf([]const u8);
 
+    const max_count = std.math.maxInt(usize) / (slice_size * 2 + 1);
+
     pub fn init(allocator: std.mem.Allocator, max: usize) !Headers {
         if (max == 0) return .{};
-        const buf = try allocator.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(slice_align), max * slice_size * 2 + max);
-        const keys: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf.ptr)))[0..max];
-        const values: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf[max * slice_size ..].ptr)))[0..max];
-        return .{ .keys = keys, .values = values, .hashes = buf[max * slice_size * 2 ..] };
+        const capped = @min(max, max_count);
+        const keys_bytes = capped * slice_size;
+        const hashes_offset = keys_bytes * 2;
+        const total_size = hashes_offset + capped;
+        const buf = try allocator.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(slice_align), total_size);
+        const keys: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf.ptr)))[0..capped];
+        const values: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf[keys_bytes..].ptr)))[0..capped];
+        return .{ .keys = keys, .values = values, .hashes = buf[hashes_offset..] };
     }
 
     pub fn deinit(self: *Headers, allocator: std.mem.Allocator) void {

--- a/src/http.zig
+++ b/src/http.zig
@@ -204,50 +204,135 @@ test "Status: format" {
     try std.testing.expectEqualStrings("NOT_FOUND", result);
 }
 
-const IgnoreCase = struct {
-    pub fn hash(self: @This(), s: []const u8) u64 {
-        _ = self;
-        var h = std.hash.Wyhash.init(0);
+/// Case-insensitive multi-value HTTP header map backed by parallel arrays in a
+/// single pre-allocated block.  A 1-byte hash filters most mismatches before
+/// the full case-insensitive string compare, keeping the linear scan cheap for
+/// the small number of headers in a typical HTTP message.
+pub const Headers = struct {
+    keys: [][]const u8 = &.{},
+    values: [][]const u8 = &.{},
+    hashes: []u8 = &.{},
+    len: usize = 0,
 
-        // Process in 48-byte chunks
-        var i: usize = 0;
-        const chunk_size = 48;
-        var lc: [chunk_size]u8 = undefined;
-        while (i + chunk_size <= s.len) : (i += chunk_size) {
-            inline for (0..chunk_size) |j| {
-                lc[j] = std.ascii.toLower(s[i + j]);
-            }
-            h.update(&lc);
-        }
+    const slice_size = @sizeOf([]const u8);
+    const slice_align = @alignOf([]const u8);
 
-        // Process remaining bytes
-        const remaining = s.len - i;
-        if (remaining > 0) {
-            for (0..remaining) |j| {
-                lc[j] = std.ascii.toLower(s[i + j]);
-            }
-            h.update(lc[0..remaining]);
-        }
-
-        return h.final();
+    pub fn init(allocator: std.mem.Allocator, max: usize) !Headers {
+        if (max == 0) return .{};
+        const buf = try allocator.alignedAlloc(u8, std.mem.Alignment.fromByteUnits(slice_align), max * slice_size * 2 + max);
+        const keys: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf.ptr)))[0..max];
+        const values: [][]const u8 = @as([*][]const u8, @ptrCast(@alignCast(buf[max * slice_size ..].ptr)))[0..max];
+        return .{ .keys = keys, .values = values, .hashes = buf[max * slice_size * 2 ..] };
     }
-    pub fn eql(self: @This(), a: []const u8, b: []const u8) bool {
-        _ = self;
-        return std.ascii.eqlIgnoreCase(a, b);
+
+    pub fn deinit(self: *Headers, allocator: std.mem.Allocator) void {
+        const max = self.keys.len;
+        if (max == 0) return;
+        const ptr: [*]align(slice_align) u8 = @ptrCast(@alignCast(self.keys.ptr));
+        allocator.free(ptr[0 .. max * slice_size * 2 + max]);
+        self.* = .{};
     }
+
+    inline fn hashFn(name: []const u8) u8 {
+        if (name.len == 0) return 0;
+        return @as(u8, @truncate(name.len)) | (std.ascii.toLower(name[0]) ^ std.ascii.toLower(name[name.len - 1]));
+    }
+
+    /// Replaces the value of the first entry matching name (case-insensitive),
+    /// or appends a new entry. Returns error.TooManyHeaders if at capacity.
+    pub fn put(self: *Headers, name: []const u8, value: []const u8) !void {
+        const h = hashFn(name);
+        for (self.hashes[0..self.len], 0..) |hh, i| {
+            if (hh == h and std.ascii.eqlIgnoreCase(self.keys[i], name)) {
+                self.values[i] = value;
+                return;
+            }
+        }
+        try self.add(name, value);
+    }
+
+    /// Always appends a new entry regardless of existing keys.
+    /// Returns error.TooManyHeaders if at capacity.
+    pub fn add(self: *Headers, name: []const u8, value: []const u8) !void {
+        const i = self.len;
+        if (i >= self.keys.len) return error.TooManyHeaders;
+        self.keys[i] = name;
+        self.values[i] = value;
+        self.hashes[i] = hashFn(name);
+        self.len = i + 1;
+    }
+
+    /// Returns the value of the first matching entry (case-insensitive), or null.
+    pub fn get(self: *const Headers, name: []const u8) ?[]const u8 {
+        const h = hashFn(name);
+        for (self.hashes[0..self.len], 0..) |hh, i| {
+            if (hh == h and std.ascii.eqlIgnoreCase(self.keys[i], name)) {
+                return self.values[i];
+            }
+        }
+        return null;
+    }
+
+    pub fn count(self: *const Headers) usize {
+        return self.len;
+    }
+
+    pub fn iterator(self: *const Headers) Iterator {
+        return .{ .keys = self.keys[0..self.len], .values = self.values[0..self.len], .pos = 0 };
+    }
+
+    pub const Iterator = struct {
+        keys: [][]const u8,
+        values: [][]const u8,
+        pos: usize,
+
+        pub const Entry = struct {
+            key: []const u8,
+            value: []const u8,
+        };
+
+        pub fn next(self: *Iterator) ?Entry {
+            if (self.pos >= self.keys.len) return null;
+            const i = self.pos;
+            self.pos += 1;
+            return .{ .key = self.keys[i], .value = self.values[i] };
+        }
+    };
 };
 
-pub const Headers = std.HashMapUnmanaged([]const u8, []const u8, IgnoreCase, 80);
-
-test "Headers: put/get case insenstive" {
-    var headers: Headers = .{};
+test "Headers: put/get case insensitive" {
+    var headers = try Headers.init(std.testing.allocator, 8);
     defer headers.deinit(std.testing.allocator);
 
-    try headers.put(std.testing.allocator, "FOO", "bar");
+    try headers.put("FOO", "bar");
 
-    const val = headers.get("foo");
-    try std.testing.expect(val != null);
-    try std.testing.expectEqualStrings("bar", val.?);
+    try std.testing.expectEqualStrings("bar", headers.get("foo").?);
+    try std.testing.expectEqualStrings("bar", headers.get("FOO").?);
+}
+
+test "Headers: put replaces, add appends" {
+    var headers = try Headers.init(std.testing.allocator, 4);
+    defer headers.deinit(std.testing.allocator);
+
+    try headers.put("Set-Cookie", "a=1");
+    try headers.add("Set-Cookie", "b=2");
+    try headers.put("Set-Cookie", "c=3"); // replaces first
+
+    try std.testing.expectEqualStrings("c=3", headers.get("set-cookie").?);
+    try std.testing.expectEqual(2, headers.count());
+
+    var it = headers.iterator();
+    try std.testing.expectEqualStrings("c=3", it.next().?.value);
+    try std.testing.expectEqualStrings("b=2", it.next().?.value);
+    try std.testing.expectEqual(null, it.next());
+}
+
+test "Headers: error on overflow" {
+    var headers = try Headers.init(std.testing.allocator, 1);
+    defer headers.deinit(std.testing.allocator);
+
+    try headers.add("A", "1");
+    try std.testing.expectError(error.TooManyHeaders, headers.add("B", "2"));
 }
 
 // Bytes that would break "Name: Value\r\n" framing on the wire.

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -66,6 +66,7 @@ pub const RequestParser = struct {
             .settings = undefined,
             .request = request,
         };
+        request.headers = try Headers.init(request.arena, request.config.max_header_count);
 
         self.settings = std.mem.zeroes(c.llhttp_settings_t);
         self.settings.on_method_complete = onMethod;
@@ -200,13 +201,8 @@ pub const RequestParser = struct {
 
         std.debug.assert(self.state.has_header_field);
 
-        // Check header count limit
-        if (self.request.headers.count() >= self.request.config.max_header_count) {
-            return -1;
-        }
-
         // Headers point directly into arena-allocated read buffer, no copy needed
-        self.request.headers.put(self.request.arena, self.state.header_field, self.state.header_value) catch return -1;
+        self.request.headers.add(self.state.header_field, self.state.header_value) catch return -1;
 
         self.state.header_value = "";
         self.state.header_field = "";
@@ -285,12 +281,13 @@ pub const ResponseParser = struct {
         body_dest_pos: usize = 0, // How much onBody has written
     };
 
-    pub fn init(self: *ResponseParser, response: *ParsedResponse) void {
+    pub fn init(self: *ResponseParser, response: *ParsedResponse, max_headers: usize) !void {
         self.* = .{
             .parser = undefined,
             .settings = undefined,
             .response = response,
         };
+        response.headers = try Headers.init(response.arena, max_headers);
 
         self.settings = std.mem.zeroes(c.llhttp_settings_t);
         self.settings.on_status_complete = onStatusComplete;
@@ -411,7 +408,7 @@ pub const ResponseParser = struct {
         std.debug.assert(self.state.has_header_field);
 
         // Headers point directly into arena-allocated read buffer, no copy needed
-        self.response.headers.put(self.response.arena, self.state.header_field, self.state.header_value) catch return -1;
+        self.response.headers.add(self.state.header_field, self.state.header_value) catch return -1;
 
         self.state.header_value = "";
         self.state.header_field = "";
@@ -698,7 +695,7 @@ test "ResponseParser: basic" {
     };
 
     var parser: ResponseParser = undefined;
-    parser.init(&response);
+    try parser.init(&response, 64);
     defer parser.deinit();
 
     const http_response = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";
@@ -738,7 +735,7 @@ test "ResponseParser: 404 status" {
     };
 
     var parser: ResponseParser = undefined;
-    parser.init(&response);
+    try parser.init(&response, 64);
     defer parser.deinit();
 
     const http_response = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";

--- a/src/request.zig
+++ b/src/request.zig
@@ -469,12 +469,14 @@ const MultipartForm = struct {
     // End of chunk.
 };
 
-const ParseHeadersError = std.Io.Reader.Error || ParseError || error{IncompleteRequest};
+const ParseHeadersError = std.Io.Reader.Error || ParseError || error{ IncompleteRequest, OutOfMemory };
 
 /// Parse HTTP headers from a reader and prepare for body reading.
 /// Returns error.EndOfStream if connection closed cleanly with no data.
 /// Returns error.IncompleteRequest if connection closed mid-request.
 pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeadersError!void {
+    // Re-pre-allocate headers each call to handle keep-alive (arena was reset).
+    parser.request.headers = try http.Headers.init(parser.request.arena, parser.request.config.max_header_count);
     var parsed_len: usize = 0;
     while (!parser.state.headers_complete) {
         const buffered = reader.buffered();

--- a/src/response.zig
+++ b/src/response.zig
@@ -111,18 +111,19 @@ pub const Response = struct {
     chunked: bool = false,
     streaming: bool = false,
 
-    pub fn init(arena: std.mem.Allocator, conn: *std.Io.Writer) Response {
+    pub fn init(arena: std.mem.Allocator, conn: *std.Io.Writer) !Response {
         return .{
             .arena = arena,
             .buffer = .init(arena),
             .conn = conn,
+            .headers = try http.Headers.init(arena, 16),
         };
     }
 
     pub fn header(self: *Response, name: []const u8, value: []const u8) !void {
         try http.validateHeaderName(name);
         try http.validateHeaderValue(value);
-        try self.headers.put(self.arena, name, value);
+        try self.headers.put(name, value);
     }
 
     pub fn writer(self: *Response) *std.Io.Writer {
@@ -141,7 +142,8 @@ pub const Response = struct {
 
     pub fn setCookie(self: *Response, name: []const u8, value: []const u8, opts: CookieOpts) !void {
         const serialized = try serializeCookie(self.arena, name, value, opts);
-        try self.header("Set-Cookie", serialized);
+        try http.validateHeaderValue(serialized);
+        try self.headers.add("Set-Cookie", serialized);
     }
 
     pub fn chunk(self: *Response, data: []const u8) !void {
@@ -227,7 +229,7 @@ pub const Response = struct {
         // Write headers
         var iter = self.headers.iterator();
         while (iter.next()) |entry| {
-            try self.conn.print("{s}: {s}\r\n", .{ entry.key_ptr.*, entry.value_ptr.* });
+            try self.conn.print("{s}: {s}\r\n", .{ entry.key, entry.value });
         }
 
         // Write Connection header based on keepalive
@@ -287,7 +289,7 @@ test "Response: basic writer usage" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const w = response.writer();
 
     try w.writeAll("Hello, ");
@@ -304,7 +306,7 @@ test "Response: writer with formatted output" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const w = response.writer();
 
     try w.print("Hello, {s}! You are {d} years old.", .{ "Alice", 30 });
@@ -320,7 +322,7 @@ test "Response: buffer takes precedence over body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "body content";
 
     const w = response.writer();
@@ -342,7 +344,7 @@ test "Response: body used when buffer is empty" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "body content";
 
     // Don't write to buffer
@@ -361,7 +363,7 @@ test "Response: write() with body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "Hello World";
 
     try response.write();
@@ -379,7 +381,7 @@ test "Response: write() with writer buffer" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const w = response.writer();
     try w.print("Count: {d}", .{42});
 
@@ -398,7 +400,7 @@ test "Response: write() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "First";
 
     try response.write();
@@ -419,7 +421,7 @@ test "Response: writeHeader() basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.status = .created;
     try response.header("X-Custom", "value");
     response.body = "Hello";
@@ -441,7 +443,7 @@ test "Response: writeHeader() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "Test";
 
     try response.writeHeader();
@@ -462,7 +464,7 @@ test "Response: write() after writeHeader() doesn't duplicate headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.body = "Body content";
 
     // Write headers first
@@ -489,7 +491,7 @@ test "Response: clearWriter()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const w = response.writer();
 
     try w.writeAll("First content");
@@ -509,7 +511,7 @@ test "Response: keepalive defaults to true" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try std.testing.expectEqual(true, response.keepalive);
 
     response.body = "test";
@@ -527,7 +529,7 @@ test "Response: Connection close header when keepalive is false" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.keepalive = false;
     response.body = "test";
 
@@ -544,7 +546,7 @@ test "Response: chunked with single chunk" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.status = .ok;
 
     try response.chunk("Hello");
@@ -571,7 +573,7 @@ test "Response: chunked with multiple chunks" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
 
     try response.chunk("First");
     try response.chunk("Second chunk");
@@ -600,7 +602,7 @@ test "Response: chunked with custom headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.status = .created;
     try response.header("X-Custom", "value");
 
@@ -629,7 +631,7 @@ test "Response: chunked flag defaults to false" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    const response = Response.init(arena.allocator(), &conn_writer);
+    const response = try Response.init(arena.allocator(), &conn_writer);
     try std.testing.expectEqual(false, response.chunked);
 }
 
@@ -640,7 +642,7 @@ test "Response: chunk() skips empty data so it doesn't terminate the stream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
 
     try response.chunk("first");
     try response.chunk(""); // would be the chunked terminator if written; must be skipped
@@ -665,7 +667,7 @@ test "Response: chunked mode doesn't write Content-Length" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
 
     try response.chunk("test");
     try response.write();
@@ -686,7 +688,7 @@ test "Response: json() with simple object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try response.json(.{ .name = "Alice", .age = 30 }, .{});
 
     const buffered = response.buffer.writer.buffered();
@@ -705,7 +707,7 @@ test "Response: json() writes complete response" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     response.status = .created;
     try response.json(.{ .id = 123, .message = "Created" }, .{});
     try response.write();
@@ -730,7 +732,7 @@ test "Response: json() with array" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const items = [_]i32{ 1, 2, 3, 4, 5 };
     try response.json(items, .{});
 
@@ -745,7 +747,7 @@ test "Response: json() with nested object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try response.json(.{
         .user = .{
             .name = "Bob",
@@ -810,7 +812,7 @@ test "Response: startEventStream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     const stream = try response.startEventStream();
 
     try stream.send("connected", .{});
@@ -830,7 +832,7 @@ test "Response: setCookie basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try response.setCookie("session", "abc123", .{});
     response.body = "OK";
 
@@ -847,7 +849,7 @@ test "Response: setCookie with options" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try response.setCookie("auth", "token123", .{
         .path = "/",
         .http_only = true,
@@ -869,7 +871,7 @@ test "Response: header() rejects CRLF in value" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try std.testing.expectError(error.InvalidHeaderValue, response.header("Location", "/ok\r\nX-Evil: 1"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\nbaz"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\x00baz"));
@@ -882,7 +884,7 @@ test "Response: header() rejects invalid name" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try std.testing.expectError(error.InvalidHeaderName, response.header("", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X-Bad\r\n", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X: Bad", "value"));
@@ -896,7 +898,7 @@ test "Response: setCookie rejects CRLF via header()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer);
     try std.testing.expectError(error.InvalidHeaderValue, response.setCookie("session", "abc\r\nSet-Cookie: evil=1", .{}));
 }
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -111,12 +111,12 @@ pub const Response = struct {
     chunked: bool = false,
     streaming: bool = false,
 
-    pub fn init(arena: std.mem.Allocator, conn: *std.Io.Writer) !Response {
+    pub fn init(arena: std.mem.Allocator, conn: *std.Io.Writer, max_headers: usize) !Response {
         return .{
             .arena = arena,
             .buffer = .init(arena),
             .conn = conn,
-            .headers = try http.Headers.init(arena, 16),
+            .headers = try http.Headers.init(arena, max_headers),
         };
     }
 
@@ -289,7 +289,7 @@ test "Response: basic writer usage" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const w = response.writer();
 
     try w.writeAll("Hello, ");
@@ -306,7 +306,7 @@ test "Response: writer with formatted output" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const w = response.writer();
 
     try w.print("Hello, {s}! You are {d} years old.", .{ "Alice", 30 });
@@ -322,7 +322,7 @@ test "Response: buffer takes precedence over body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "body content";
 
     const w = response.writer();
@@ -344,7 +344,7 @@ test "Response: body used when buffer is empty" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "body content";
 
     // Don't write to buffer
@@ -363,7 +363,7 @@ test "Response: write() with body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "Hello World";
 
     try response.write();
@@ -381,7 +381,7 @@ test "Response: write() with writer buffer" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const w = response.writer();
     try w.print("Count: {d}", .{42});
 
@@ -400,7 +400,7 @@ test "Response: write() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "First";
 
     try response.write();
@@ -421,7 +421,7 @@ test "Response: writeHeader() basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.status = .created;
     try response.header("X-Custom", "value");
     response.body = "Hello";
@@ -443,7 +443,7 @@ test "Response: writeHeader() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "Test";
 
     try response.writeHeader();
@@ -464,7 +464,7 @@ test "Response: write() after writeHeader() doesn't duplicate headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.body = "Body content";
 
     // Write headers first
@@ -491,7 +491,7 @@ test "Response: clearWriter()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const w = response.writer();
 
     try w.writeAll("First content");
@@ -511,7 +511,7 @@ test "Response: keepalive defaults to true" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try std.testing.expectEqual(true, response.keepalive);
 
     response.body = "test";
@@ -529,7 +529,7 @@ test "Response: Connection close header when keepalive is false" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.keepalive = false;
     response.body = "test";
 
@@ -546,7 +546,7 @@ test "Response: chunked with single chunk" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.status = .ok;
 
     try response.chunk("Hello");
@@ -573,7 +573,7 @@ test "Response: chunked with multiple chunks" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
 
     try response.chunk("First");
     try response.chunk("Second chunk");
@@ -602,7 +602,7 @@ test "Response: chunked with custom headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.status = .created;
     try response.header("X-Custom", "value");
 
@@ -631,7 +631,7 @@ test "Response: chunked flag defaults to false" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    const response = try Response.init(arena.allocator(), &conn_writer);
+    const response = try Response.init(arena.allocator(), &conn_writer, 32);
     try std.testing.expectEqual(false, response.chunked);
 }
 
@@ -642,7 +642,7 @@ test "Response: chunk() skips empty data so it doesn't terminate the stream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
 
     try response.chunk("first");
     try response.chunk(""); // would be the chunked terminator if written; must be skipped
@@ -667,7 +667,7 @@ test "Response: chunked mode doesn't write Content-Length" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
 
     try response.chunk("test");
     try response.write();
@@ -688,7 +688,7 @@ test "Response: json() with simple object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try response.json(.{ .name = "Alice", .age = 30 }, .{});
 
     const buffered = response.buffer.writer.buffered();
@@ -707,7 +707,7 @@ test "Response: json() writes complete response" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     response.status = .created;
     try response.json(.{ .id = 123, .message = "Created" }, .{});
     try response.write();
@@ -732,7 +732,7 @@ test "Response: json() with array" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const items = [_]i32{ 1, 2, 3, 4, 5 };
     try response.json(items, .{});
 
@@ -747,7 +747,7 @@ test "Response: json() with nested object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try response.json(.{
         .user = .{
             .name = "Bob",
@@ -812,7 +812,7 @@ test "Response: startEventStream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     const stream = try response.startEventStream();
 
     try stream.send("connected", .{});
@@ -832,7 +832,7 @@ test "Response: setCookie basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try response.setCookie("session", "abc123", .{});
     response.body = "OK";
 
@@ -849,7 +849,7 @@ test "Response: setCookie with options" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try response.setCookie("auth", "token123", .{
         .path = "/",
         .http_only = true,
@@ -871,7 +871,7 @@ test "Response: header() rejects CRLF in value" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try std.testing.expectError(error.InvalidHeaderValue, response.header("Location", "/ok\r\nX-Evil: 1"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\nbaz"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\x00baz"));
@@ -884,7 +884,7 @@ test "Response: header() rejects invalid name" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try std.testing.expectError(error.InvalidHeaderName, response.header("", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X-Bad\r\n", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X: Bad", "value"));
@@ -898,7 +898,7 @@ test "Response: setCookie rejects CRLF via header()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer);
+    var response = try Response.init(arena.allocator(), &conn_writer, 32);
     try std.testing.expectError(error.InvalidHeaderValue, response.setCookie("session", "abc\r\nSet-Cookie: evil=1", .{}));
 }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -215,7 +215,7 @@ pub fn Server(comptime Ctx: type) type {
 
                 log.debug("Received: {f} {s}", .{ request.method, request.url });
 
-                var response = Response.init(arena.allocator(), &writer.interface);
+                var response = try Response.init(arena.allocator(), &writer.interface);
                 request.response = &response;
 
                 // Handle Expect header (100-continue)

--- a/src/server.zig
+++ b/src/server.zig
@@ -215,7 +215,7 @@ pub fn Server(comptime Ctx: type) type {
 
                 log.debug("Received: {f} {s}", .{ request.method, request.url });
 
-                var response = try Response.init(arena.allocator(), &writer.interface);
+                var response = try Response.init(arena.allocator(), &writer.interface, self.config.request.max_header_count);
                 request.response = &response;
 
                 // Handle Expect header (100-continue)


### PR DESCRIPTION
Fixes https://github.com/lalinsky/dusty/issues/8

## Summary

- Replaces the `std.HashMapUnmanaged`-based `Headers` type (one value per key) with a pre-allocated parallel-arrays structure that supports multiple values per key
- A single allocation holds keys, values, and 1-byte hashes; `put()` replaces the first match or appends, `add()` always appends — both return `error.TooManyHeaders` at capacity instead of dropping entries
- Fixes `Set-Cookie` handling: multiple cookies can now be set on a response without overwriting each other
- Fixes a case-sensitivity bug in the hash function where lookup keys with different casing than stored keys would not match

## Test plan

- [ ] `./check.sh` passes all 207 tests