### PR TITLE
Replace std TLS client with tls.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,11 +4,17 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const use_tls = b.option(bool, "use_tls", "Build with TLS/HTTPS support via tls.zig") orelse true;
+
     const mod = b.addModule("dusty", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
     });
+
+    const build_options = b.addOptions();
+    build_options.addOption(bool, "use_tls", use_tls);
+    mod.addOptions("build_options", build_options);
 
     // Default `zio` import — a stub that no-ops `clear` and panics on `set`.
     // Apps that want real timeouts override this in their own build.zig:
@@ -16,6 +22,22 @@ pub fn build(b: *std.Build) void {
     mod.addAnonymousImport("zio", .{
         .root_source_file = b.path("src/zio_stub.zig"),
     });
+
+    // TLS support is a lazy dependency: only fetched when `use_tls` is set (the
+    // default). When disabled, a stub is imported so the client still builds but
+    // HTTPS requests fail with error.TlsNotConfigured.
+    if (use_tls) {
+        if (b.lazyDependency("tls", .{
+            .target = target,
+            .optimize = optimize,
+        })) |tls_dep| {
+            mod.addImport("tls", tls_dep.module("tls"));
+        }
+    } else {
+        mod.addAnonymousImport("tls", .{
+            .root_source_file = b.path("src/tls_stub.zig"),
+        });
+    }
 
     const translate_c = b.addTranslateC(.{
         .root_source_file = b.path("src/llhttp/llhttp.h"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,7 +31,13 @@
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
     // Once all dependencies are fetched, `zig build` no longer requires
     // internet connectivity.
-    .dependencies = .{},
+    .dependencies = .{
+        .tls = .{
+            .url = "git+https://github.com/ianic/tls.zig#5452bafc98d23e304209cb24d81fd2d19434e52d",
+            .hash = "tls-0.1.0-ER2e0hOsBQA6IN_UFrQFn0A_dIdW8HleuHi3oTT059RI",
+            .lazy = true,
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/src/client.zig
+++ b/src/client.zig
@@ -702,6 +702,7 @@ pub const Client = struct {
 
         // Initialize CA bundle for HTTPS
         const ca_bundle: ?CaBundleRef = if (info.protocol == .https) blk: {
+            if (!build_options.use_tls) return error.TlsNotConfigured;
             if (!self.config.use_system_ca_bundle) {
                 return error.TlsNotConfigured;
             }
@@ -794,6 +795,7 @@ pub const Client = struct {
 
         // Initialize CA bundle for HTTPS
         const ca_bundle: ?CaBundleRef = if (state.protocol == .https) blk: {
+            if (!build_options.use_tls) return error.TlsNotConfigured;
             if (!self.config.use_system_ca_bundle) {
                 return error.TlsNotConfigured;
             }

--- a/src/client.zig
+++ b/src/client.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const Uri = std.Uri;
+const tls = @import("tls");
+const build_options = @import("build_options");
 
 const unix_path_max = 108;
 
@@ -116,8 +118,6 @@ pub const WebSocketClient = struct {
 };
 
 const CaBundleRef = struct {
-    gpa: std.mem.Allocator,
-    lock: *std.Io.RwLock,
     bundle: *std.crypto.Certificate.Bundle,
 };
 
@@ -249,10 +249,15 @@ pub const Connection = struct {
     tcp_reader: std.Io.net.Stream.Reader,
     tcp_writer: std.Io.net.Stream.Writer,
 
-    // TLS TCP layer buffers (allocated from main allocator, persist across requests)
+    // TLS TCP layer buffers (allocated from main allocator, persist across requests).
+    // These hold the encrypted (ciphertext) data exchanged over the raw socket.
     tls_tcp_read_buffer: []u8,
     tls_tcp_write_buffer: []u8,
-    tls_client: ?std.crypto.tls.Client,
+    tls_conn: ?tls.Connection,
+    // Cleartext Reader/Writer adapters layered on top of tls_conn. They store a
+    // pointer back to tls_conn, so the Connection must never be moved after init.
+    tls_reader: tls.Connection.Reader,
+    tls_writer: tls.Connection.Writer,
 
     // HTTP layer buffers (allocated from main allocator, persist across requests)
     read_buffer: []u8,
@@ -329,49 +334,44 @@ pub const Connection = struct {
         self.protocol = protocol;
 
         if (protocol == .https) {
-            const bundle = ca_bundle orelse return error.MissingCaBundle;
+            if (!build_options.use_tls) return error.TlsNotConfigured;
+            const ca = ca_bundle orelse return error.MissingCaBundle;
 
-            const tls_buffer_size = std.crypto.tls.Client.min_buffer_len;
-
-            self.read_buffer = try allocator.alloc(u8, self.buffer_size + tls_buffer_size + 1024);
-            errdefer allocator.free(self.read_buffer);
-            self.write_buffer = try allocator.alloc(u8, tls_buffer_size + 1024);
-            errdefer allocator.free(self.write_buffer);
-
-            self.tls_tcp_read_buffer = try allocator.alloc(u8, tls_buffer_size);
+            // TCP-layer (ciphertext) buffers. tls.zig requires the input buffer to
+            // fit a full TLS record; the output buffer caps the produced record size.
+            self.tls_tcp_read_buffer = try allocator.alloc(u8, tls.input_buffer_len);
             errdefer allocator.free(self.tls_tcp_read_buffer);
-            self.tls_tcp_write_buffer = try allocator.alloc(u8, tls_buffer_size);
+            self.tls_tcp_write_buffer = try allocator.alloc(u8, tls.output_buffer_len);
             errdefer allocator.free(self.tls_tcp_write_buffer);
+
+            // HTTP-layer (cleartext) buffers, used by the tls.Connection reader/writer.
+            self.read_buffer = try allocator.alloc(u8, self.buffer_size + 1024);
+            errdefer allocator.free(self.read_buffer);
+            self.write_buffer = try allocator.alloc(u8, 1024);
+            errdefer allocator.free(self.write_buffer);
 
             self.tcp_reader = stream.reader(io, self.tls_tcp_read_buffer);
             self.tcp_writer = stream.writer(io, self.tls_tcp_write_buffer);
 
-            var entropy: [std.crypto.tls.Client.Options.entropy_len]u8 = undefined;
-            self.io.random(&entropy);
+            var rng_source: std.Random.IoSource = .{ .io = self.io };
 
-            self.tls_client = std.crypto.tls.Client.init(
+            self.tls_conn = tls.client(
                 &self.tcp_reader.interface,
                 &self.tcp_writer.interface,
                 .{
-                    .host = .{ .explicit = remote_host },
-                    .ca = .{ .bundle = .{
-                        .gpa = bundle.gpa,
-                        .io = self.io,
-                        .lock = bundle.lock,
-                        .bundle = bundle.bundle,
-                    } },
-                    .entropy = &entropy,
-                    .realtime_now = std.Io.Timestamp.now(self.io, .real),
-                    .read_buffer = self.read_buffer,
-                    .write_buffer = self.write_buffer,
-                    .allow_truncation_attacks = true,
+                    .host = remote_host,
+                    .root_ca = ca.bundle.*,
+                    .now = std.Io.Clock.real.now(self.io),
+                    .rng = rng_source.interface(),
                 },
             ) catch return error.TlsInitializationFailed;
 
-            self.reader = &self.tls_client.?.reader;
-            self.writer = &self.tls_client.?.writer;
+            self.tls_reader = self.tls_conn.?.reader(self.read_buffer);
+            self.tls_writer = self.tls_conn.?.writer(self.write_buffer);
+            self.reader = &self.tls_reader.interface;
+            self.writer = &self.tls_writer.interface;
         } else {
-            self.tls_client = null;
+            self.tls_conn = null;
             self.tls_tcp_read_buffer = &.{};
             self.tls_tcp_write_buffer = &.{};
 
@@ -416,10 +416,9 @@ pub const Connection = struct {
     }
 
     pub fn flush(self: *Connection) !void {
+        // For HTTPS this drains the cleartext writer, which encrypts and flushes
+        // the underlying TCP writer in one step; for HTTP it flushes the socket directly.
         try self.writer.flush();
-        if (self.protocol == .https) {
-            try self.tcp_writer.interface.flush();
-        }
     }
 
     pub fn host(self: *const Connection) []const u8 {
@@ -621,8 +620,6 @@ pub const Client = struct {
             }
         }
         return .{
-            .gpa = self.allocator,
-            .lock = &self.ca_bundle_lock,
             .bundle = &self.ca_bundle,
         };
     }

--- a/src/client.zig
+++ b/src/client.zig
@@ -258,6 +258,7 @@ pub const Connection = struct {
     // pointer back to tls_conn, so the Connection must never be moved after init.
     tls_reader: tls.Connection.Reader,
     tls_writer: tls.Connection.Writer,
+    tls_rng: std.Random.IoSource,
 
     // HTTP layer buffers (allocated from main allocator, persist across requests)
     read_buffer: []u8,
@@ -353,7 +354,7 @@ pub const Connection = struct {
             self.tcp_reader = stream.reader(io, self.tls_tcp_read_buffer);
             self.tcp_writer = stream.writer(io, self.tls_tcp_write_buffer);
 
-            var rng_source: std.Random.IoSource = .{ .io = self.io };
+            self.tls_rng = .{ .io = self.io };
 
             self.tls_conn = tls.client(
                 &self.tcp_reader.interface,
@@ -362,7 +363,7 @@ pub const Connection = struct {
                     .host = remote_host,
                     .root_ca = ca.bundle.*,
                     .now = std.Io.Clock.real.now(self.io),
-                    .rng = rng_source.interface(),
+                    .rng = self.tls_rng.interface(),
                 },
             ) catch return error.TlsInitializationFailed;
 

--- a/src/tls_stub.zig
+++ b/src/tls_stub.zig
@@ -1,0 +1,34 @@
+//! Stub used when the `use_tls` build option is disabled.
+//!
+//! It mirrors just enough of the tls.zig API surface for `client.zig` to type
+//! check. The bodies are never reached: the HTTPS path in `Connection.init`
+//! returns `error.TlsNotConfigured` up front when `use_tls` is false.
+
+const std = @import("std");
+
+pub const input_buffer_len: usize = 0;
+pub const output_buffer_len: usize = 0;
+
+pub fn client(input: *std.Io.Reader, output: *std.Io.Writer, opt: anytype) !Connection {
+    _ = input;
+    _ = output;
+    _ = opt;
+    return error.TlsNotConfigured;
+}
+
+pub const Connection = struct {
+    pub const Reader = struct { interface: std.Io.Reader };
+    pub const Writer = struct { interface: std.Io.Writer };
+
+    pub fn reader(self: *Connection, buffer: []u8) Reader {
+        _ = self;
+        _ = buffer;
+        unreachable;
+    }
+
+    pub fn writer(self: *Connection, buffer: []u8) Writer {
+        _ = self;
+        _ = buffer;
+        unreachable;
+    }
+};


### PR DESCRIPTION
## Summary

Replaces the standard library TLS client (`std.crypto.tls.Client`) with [ianic/tls.zig](https://github.com/ianic/tls.zig) in the HTTP client. tls.zig connects to substantially more real-world sites than the std implementation and correctly handles the badssl.com test cases.

## Changes

- **Lazy, optional dependency.** tls.zig is added as a `lazy` dependency and gated behind a new `-Duse_tls` build option (**default `true`**). When `use_tls=false`, a small stub (`src/tls_stub.zig`) is imported instead so the client still builds; HTTPS requests then return `error.TlsNotConfigured` and the dependency is never fetched.
- **CA bundle unchanged.** `tls.config.cert.Bundle` *is* `std.crypto.Certificate.Bundle`, so the existing lazy system-CA `rescan` logic carries over untouched.
- **Buffers.** TCP-layer (ciphertext) buffers are sized to tls.zig's record limits (`tls.input_buffer_len` / `tls.output_buffer_len`); the cleartext HTTP read/write buffers are now separate.
- **`flush()` simplified.** Draining the cleartext writer cascades to a TCP flush inside tls.zig, so the HTTPS special-case is gone.

ALPN is left unset (HTTP/1.1 behavior preserved). Connection pooling, redirect handling, and the protocol/CA gating are unchanged.

## Testing

- `./check.sh` — full pass (build, examples, 207/207 tests) with the default `use_tls=true`.
- `zig build -Duse_tls=false` builds; HTTPS then returns `error.TlsNotConfigured` (no panic, no fetch) while plain HTTP still works.
- Manual: `client-example` fetches `https://example.com/` and `https://httpbingo.org/get` successfully (handshake, cert verification, chunked + gzip).

## Notes

- Pinned to tls.zig commit `5452baf`.
- Out of scope: connection-close (EOF-delimited) response bodies still fail — that's a pre-existing parser bug, not caused by this change (tracked in #98).
