### PR TITLE
Fix connection-close (EOF-delimited) response bodies failing with ReadFailed

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -1280,6 +1280,34 @@ test "ClientResponse.body: no body" {
     try std.testing.expectEqual(.no_content, response.status());
 }
 
+test "ClientResponse.body: connection-close (EOF-delimited) body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // No Content-Length and no Transfer-Encoding: body is delimited by EOF.
+    const body_content = "body delimited by connection close, not length.";
+    const raw_response = "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nconnection: close\r\n\r\n" ++ body_content;
+    var reader = std.Io.Reader.fixed(raw_response);
+
+    var parsed: ParsedResponse = .{ .arena = arena.allocator() };
+    var parser: ResponseParser = undefined;
+    try parser.init(&parsed, 64);
+
+    try parseResponseHeaders(&reader, &parser);
+
+    var response = ClientResponse{
+        .arena = arena.allocator(),
+        .parser = &parser,
+        .conn = &reader,
+        .parsed = &parsed,
+        .max_response_size = 1024,
+    };
+
+    const body = try response.body();
+    try std.testing.expectEqualStrings(body_content, body.?);
+    try std.testing.expectEqual(.forbidden, response.status());
+}
+
 test "ClientResponse.reader: streaming read" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -109,7 +109,9 @@ pub const RequestParser = struct {
 
     pub fn finish(self: *RequestParser) ParseError!void {
         const err = c.llhttp_finish(&self.parser);
-        if (err != c.HPE_OK) {
+        // HPE_PAUSED means our on_message_complete callback fired and paused,
+        // i.e. the message was completed by EOF (connection-close framing).
+        if (err != c.HPE_OK and err != c.HPE_PAUSED) {
             return mapError(err);
         }
     }
@@ -328,7 +330,9 @@ pub const ResponseParser = struct {
 
     pub fn finish(self: *ResponseParser) !void {
         const err = c.llhttp_finish(&self.parser);
-        if (err != c.HPE_OK) {
+        // HPE_PAUSED means our on_message_complete callback fired and paused,
+        // i.e. the message was completed by EOF (connection-close framing).
+        if (err != c.HPE_OK and err != c.HPE_PAUSED) {
             return mapError(err);
         }
     }


### PR DESCRIPTION
## Summary

Fixes #98. Reading a response body delimited by connection close (HTTP/1.1 `Connection: close` with no `Content-Length` and no `Transfer-Encoding: chunked`) failed with `error.ReadFailed`. The status line and headers parsed correctly, but the first body read errored out.

## Root cause

On EOF the body reader calls `parser.finish()`, which invokes `llhttp_finish()`. That fires the `on_message_complete` callback — but the callback returns `HPE_PAUSED` by design (the parser pauses on completion so we can track consumed bytes). `finish()` only treated `HPE_OK` as success, so `HPE_PAUSED` was mapped to a parse error and surfaced as `error.ReadFailed`, even though the message had actually completed.

## Fix

Treat `HPE_PAUSED` from `llhttp_finish()` as success in both `RequestParser.finish()` and `ResponseParser.finish()`. After `finish()` returns, `isBodyComplete()` is already `true`, so the body reader returns the received bytes and then `EndOfStream`.

## Testing

- Added a regression test (`ClientResponse.body: connection-close (EOF-delimited) body`) covering the minimal plain-HTTP case.
- Full suite: 208/208 tests pass.
- Verified end-to-end against the issue's real-world repro — `client-example https://api.github.com/zen` now reads the 252-byte EOF-delimited 403 body instead of erroring.