### PR TITLE
Add optional HTTP/2 client (nghttp2, multiplexing)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,12 +43,14 @@ jobs:
       run: zig build examples
       timeout-minutes: 5
 
-    - name: Run client example
-      run: ./zig-out/bin/client-example https://httpbin.org/get
+    # Fetch over HTTP/2 (nghttp2.org serves an httpbin instance over h2; h2 is on
+    # by default). Exercises the full h2 client path on the whole OS matrix.
+    - name: Run client example (HTTP/2)
+      run: ./zig-out/bin/client-example https://nghttp2.org/httpbin/get
       timeout-minutes: 1
       if: runner.os != 'Windows'
 
-    - name: Run client example (Windows)
-      run: .\zig-out\bin\client-example.exe https://httpbin.org/get
+    - name: Run client example (HTTP/2, Windows)
+      run: .\zig-out\bin\client-example.exe https://nghttp2.org/httpbin/get
       timeout-minutes: 1
       if: runner.os == 'Windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,17 @@ jobs:
       run: zig build examples
       timeout-minutes: 5
 
+    # Fetch over plain HTTP/1.1 (no TLS, so no ALPN -> h1).
+    - name: Run client example (HTTP/1.1)
+      run: ./zig-out/bin/client-example http://httpbin.org/get
+      timeout-minutes: 1
+      if: runner.os != 'Windows'
+
+    - name: Run client example (HTTP/1.1, Windows)
+      run: .\zig-out\bin\client-example.exe http://httpbin.org/get
+      timeout-minutes: 1
+      if: runner.os == 'Windows'
+
     # Fetch over HTTP/2 (nghttp2.org serves an httpbin instance over h2; h2 is on
     # by default). Exercises the full h2 client path on the whole OS matrix.
     - name: Run client example (HTTP/2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Optional HTTP/2 client support, gated behind the `use_http2` build option and the `http2` client config flag. Built on the bundled nghttp2 library and negotiated over TLS ALPN; multiplexes concurrent requests over a single connection per origin, with HTTP/1.1 fallback, redirects, and gzip/deflate decompression. Response bodies are buffered.
 - Fix memory leak in WebSocket clients: message allocations are now freed before each `receive()` call instead of accumulating for the lifetime of the connection. Message data is valid until the next call to `receive()`.
 
 ## [0.2.0] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Optional HTTP/2 client support, gated behind the `use_http2` build option and the `http2` client config flag. Built on the bundled nghttp2 library and negotiated over TLS ALPN; multiplexes concurrent requests over a single connection per origin, with HTTP/1.1 fallback, redirects, and gzip/deflate decompression. Response bodies are buffered.
+- Optional HTTP/2 client support, gated behind the `use_http2` build option and the `http2` client config flag. Built on the bundled nghttp2 library and negotiated over TLS ALPN; multiplexes concurrent requests over a single connection per origin, with HTTP/1.1 fallback, redirects, and gzip/deflate decompression. Response bodies stream incrementally with flow-control backpressure.
 - Fix memory leak in WebSocket clients: message allocations are now freed before each `receive()` call instead of accumulating for the lifetime of the connection. Message data is valid until the next call to `receive()`.
 
 ## [0.2.0] - 2026-04-26

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ defer response.deinit();
 ```
 
 Redirects, gzip/deflate decompression, request bodies, and the rest of the
-client API work the same as on HTTP/1.1. Response bodies are currently buffered.
+client API work the same as on HTTP/1.1. Response bodies stream incrementally
+with HTTP/2 flow control providing backpressure (`response.reader()`).
 
 ## Selecting the I/O Backend
 

--- a/README.md
+++ b/README.md
@@ -92,19 +92,19 @@ defer response.deinit();
 
 ## HTTP/2 (client)
 
-The client can speak HTTP/2, negotiated over TLS ALPN. It is gated behind the
-`use_http2` build option (off by default) because it links the bundled
-[nghttp2](https://github.com/nghttp2/nghttp2) C library:
+The client can speak HTTP/2, negotiated over TLS ALPN. It links the bundled
+[nghttp2](https://github.com/nghttp2/nghttp2) C library and is on by default; to
+build without it, set the `use_http2` build option to false:
 
 ```zig
 const dusty = b.dependency("dusty", .{
     .target = target,
     .optimize = optimize,
-    .use_http2 = true,
+    .use_http2 = false, // optional: omit HTTP/2 / nghttp2
 });
 ```
 
-Then opt in per client via the `http2` config flag. When enabled, HTTPS
+Opt in per client via the `http2` config flag. When enabled, HTTPS
 connections advertise `h2` and, if the server agrees, requests are multiplexed
 over a single connection (one connection per origin, shared across concurrent
 and sequential requests). Servers that don't negotiate `h2` transparently fall

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The server API is inspired by Karl Seguin's [http.zig](https://github.com/karlse
 - Router with support for parameters and wildcards
 - Supports HTTP/1.0 and HTTP/1.1
 - Supports chunked transfer encoding in both request/response bodies
+- Optional HTTP/2 client (via [nghttp2](https://github.com/nghttp2/nghttp2)) with request multiplexing over a single connection
 - Server-Sent Events (SSE) for streaming responses
 - WebSocket support (RFC 6455)
 - HTTP/HTTPS client with connection pooling
@@ -88,6 +89,38 @@ var response = try client.fetch("http://localhost/v1.41/info", .{
 });
 defer response.deinit();
 ```
+
+## HTTP/2 (client)
+
+The client can speak HTTP/2, negotiated over TLS ALPN. It is gated behind the
+`use_http2` build option (off by default) because it links the bundled
+[nghttp2](https://github.com/nghttp2/nghttp2) C library:
+
+```zig
+const dusty = b.dependency("dusty", .{
+    .target = target,
+    .optimize = optimize,
+    .use_http2 = true,
+});
+```
+
+Then opt in per client via the `http2` config flag. When enabled, HTTPS
+connections advertise `h2` and, if the server agrees, requests are multiplexed
+over a single connection (one connection per origin, shared across concurrent
+and sequential requests). Servers that don't negotiate `h2` transparently fall
+back to HTTP/1.1.
+
+```zig
+var client = http.Client.init(allocator, io, .{ .http2 = true });
+defer client.deinit();
+
+var response = try client.fetch("https://nghttp2.org/", .{});
+defer response.deinit();
+// response.version() reports 2.0 when HTTP/2 was used
+```
+
+Redirects, gzip/deflate decompression, request bodies, and the rest of the
+client API work the same as on HTTP/1.1. Response bodies are currently buffered.
 
 ## Selecting the I/O Backend
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,14 @@ const dusty = b.dependency("dusty", .{
 });
 ```
 
-Opt in per client via the `http2` config flag. When enabled, HTTPS
+HTTP/2 is also enabled per client by default (the `http2` config flag). HTTPS
 connections advertise `h2` and, if the server agrees, requests are multiplexed
 over a single connection (one connection per origin, shared across concurrent
 and sequential requests). Servers that don't negotiate `h2` transparently fall
-back to HTTP/1.1.
+back to HTTP/1.1. Set `.http2 = false` to force HTTP/1.1.
 
 ```zig
-var client = http.Client.init(allocator, io, .{ .http2 = true });
+var client = http.Client.init(allocator, io, .{}); // h2 on by default
 defer client.deinit();
 
 var response = try client.fetch("https://nghttp2.org/", .{});

--- a/build.zig
+++ b/build.zig
@@ -74,6 +74,27 @@ pub fn build(b: *std.Build) void {
         nghttp2_translate_c.addIncludePath(b.path("src/nghttp2/lib/includes"));
         mod.addImport("nghttp2", nghttp2_translate_c.createModule());
 
+        // nghttp2 needs platform feature macros so the right headers/APIs are
+        // visible under -std=c99: a feature-test macro to un-hide POSIX/C99
+        // declarations (e.g. clock_gettime, vsnprintf) plus HAVE_* to select
+        // nghttp2's code paths. Windows uses nghttp2's own Win32 fallbacks
+        // (its inline htonl, windows.h time). Applying the POSIX set
+        // unconditionally breaks non-Unix builds (e.g. arpa/inet.h not found),
+        // and a too-strict _POSIX_C_SOURCE hides vsnprintf on Darwin.
+        const c99 = "-std=c99";
+        const staticlib = "-DNGHTTP2_STATICLIB";
+        const have_posix = [_][]const u8{
+            "-DHAVE_ARPA_INET_H=1",
+            "-DHAVE_NETINET_IN_H=1",
+            "-DHAVE_CLOCK_GETTIME=1",
+            "-DHAVE_DECL_CLOCK_MONOTONIC=1",
+        };
+        const nghttp2_flags: []const []const u8 = switch (target.result.os.tag) {
+            .windows => &.{ c99, staticlib, "-DWIN32", "-DHAVE_WINDOWS_H=1", "-DHAVE_GETTICKCOUNT64=1" },
+            .macos, .ios, .tvos, .watchos => &([_][]const u8{ c99, staticlib, "-D_DARWIN_C_SOURCE" } ++ have_posix),
+            else => &([_][]const u8{ c99, staticlib, "-D_GNU_SOURCE" } ++ have_posix),
+        };
+
         mod.addCSourceFiles(.{
             .files = &[_][]const u8{
                 "src/nghttp2/lib/nghttp2_alpn.c",
@@ -103,15 +124,7 @@ pub fn build(b: *std.Build) void {
                 "src/nghttp2/lib/nghttp2_version.c",
                 "src/nghttp2/lib/sfparse.c",
             },
-            .flags = &.{
-                "-std=c99",
-                "-DNGHTTP2_STATICLIB",
-                "-D_POSIX_C_SOURCE=199309L",
-                "-DHAVE_ARPA_INET_H=1",
-                "-DHAVE_NETINET_IN_H=1",
-                "-DHAVE_CLOCK_GETTIME=1",
-                "-DHAVE_DECL_CLOCK_MONOTONIC=1",
-            },
+            .flags = nghttp2_flags,
         });
         mod.addIncludePath(b.path("src/nghttp2/lib"));
         mod.addIncludePath(b.path("src/nghttp2/lib/includes"));

--- a/build.zig
+++ b/build.zig
@@ -5,10 +5,10 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const use_tls = b.option(bool, "use_tls", "Build with TLS/HTTPS support via tls.zig") orelse true;
-    // HTTP/2 support is gated behind this option (like use_tls) because it links
-    // the nghttp2 C library. Defaults off until the implementation lands. Requires
-    // use_tls, since h2 is negotiated via TLS ALPN.
-    const use_http2 = b.option(bool, "use_http2", "Build with HTTP/2 support via nghttp2") orelse false;
+    // HTTP/2 support links the vendored nghttp2 C library. On by default (like
+    // use_tls); set -Duse_http2=false to build without it. h2 is negotiated via
+    // TLS ALPN, so it's only effective together with use_tls.
+    const use_http2 = b.option(bool, "use_http2", "Build with HTTP/2 support via nghttp2") orelse true;
 
     const mod = b.addModule("dusty", .{
         .root_source_file = b.path("src/root.zig"),

--- a/examples/client.zig
+++ b/examples/client.zig
@@ -20,6 +20,8 @@ pub fn main(init: std.process.Init) !void {
     var response = try client.fetch(url, .{});
     defer response.deinit();
 
+    const v = response.version();
+    std.debug.print("HTTP/{d}.{d}\n", .{ v.major, v.minor });
     std.debug.print("Status: {any}\n", .{response.status()});
 
     std.debug.print("Headers:\n", .{});

--- a/src/client.zig
+++ b/src/client.zig
@@ -128,10 +128,11 @@ pub const ClientConfig = struct {
     /// User-Agent header sent with requests. Set to null to omit it.
     /// A per-request User-Agent header takes precedence over this default.
     user_agent: ?[]const u8 = default_user_agent,
-    /// Advertise HTTP/2 ("h2") via TLS ALPN on HTTPS connections. Only effective
-    /// when the library is built with the `use_http2` build option; ignored for
-    /// cleartext (http://) connections. Defaults off.
-    http2: bool = false,
+    /// Advertise HTTP/2 ("h2") via TLS ALPN on HTTPS connections, falling back to
+    /// HTTP/1.1 when the server doesn't negotiate it. On by default; only
+    /// effective when built with the `use_http2` build option, and ignored for
+    /// cleartext (http://) connections. Set false to force HTTP/1.1.
+    http2: bool = true,
 };
 
 /// Options for a single fetch request.

--- a/src/client.zig
+++ b/src/client.zig
@@ -30,10 +30,29 @@ const http2 = if (build_options.use_http2) @import("http2.zig") else struct {
 /// A pooled, multiplexed HTTP/2 connection: the nghttp2 actor plus the
 /// underlying transport (socket + TLS) that backs it.
 const H2Entry = struct {
+    client: *Client,
     transport: *Connection,
     conn: *http2.Connection,
     node: std.DoublyLinkedList.Node = .{},
 };
+
+/// Reaper for HTTP/2 connections (a `http2.ReapFn`): invoked when a connection's
+/// last reference is dropped. Unlinks the pool entry and frees the connection,
+/// its nghttp2 session, and its transport.
+fn reapH2(conn: *http2.Connection) void {
+    if (build_options.use_http2) {
+        const entry: *H2Entry = @ptrCast(@alignCast(conn.owner.?));
+        const self = entry.client;
+        self.h2_pool.mutex.lockUncancelable(self.io);
+        self.h2_pool.entries.remove(&entry.node);
+        self.h2_pool.mutex.unlock(self.io);
+        conn.freeSession();
+        entry.transport.deinit();
+        self.allocator.destroy(entry.transport);
+        self.allocator.destroy(conn);
+        self.allocator.destroy(entry);
+    } else unreachable;
+}
 
 /// Pool of shared HTTP/2 connections, keyed by host:port. Unlike the HTTP/1.1
 /// idle pool, entries stay discoverable while in use so concurrent requests
@@ -694,6 +713,8 @@ pub const Client = struct {
     config: ClientConfig,
     pool: ConnectionPool,
     h2_pool: H2Pool,
+    /// Shared group for all HTTP/2 session coroutines (each owns its net-reader).
+    h2_group: std.Io.Group,
     ca_bundle: std.crypto.Certificate.Bundle,
     ca_bundle_lock: std.Io.RwLock,
     ca_bundle_loaded: std.atomic.Value(bool),
@@ -705,6 +726,7 @@ pub const Client = struct {
             .config = config,
             .pool = ConnectionPool.init(allocator, config.max_idle_connections),
             .h2_pool = .{},
+            .h2_group = .init,
             .ca_bundle = .empty,
             .ca_bundle_lock = .init,
             .ca_bundle_loaded = std.atomic.Value(bool).init(false),
@@ -728,16 +750,11 @@ pub const Client = struct {
 
     pub fn deinit(self: *Client) void {
         if (build_options.use_http2) {
-            // Tear down every multiplexed h2 connection and its transport.
-            var it = self.h2_pool.entries.first;
-            while (it) |node| {
-                it = node.next;
-                const entry: *H2Entry = @fieldParentPtr("node", node);
-                entry.conn.destroy();
-                entry.transport.deinit();
-                self.allocator.destroy(entry.transport);
-                self.allocator.destroy(entry);
-            }
+            // Cancel all h2 session coroutines; each joins its net-reader and
+            // drops its reference on the way out, self-reaping any connection
+            // whose responses have already been deinit'd. (Connections still
+            // referenced by un-deinit'd responses are intentionally left alone.)
+            self.h2_group.cancel(self.io);
         }
         self.pool.deinit();
         self.ca_bundle.deinit(self.allocator);
@@ -763,6 +780,9 @@ pub const Client = struct {
 
     /// Look up an existing, still-open multiplexed h2 connection for host:port.
     /// Closed entries encountered along the way are removed and torn down.
+    /// Find a reusable, open h2 connection for host:port and take a reference.
+    /// Closed connections are skipped (their reaper frees them); the CAS in
+    /// `tryAcquire` prevents resurrecting one that is racing with its reaper.
     fn acquireH2(self: *Client, host: []const u8, port: u16) ?*http2.Connection {
         if (!build_options.use_http2) return null;
         self.h2_pool.mutex.lockUncancelable(self.io);
@@ -772,60 +792,83 @@ pub const Client = struct {
         while (it) |node| {
             it = node.next;
             const entry: *H2Entry = @fieldParentPtr("node", node);
-            if (entry.conn.isClosed()) {
-                self.h2_pool.entries.remove(node);
-                entry.conn.destroy();
-                entry.transport.deinit();
-                self.allocator.destroy(entry.transport);
-                self.allocator.destroy(entry);
-                continue;
-            }
+            if (entry.conn.isClosed()) continue;
             if (entry.conn.port == port and std.ascii.eqlIgnoreCase(entry.conn.host_buf[0..entry.conn.host_len], host)) {
-                return entry.conn;
+                if (entry.conn.tryAcquire()) return entry.conn;
             }
         }
         return null;
     }
 
     /// Promote a freshly-dialed, h2-negotiated transport into a multiplexed
-    /// connection, register it for reuse, and issue the request. Takes ownership
-    /// of `conn`.
-    fn startHttp2(self: *Client, conn: *Connection, state: FetchState, host: []const u8) !ClientResponse {
+    /// connection, register it for reuse, spawn its session coroutine into the
+    /// shared group, and issue the request. Takes ownership of `transport`.
+    fn startHttp2(self: *Client, transport: *Connection, state: FetchState, host: []const u8) !ClientResponse {
         if (build_options.use_http2) {
-            const h2conn = http2.Connection.create(self.allocator, self.io, conn.reader, conn.writer, host, state.port) catch |err| {
-                conn.deinit();
-                self.allocator.destroy(conn);
+            const h2conn = http2.Connection.create(self.allocator, self.io, transport.reader, transport.writer, host, state.port) catch |err| {
+                transport.deinit();
+                self.allocator.destroy(transport);
                 return err;
             };
-
             const entry = self.allocator.create(H2Entry) catch {
-                h2conn.destroy();
-                conn.deinit();
-                self.allocator.destroy(conn);
+                h2conn.freeSession();
+                self.allocator.destroy(h2conn);
+                transport.deinit();
+                self.allocator.destroy(transport);
                 return error.OutOfMemory;
             };
-            entry.* = .{ .transport = conn, .conn = h2conn };
+            entry.* = .{ .client = self, .transport = transport, .conn = h2conn, .node = .{} };
+            h2conn.owner = entry;
+            h2conn.reaper = reapH2;
 
+            // Insert and spawn under the pool mutex: the entry must be linked
+            // before the session coroutine could reach its reaper, and spawns
+            // into the shared group are serialized.
             self.h2_pool.mutex.lockUncancelable(self.io);
             self.h2_pool.entries.append(&entry.node);
+            h2conn.spawn(&self.h2_group) catch {
+                self.h2_pool.entries.remove(&entry.node);
+                self.h2_pool.mutex.unlock(self.io);
+                h2conn.freeSession();
+                self.allocator.destroy(h2conn);
+                transport.deinit();
+                self.allocator.destroy(transport);
+                self.allocator.destroy(entry);
+                return error.Http2Init;
+            };
+            const acquired = h2conn.tryAcquire(); // caller reference (refs 1 -> 2)
             self.h2_pool.mutex.unlock(self.io);
+            if (!acquired) {
+                // Session died immediately and is reaping (was blocked on the
+                // mutex we just released); it now owns all teardown.
+                return error.Http2ConnectionClosed;
+            }
 
             return self.requestHttp2(h2conn, state, host);
         } else {
-            conn.deinit();
-            self.allocator.destroy(conn);
+            transport.deinit();
+            self.allocator.destroy(transport);
             return error.Http2NotImplemented;
         }
     }
 
-    /// Issue one request over a multiplexed h2 connection and return a
-    /// ClientResponse with a fully-buffered body. The per-request stream and its
-    /// arena are freed when the response is deinit'd.
+    /// Issue one request over a multiplexed h2 connection (whose caller reference
+    /// is already held) and return a ClientResponse with a fully-buffered body.
+    /// On any error the caller reference is dropped; on success it transfers to
+    /// the ClientResponse (released on deinit).
     fn requestHttp2(self: *Client, h2conn: *http2.Connection, state: FetchState, host: []const u8) !ClientResponse {
         if (build_options.use_http2) {
+            errdefer h2conn.dropRef();
+
             const arena_ptr = try self.allocator.create(std.heap.ArenaAllocator);
-            errdefer self.allocator.destroy(arena_ptr);
             arena_ptr.* = std.heap.ArenaAllocator.init(self.allocator);
+            // Free the arena on every exit except success and cancellation (on
+            // cancel the session coroutine may still reference the stream).
+            var keep_arena = false;
+            defer if (!keep_arena) {
+                arena_ptr.deinit();
+                self.allocator.destroy(arena_ptr);
+            };
             const a = arena_ptr.allocator();
 
             // Build ":path" (path + optional query) and ":authority" (host with
@@ -860,20 +903,11 @@ pub const Client = struct {
             stream.parsed.headers = try Headers.init(a, self.config.max_response_header_count);
 
             h2conn.request(stream) catch |err| {
-                // On cancellation the session coroutine may still reference the
-                // stream, so its arena must not be freed here.
-                if (err != error.Canceled) {
-                    arena_ptr.deinit();
-                    self.allocator.destroy(arena_ptr);
-                }
+                if (err == error.Canceled) keep_arena = true; // session may still touch it
                 return err;
             };
 
-            if (stream.err) |err| {
-                arena_ptr.deinit();
-                self.allocator.destroy(arena_ptr);
-                return err;
-            }
+            if (stream.err) |err| return err;
 
             // Derive content metadata exactly like the HTTP/1.1 parser does.
             if (stream.parsed.headers.get("Content-Type")) |ct| stream.parsed.content_type = ContentType.fromContentType(ct);
@@ -885,18 +919,12 @@ pub const Client = struct {
             if (state.options.decompress) {
                 switch (stream.parsed.content_encoding) {
                     .identity => {},
-                    .unknown => {
-                        arena_ptr.deinit();
-                        self.allocator.destroy(arena_ptr);
-                        return error.UnsupportedContentEncoding;
-                    },
+                    .unknown => return error.UnsupportedContentEncoding,
                     .gzip, .deflate => |enc| {
                         var in = std.Io.Reader.fixed(body);
                         var win: [std.compress.flate.max_window_len]u8 = undefined;
                         var dec = std.compress.flate.Decompress.init(&in, if (enc == .gzip) .gzip else .zlib, &win);
                         body = dec.reader.allocRemaining(a, .limited(self.config.max_response_size)) catch |err| {
-                            arena_ptr.deinit();
-                            self.allocator.destroy(arena_ptr);
                             return switch (err) {
                                 error.StreamTooLong => error.ResponseTooLarge,
                                 else => err,
@@ -906,6 +934,8 @@ pub const Client = struct {
                     },
                 }
             }
+
+            keep_arena = true; // success: arena + connection ref transfer to the response
             return ClientResponse{
                 .arena = a,
                 .parsed = &stream.parsed,

--- a/src/client.zig
+++ b/src/client.zig
@@ -19,6 +19,30 @@ const ResponseBodyReader = @import("parser.zig").ResponseBodyReader;
 const KeepAliveParams = @import("parser.zig").KeepAliveParams;
 const parseKeepAliveHeader = @import("parser.zig").parseKeepAliveHeader;
 
+// HTTP/2 support lives in http2.zig (which pulls in nghttp2). It is only
+// imported when built with use_http2; otherwise opaque placeholders stand in so
+// types referencing it still compile (the real code paths are comptime-gated).
+const http2 = if (build_options.use_http2) @import("http2.zig") else struct {
+    pub const Connection = opaque {};
+    pub const Stream = opaque {};
+};
+
+/// A pooled, multiplexed HTTP/2 connection: the nghttp2 actor plus the
+/// underlying transport (socket + TLS) that backs it.
+const H2Entry = struct {
+    transport: *Connection,
+    conn: *http2.Connection,
+    node: std.DoublyLinkedList.Node = .{},
+};
+
+/// Pool of shared HTTP/2 connections, keyed by host:port. Unlike the HTTP/1.1
+/// idle pool, entries stay discoverable while in use so concurrent requests
+/// multiplex onto one connection.
+const H2Pool = struct {
+    mutex: std.Io.Mutex = .init,
+    entries: std.DoublyLinkedList = .{},
+};
+
 /// Protocol type for HTTP/HTTPS connections.
 pub const Protocol = enum {
     http,
@@ -529,13 +553,24 @@ pub const Connection = struct {
 /// HTTP client response.
 /// Call deinit() when done to release the connection.
 pub const ClientResponse = struct {
-    // Direct pointers for reading (testable without full connection)
+    // Direct pointers for reading (testable without full connection).
+    // For HTTP/2 responses the body is pre-buffered and `parser`/`conn` are
+    // null (there is no llhttp parser); see the h2_* fields below.
     arena: std.mem.Allocator,
-    parser: *ResponseParser,
-    conn: *std.Io.Reader,
+    parser: ?*ResponseParser = null,
+    conn: ?*std.Io.Reader = null,
     parsed: *ParsedResponse,
     max_response_size: usize,
     decompress: bool = true,
+
+    // HTTP/2 backing (set only for h2 responses). The stream lives on h2_arena,
+    // which is freed on deinit; the connection stays in the pool for reuse.
+    h2_conn: ?*http2.Connection = null,
+    h2_stream: ?*http2.Stream = null,
+    h2_arena: ?*std.heap.ArenaAllocator = null,
+
+    // Fixed reader over an already-buffered body (h2, or a cached h1 body).
+    _fixed_reader: std.Io.Reader = undefined,
 
     // Cached body (read lazily)
     _body: ?[]const u8 = null,
@@ -556,6 +591,17 @@ pub const ClientResponse = struct {
 
     /// Release the connection back to the pool (or close if not reusable).
     pub fn deinit(self: *ClientResponse) void {
+        if (build_options.use_http2) {
+            if (self.h2_stream) |stream| {
+                if (self.h2_conn) |hc| hc.releaseStream(stream);
+                if (self.h2_arena) |a| {
+                    const base = a.child_allocator;
+                    a.deinit();
+                    base.destroy(a);
+                }
+                return;
+            }
+        }
         if (self.owner) |conn| {
             conn.release();
         }
@@ -609,17 +655,17 @@ pub const ClientResponse = struct {
     /// Get a streaming body reader. Returns decompressed data if server sent
     /// compressed response and decompress option was enabled.
     pub fn reader(self: *ClientResponse) *std.Io.Reader {
-        // If body has already been read, return a reader for the cached body
+        // If body has already been read (cached, or an h2 pre-buffered body),
+        // return a fixed reader over it. No llhttp parser is involved.
         if (self._body_read) {
             const cached_body = self._body orelse &.{};
-            self._body_reader = ResponseBodyReader.init(self.parser, self.conn, &self._body_reader_buffer);
-            self._body_reader.interface = std.Io.Reader.fixed(cached_body);
-            return &self._body_reader.interface;
+            self._fixed_reader = std.Io.Reader.fixed(cached_body);
+            return &self._fixed_reader;
         }
 
         // Initialize body reader if not already done
         if (!self._body_reader_init) {
-            self._body_reader = ResponseBodyReader.init(self.parser, self.conn, &self._body_reader_buffer);
+            self._body_reader = ResponseBodyReader.init(self.parser.?, self.conn.?, &self._body_reader_buffer);
             self._body_reader_init = true;
         }
 
@@ -647,6 +693,7 @@ pub const Client = struct {
     io: std.Io,
     config: ClientConfig,
     pool: ConnectionPool,
+    h2_pool: H2Pool,
     ca_bundle: std.crypto.Certificate.Bundle,
     ca_bundle_lock: std.Io.RwLock,
     ca_bundle_loaded: std.atomic.Value(bool),
@@ -657,6 +704,7 @@ pub const Client = struct {
             .io = io,
             .config = config,
             .pool = ConnectionPool.init(allocator, config.max_idle_connections),
+            .h2_pool = .{},
             .ca_bundle = .empty,
             .ca_bundle_lock = .init,
             .ca_bundle_loaded = std.atomic.Value(bool).init(false),
@@ -679,6 +727,18 @@ pub const Client = struct {
     }
 
     pub fn deinit(self: *Client) void {
+        if (build_options.use_http2) {
+            // Tear down every multiplexed h2 connection and its transport.
+            var it = self.h2_pool.entries.first;
+            while (it) |node| {
+                it = node.next;
+                const entry: *H2Entry = @fieldParentPtr("node", node);
+                entry.conn.destroy();
+                entry.transport.deinit();
+                self.allocator.destroy(entry.transport);
+                self.allocator.destroy(entry);
+            }
+        }
         self.pool.deinit();
         self.ca_bundle.deinit(self.allocator);
     }
@@ -701,72 +761,136 @@ pub const Client = struct {
         });
     }
 
-    /// Acquire a connection from the pool or create a new one.
-    /// Perform a request over an HTTP/2 (ALPN-negotiated) connection. The
-    /// response body is fully buffered. The `nghttp2` module is only referenced
-    /// when built with use_http2; otherwise this returns error.Http2NotImplemented
-    /// (unreachable in practice, since h2 is never negotiated without the option).
-    fn fetchHttp2(self: *Client, conn: *Connection, state: FetchState, host: []const u8) !ClientResponse {
+    /// Look up an existing, still-open multiplexed h2 connection for host:port.
+    /// Closed entries encountered along the way are removed and torn down.
+    fn acquireH2(self: *Client, host: []const u8, port: u16) ?*http2.Connection {
+        if (!build_options.use_http2) return null;
+        self.h2_pool.mutex.lockUncancelable(self.io);
+        defer self.h2_pool.mutex.unlock(self.io);
+
+        var it = self.h2_pool.entries.first;
+        while (it) |node| {
+            it = node.next;
+            const entry: *H2Entry = @fieldParentPtr("node", node);
+            if (entry.conn.isClosed()) {
+                self.h2_pool.entries.remove(node);
+                entry.conn.destroy();
+                entry.transport.deinit();
+                self.allocator.destroy(entry.transport);
+                self.allocator.destroy(entry);
+                continue;
+            }
+            if (entry.conn.port == port and std.ascii.eqlIgnoreCase(entry.conn.host_buf[0..entry.conn.host_len], host)) {
+                return entry.conn;
+            }
+        }
+        return null;
+    }
+
+    /// Promote a freshly-dialed, h2-negotiated transport into a multiplexed
+    /// connection, register it for reuse, and issue the request. Takes ownership
+    /// of `conn`.
+    fn startHttp2(self: *Client, conn: *Connection, state: FetchState, host: []const u8) !ClientResponse {
         if (build_options.use_http2) {
-            const http2 = @import("http2.zig");
-            const arena = conn.arena.allocator();
-
-            // Build the ":path" (path + optional query) and ":authority"
-            // (host, with port only when non-default) pseudo-headers.
-            const path = blk: {
-                const p = uriPath(state.uri);
-                if (state.uri.query) |q| {
-                    break :blk try std.fmt.allocPrint(arena, "{s}?{s}", .{ p, q.percent_encoded });
-                }
-                break :blk p;
-            };
-            const authority = blk: {
-                if (state.port == state.protocol.defaultPort()) break :blk host;
-                break :blk try std.fmt.allocPrint(arena, "{s}:{d}", .{ host, state.port });
-            };
-
-            const parsed = &conn.parsed_response;
-            parsed.* = .{ .arena = arena };
-
-            const body = http2.fetchBuffered(
-                conn.reader,
-                conn.writer,
-                arena,
-                .{
-                    .method = state.options.method,
-                    .authority = authority,
-                    .path = path,
-                    .scheme = "https",
-                    .body = state.options.body,
-                    .headers = state.options.headers,
-                },
-                parsed,
-                self.config.max_response_size,
-                self.config.max_response_header_count,
-            ) catch |err| {
-                // Leave conn for fetchInternal's errdefer to release; mark it
-                // non-poolable since the h2 session state is now indeterminate.
-                conn.closing = true;
+            const h2conn = http2.Connection.create(self.allocator, self.io, conn.reader, conn.writer, host, state.port) catch |err| {
+                conn.deinit();
+                self.allocator.destroy(conn);
                 return err;
             };
 
-            // Stage A: a single request per connection (no multiplexing yet),
-            // so the connection is not returned to the pool.
-            conn.closing = true;
+            const entry = self.allocator.create(H2Entry) catch {
+                h2conn.destroy();
+                conn.deinit();
+                self.allocator.destroy(conn);
+                return error.OutOfMemory;
+            };
+            entry.* = .{ .transport = conn, .conn = h2conn };
 
+            self.h2_pool.mutex.lockUncancelable(self.io);
+            self.h2_pool.entries.append(&entry.node);
+            self.h2_pool.mutex.unlock(self.io);
+
+            return self.requestHttp2(h2conn, state, host);
+        } else {
+            conn.deinit();
+            self.allocator.destroy(conn);
+            return error.Http2NotImplemented;
+        }
+    }
+
+    /// Issue one request over a multiplexed h2 connection and return a
+    /// ClientResponse with a fully-buffered body. The per-request stream and its
+    /// arena are freed when the response is deinit'd.
+    fn requestHttp2(self: *Client, h2conn: *http2.Connection, state: FetchState, host: []const u8) !ClientResponse {
+        if (build_options.use_http2) {
+            const arena_ptr = try self.allocator.create(std.heap.ArenaAllocator);
+            errdefer self.allocator.destroy(arena_ptr);
+            arena_ptr.* = std.heap.ArenaAllocator.init(self.allocator);
+            const a = arena_ptr.allocator();
+
+            // Build ":path" (path + optional query) and ":authority" (host with
+            // port only when non-default). Copy onto the request arena so they
+            // outlive `state`.
+            const path = blk: {
+                const p = uriPath(state.uri);
+                if (state.uri.query) |q| {
+                    break :blk try std.fmt.allocPrint(a, "{s}?{s}", .{ p, q.percent_encoded });
+                }
+                break :blk try a.dupe(u8, p);
+            };
+            const authority = blk: {
+                if (state.port == state.protocol.defaultPort()) break :blk try a.dupe(u8, host);
+                break :blk try std.fmt.allocPrint(a, "{s}:{d}", .{ host, state.port });
+            };
+
+            const stream = try a.create(http2.Stream);
+            stream.* = .{
+                .io = self.io,
+                .arena = a,
+                .method = state.options.method,
+                .scheme = "https",
+                .authority = authority,
+                .path = path,
+                .req_headers = state.options.headers,
+                .req_body = state.options.body orelse &.{},
+                .parsed = .{ .arena = a, .version_major = 2, .version_minor = 0 },
+                .max_body = self.config.max_response_size,
+            };
+            stream.parsed.headers = try Headers.init(a, self.config.max_response_header_count);
+
+            h2conn.request(stream) catch |err| {
+                // On cancellation the session coroutine may still reference the
+                // stream, so its arena must not be freed here.
+                if (err != error.Canceled) {
+                    arena_ptr.deinit();
+                    self.allocator.destroy(arena_ptr);
+                }
+                return err;
+            };
+
+            if (stream.err) |err| {
+                arena_ptr.deinit();
+                self.allocator.destroy(arena_ptr);
+                return err;
+            }
+
+            // Derive content metadata exactly like the HTTP/1.1 parser does.
+            if (stream.parsed.headers.get("Content-Type")) |ct| stream.parsed.content_type = ContentType.fromContentType(ct);
+            if (stream.parsed.headers.get("Content-Encoding")) |ce| stream.parsed.content_encoding = http.ContentEncoding.fromString(ce);
+
+            const body = stream.body.items;
             return ClientResponse{
-                .arena = arena,
-                .parser = &conn.parser, // unused in fixed-body mode
-                .conn = conn.reader, // unused in fixed-body mode
-                .parsed = parsed,
+                .arena = a,
+                .parsed = &stream.parsed,
                 .max_response_size = self.config.max_response_size,
                 .decompress = state.options.decompress,
-                .owner = conn,
+                .h2_conn = h2conn,
+                .h2_stream = stream,
+                .h2_arena = arena_ptr,
                 ._body = if (body.len > 0) body else null,
                 ._body_read = true,
             };
         } else {
-            conn.closing = true;
             return error.Http2NotImplemented;
         }
     }
@@ -925,14 +1049,23 @@ pub const Client = struct {
             break :blk try self.ensureCaBundle();
         } else null;
 
+        // Reuse an existing multiplexed HTTP/2 connection for this origin before
+        // dialing a new one.
+        if (build_options.use_http2 and self.config.http2 and state.protocol == .https) {
+            if (self.acquireH2(host, state.port)) |h2conn| {
+                return self.requestHttp2(h2conn, state, host);
+            }
+        }
+
         // Acquire or create a connection
         const conn = try self.acquireConnection(host, state.port, state.protocol, ca_bundle, state.options.unix_socket_path);
-        errdefer self.pool.release(conn);
 
-        // HTTP/2 path: nghttp2 drives the request over the negotiated connection.
+        // Freshly negotiated HTTP/2: the h2 layer takes ownership of the transport.
         if (conn.http_version == .http_2) {
-            return self.fetchHttp2(conn, state, host);
+            return self.startHttp2(conn, state, host);
         }
+
+        errdefer self.pool.release(conn);
 
         // Send request
         try writeRequest(conn.writer, .{

--- a/src/client.zig
+++ b/src/client.zig
@@ -702,6 +702,75 @@ pub const Client = struct {
     }
 
     /// Acquire a connection from the pool or create a new one.
+    /// Perform a request over an HTTP/2 (ALPN-negotiated) connection. The
+    /// response body is fully buffered. The `nghttp2` module is only referenced
+    /// when built with use_http2; otherwise this returns error.Http2NotImplemented
+    /// (unreachable in practice, since h2 is never negotiated without the option).
+    fn fetchHttp2(self: *Client, conn: *Connection, state: FetchState, host: []const u8) !ClientResponse {
+        if (build_options.use_http2) {
+            const http2 = @import("http2.zig");
+            const arena = conn.arena.allocator();
+
+            // Build the ":path" (path + optional query) and ":authority"
+            // (host, with port only when non-default) pseudo-headers.
+            const path = blk: {
+                const p = uriPath(state.uri);
+                if (state.uri.query) |q| {
+                    break :blk try std.fmt.allocPrint(arena, "{s}?{s}", .{ p, q.percent_encoded });
+                }
+                break :blk p;
+            };
+            const authority = blk: {
+                if (state.port == state.protocol.defaultPort()) break :blk host;
+                break :blk try std.fmt.allocPrint(arena, "{s}:{d}", .{ host, state.port });
+            };
+
+            const parsed = &conn.parsed_response;
+            parsed.* = .{ .arena = arena };
+
+            const body = http2.fetchBuffered(
+                conn.reader,
+                conn.writer,
+                arena,
+                .{
+                    .method = state.options.method,
+                    .authority = authority,
+                    .path = path,
+                    .scheme = "https",
+                    .body = state.options.body,
+                    .headers = state.options.headers,
+                },
+                parsed,
+                self.config.max_response_size,
+                self.config.max_response_header_count,
+            ) catch |err| {
+                // Leave conn for fetchInternal's errdefer to release; mark it
+                // non-poolable since the h2 session state is now indeterminate.
+                conn.closing = true;
+                return err;
+            };
+
+            // Stage A: a single request per connection (no multiplexing yet),
+            // so the connection is not returned to the pool.
+            conn.closing = true;
+
+            return ClientResponse{
+                .arena = arena,
+                .parser = &conn.parser, // unused in fixed-body mode
+                .conn = conn.reader, // unused in fixed-body mode
+                .parsed = parsed,
+                .max_response_size = self.config.max_response_size,
+                .decompress = state.options.decompress,
+                .owner = conn,
+                ._body = if (body.len > 0) body else null,
+                ._body_read = true,
+            };
+        } else {
+            conn.closing = true;
+            return error.Http2NotImplemented;
+        }
+    }
+
     fn acquireConnection(
         self: *Client,
         host: []const u8,
@@ -860,12 +929,9 @@ pub const Client = struct {
         const conn = try self.acquireConnection(host, state.port, state.protocol, ca_bundle, state.options.unix_socket_path);
         errdefer self.pool.release(conn);
 
-        // HTTP/2 was negotiated via ALPN but the h2 path isn't implemented yet.
-        // The TLS connection is already committed to h2 (we can't speak HTTP/1.1
-        // over it), so don't pool it — mark closing so release() tears it down.
+        // HTTP/2 path: nghttp2 drives the request over the negotiated connection.
         if (conn.http_version == .http_2) {
-            conn.closing = true;
-            return error.Http2NotImplemented;
+            return self.fetchHttp2(conn, state, host);
         }
 
         // Send request

--- a/src/client.zig
+++ b/src/client.zig
@@ -814,7 +814,7 @@ pub const Client = struct {
     /// Find a reusable, open h2 connection for host:port and take a reference.
     /// Closed connections are skipped (their reaper frees them); the CAS in
     /// `tryAcquire` prevents resurrecting one that is racing with its reaper.
-    fn acquireH2(self: *Client, host: []const u8, port: u16) ?*http2.Connection {
+    fn acquireH2(self: *Client, host: []const u8, port: u16, unix_socket_path: ?[]const u8) ?*http2.Connection {
         if (!build_options.use_http2) return null;
         self.h2_pool.mutex.lockUncancelable(self.io);
         defer self.h2_pool.mutex.unlock(self.io);
@@ -824,7 +824,9 @@ pub const Client = struct {
             it = node.next;
             const entry: *H2Entry = @fieldParentPtr("node", node);
             if (entry.conn.isClosed()) continue;
-            if (entry.conn.port == port and std.ascii.eqlIgnoreCase(entry.conn.host_buf[0..entry.conn.host_len], host)) {
+            // Match on the transport too (TCP host:port vs unix socket path) so a
+            // unix-socket request can't reuse a TCP connection, or vice versa.
+            if (entry.transport.matches(host, port, .https, unix_socket_path)) {
                 if (entry.conn.tryAcquire()) return entry.conn;
             }
         }
@@ -1186,7 +1188,7 @@ pub const Client = struct {
         // Reuse an existing multiplexed HTTP/2 connection for this origin before
         // dialing a new one.
         if (build_options.use_http2 and self.config.http2 and state.protocol == .https) {
-            if (self.acquireH2(host, state.port)) |h2conn| {
+            if (self.acquireH2(host, state.port, state.options.unix_socket_path)) |h2conn| {
                 var resp = try self.requestHttp2(h2conn, state, host);
                 var resolve_buf: [2048]u8 = undefined;
                 var referer_buf: [2048]u8 = undefined;

--- a/src/client.zig
+++ b/src/client.zig
@@ -587,6 +587,8 @@ pub const ClientResponse = struct {
     h2_conn: ?*http2.Connection = null,
     h2_stream: ?*http2.Stream = null,
     h2_arena: ?*std.heap.ArenaAllocator = null,
+    _h2_body_reader: if (build_options.use_http2) http2.BodyReader else void = undefined,
+    _h2_body_reader_init: bool = false,
 
     // Fixed reader over an already-buffered body (h2, or a cached h1 body).
     _fixed_reader: std.Io.Reader = undefined,
@@ -612,7 +614,16 @@ pub const ClientResponse = struct {
     pub fn deinit(self: *ClientResponse) void {
         if (build_options.use_http2) {
             if (self.h2_stream) |stream| {
-                if (self.h2_conn) |hc| hc.releaseStream(stream);
+                if (self.h2_conn) |hc| {
+                    // If the body wasn't fully read, ask the session to RST the
+                    // stream and wait until it's closed, so the session coroutine
+                    // is finished touching the stream before we free its arena.
+                    if (!stream.done.isSet()) {
+                        hc.cancelStream(stream.stream_id);
+                        stream.done.waitUncancelable(hc.io);
+                    }
+                    hc.releaseStream(stream);
+                }
                 if (self.h2_arena) |a| {
                     const base = a.child_allocator;
                     a.deinit();
@@ -674,12 +685,32 @@ pub const ClientResponse = struct {
     /// Get a streaming body reader. Returns decompressed data if server sent
     /// compressed response and decompress option was enabled.
     pub fn reader(self: *ClientResponse) *std.Io.Reader {
-        // If body has already been read (cached, or an h2 pre-buffered body),
-        // return a fixed reader over it. No llhttp parser is involved.
+        // If body has already been read (cached), return a fixed reader over it.
         if (self._body_read) {
             const cached_body = self._body orelse &.{};
             self._fixed_reader = std.Io.Reader.fixed(cached_body);
             return &self._fixed_reader;
+        }
+
+        // HTTP/2: stream the body from the connection's pipe, decompressing on
+        // the fly if needed.
+        if (build_options.use_http2) {
+            if (self.h2_stream) |stream| {
+                if (!self._h2_body_reader_init) {
+                    self._h2_body_reader = http2.BodyReader.init(stream, self.h2_conn.?, &self._body_reader_buffer);
+                    self._h2_body_reader_init = true;
+                }
+                if (self.decompress and self.parsed.content_encoding != .identity and !self._decompressor_init) {
+                    self._decompressor = std.compress.flate.Decompress.init(
+                        &self._h2_body_reader.interface,
+                        if (self.parsed.content_encoding == .gzip) .gzip else .zlib,
+                        &self._decompressor_buffer,
+                    );
+                    self._decompressor_init = true;
+                }
+                if (self._decompressor_init) return &self._decompressor.reader;
+                return &self._h2_body_reader.interface;
+            }
         }
 
         // Initialize body reader if not already done
@@ -886,6 +917,10 @@ pub const Client = struct {
                 break :blk try std.fmt.allocPrint(a, "{s}:{d}", .{ host, state.port });
             };
 
+            // Body pipe buffer, sized to the stream window so the session
+            // coroutine never blocks pushing DATA frames.
+            const body_buf = try a.alloc(u8, http2.stream_window_bytes);
+
             const stream = try a.create(http2.Stream);
             stream.* = .{
                 .io = self.io,
@@ -898,10 +933,12 @@ pub const Client = struct {
                 .req_body = state.options.body orelse &.{},
                 .accept_encoding = if (state.options.decompress) "gzip, deflate" else null,
                 .parsed = .{ .arena = a, .version_major = 2, .version_minor = 0 },
-                .max_body = self.config.max_response_size,
+                .body = .init(body_buf),
             };
             stream.parsed.headers = try Headers.init(a, self.config.max_response_header_count);
 
+            // Returns once the response headers are available; the body then
+            // streams via the pipe (read through ClientResponse.reader()).
             h2conn.request(stream) catch |err| {
                 if (err == error.Canceled) keep_arena = true; // session may still touch it
                 return err;
@@ -909,30 +946,16 @@ pub const Client = struct {
 
             if (stream.err) |err| return err;
 
-            // Derive content metadata exactly like the HTTP/1.1 parser does.
+            // Derive content metadata exactly like the HTTP/1.1 parser does;
+            // decompression happens lazily in reader().
             if (stream.parsed.headers.get("Content-Type")) |ct| stream.parsed.content_type = ContentType.fromContentType(ct);
             if (stream.parsed.headers.get("Content-Encoding")) |ce| stream.parsed.content_encoding = http.ContentEncoding.fromString(ce);
-
-            // Eagerly decompress the buffered body (the response is delivered in
-            // fixed-body mode, so decompression can't be deferred to reader()).
-            var body = stream.body.items;
-            if (state.options.decompress) {
-                switch (stream.parsed.content_encoding) {
-                    .identity => {},
-                    .unknown => return error.UnsupportedContentEncoding,
-                    .gzip, .deflate => |enc| {
-                        var in = std.Io.Reader.fixed(body);
-                        var win: [std.compress.flate.max_window_len]u8 = undefined;
-                        var dec = std.compress.flate.Decompress.init(&in, if (enc == .gzip) .gzip else .zlib, &win);
-                        body = dec.reader.allocRemaining(a, .limited(self.config.max_response_size)) catch |err| {
-                            return switch (err) {
-                                error.StreamTooLong => error.ResponseTooLarge,
-                                else => err,
-                            };
-                        };
-                        stream.parsed.content_encoding = .identity;
-                    },
-                }
+            if (state.options.decompress and stream.parsed.content_encoding == .unknown) {
+                // The stream is live (headers received, body streaming); RST it
+                // and wait for the session to finish before the arena is freed.
+                h2conn.cancelStream(stream.stream_id);
+                stream.done.waitUncancelable(self.io);
+                return error.UnsupportedContentEncoding;
             }
 
             keep_arena = true; // success: arena + connection ref transfer to the response
@@ -944,8 +967,6 @@ pub const Client = struct {
                 .h2_conn = h2conn,
                 .h2_stream = stream,
                 .h2_arena = arena_ptr,
-                ._body = if (body.len > 0) body else null,
-                ._body_read = true,
             };
         } else {
             return error.Http2NotImplemented;

--- a/src/client.zig
+++ b/src/client.zig
@@ -883,6 +883,52 @@ pub const Client = struct {
         }
     }
 
+    /// Build the outgoing header set for an HTTP/2 request, applying the same
+    /// policy as writeRequest: skip Host/Content-Length, strip sensitive/body
+    /// headers per the redirect rules, and add Referer, default User-Agent, and
+    /// Accept-Encoding. Allocated on `a`; returned as a stable pointer.
+    fn buildH2RequestHeaders(self: *Client, a: std.mem.Allocator, state: FetchState) !*const Headers {
+        var count: usize = 4; // Referer + User-Agent + Accept-Encoding + slack
+        if (state.options.headers) |h| count += h.len;
+
+        const headers = try a.create(Headers);
+        headers.* = try Headers.init(a, count);
+
+        var has_referer = false;
+        var has_user_agent = false;
+        var has_accept_encoding = false;
+        if (state.options.headers) |h| {
+            var it = h.iterator();
+            while (it.next()) |entry| {
+                if (std.ascii.eqlIgnoreCase(entry.key, "Host")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Length")) continue;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Referer")) has_referer = true;
+                if (std.ascii.eqlIgnoreCase(entry.key, "User-Agent")) has_user_agent = true;
+                if (std.ascii.eqlIgnoreCase(entry.key, "Accept-Encoding")) has_accept_encoding = true;
+                if (shouldStripHeader(entry.key, state.strip_sensitive_headers, state.strip_body_headers)) continue;
+                try http.validateHeaderName(entry.key);
+                try http.validateHeaderValue(entry.value);
+                try headers.add(entry.key, entry.value);
+            }
+        }
+        if (state.referer) |referer| {
+            if (!has_referer) {
+                try http.validateHeaderValue(referer);
+                try headers.add("Referer", referer);
+            }
+        }
+        if (self.config.user_agent) |ua| {
+            if (!has_user_agent) {
+                try http.validateHeaderValue(ua);
+                try headers.add("User-Agent", ua);
+            }
+        }
+        if (state.options.decompress and !has_accept_encoding) {
+            try headers.add("Accept-Encoding", "gzip, deflate");
+        }
+        return headers;
+    }
+
     /// Issue one request over a multiplexed h2 connection (whose caller reference
     /// is already held) and return a ClientResponse with a fully-buffered body.
     /// On any error the caller reference is dropped; on success it transfers to
@@ -917,6 +963,13 @@ pub const Client = struct {
                 break :blk try std.fmt.allocPrint(a, "{s}:{d}", .{ host, state.port });
             };
 
+            // Apply the same outgoing-header policy as HTTP/1.1: drop Host /
+            // Content-Length (carried as :authority / framing), strip sensitive
+            // and body headers per the redirect rules, and add Referer, default
+            // User-Agent, and Accept-Encoding. The result is what the h2 layer
+            // emits (it additionally drops h2-forbidden connection headers).
+            const req_headers = try self.buildH2RequestHeaders(a, state);
+
             // Body pipe buffer, sized to the stream window so the session
             // coroutine never blocks pushing DATA frames.
             const body_buf = try a.alloc(u8, http2.stream_window_bytes);
@@ -929,9 +982,8 @@ pub const Client = struct {
                 .scheme = "https",
                 .authority = authority,
                 .path = path,
-                .req_headers = state.options.headers,
+                .req_headers = req_headers,
                 .req_body = state.options.body orelse &.{},
-                .accept_encoding = if (state.options.decompress) "gzip, deflate" else null,
                 .parsed = .{ .arena = a, .version_major = 2, .version_minor = 0 },
                 .body = .init(body_buf),
             };
@@ -1155,7 +1207,9 @@ pub const Client = struct {
             return resp;
         }
 
-        errdefer self.pool.release(conn);
+        // Released early on the redirect path; the errdefer must not release again.
+        var conn_released = false;
+        errdefer if (!conn_released) self.pool.release(conn);
 
         // Send request
         try writeRequest(conn.writer, .{
@@ -1214,6 +1268,7 @@ pub const Client = struct {
                 }
                 if (!conn.parser.shouldKeepAlive()) conn.closing = true;
                 self.pool.release(conn);
+                conn_released = true; // disarm the errdefer; conn is back in the pool
 
                 var referer_buf: [2048]u8 = undefined;
                 const next = try self.buildRedirectState(state, host, status_code, redirect_uri, &referer_buf);
@@ -1315,10 +1370,11 @@ pub const Client = struct {
         var aux_buf: []u8 = resolve_buf[0..];
         const redirect_uri = Uri.resolveInPlace(state.uri, location.len, &aux_buf) catch return null;
         // redirect_uri now lives in resolve_buf (caller's frame), so the response
-        // (and its arena, which `location` pointed into) can be freed.
-        const next = try self.buildRedirectState(state, host, status_code, redirect_uri, referer_buf);
+        // (and its arena, which `location` pointed into) can be freed. Release it
+        // before buildRedirectState, which can fail — otherwise the response would
+        // leak on that error path.
         resp.deinit();
-        return next;
+        return try self.buildRedirectState(state, host, status_code, redirect_uri, referer_buf);
     }
 };
 
@@ -1348,6 +1404,22 @@ const WriteRequestOptions = struct {
     referer: ?[]const u8 = null,
     user_agent: ?[]const u8 = null,
 };
+
+/// Redirect/cross-origin header policy, shared by the HTTP/1.1 and HTTP/2 request
+/// paths. Returns true if a user-supplied header must be dropped: sensitive
+/// credentials when crossing origins, and body-description headers when the body
+/// is dropped (e.g. on a 303).
+fn shouldStripHeader(name: []const u8, strip_sensitive: bool, strip_body: bool) bool {
+    if (strip_sensitive) {
+        const sensitive = [_][]const u8{ "Authorization", "Www-Authenticate", "Cookie", "Cookie2", "Proxy-Authorization", "Proxy-Authenticate" };
+        for (sensitive) |h| if (std.ascii.eqlIgnoreCase(name, h)) return true;
+    }
+    if (strip_body) {
+        const body_headers = [_][]const u8{ "Content-Encoding", "Content-Language", "Content-Location", "Content-Type" };
+        for (body_headers) |h| if (std.ascii.eqlIgnoreCase(name, h)) return true;
+    }
+    return false;
+}
 
 fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
     // Reject any CRLF/NUL smuggled in via the URL host (a URL like
@@ -1388,20 +1460,7 @@ fn writeRequest(writer: *std.Io.Writer, opts: WriteRequestOptions) !void {
             if (std.ascii.eqlIgnoreCase(entry.key, "Referer")) has_referer = true;
             if (std.ascii.eqlIgnoreCase(entry.key, "User-Agent")) has_user_agent = true;
 
-            if (opts.strip_sensitive_headers) {
-                if (std.ascii.eqlIgnoreCase(entry.key, "Authorization")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Www-Authenticate")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Cookie")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Cookie2")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Proxy-Authorization")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Proxy-Authenticate")) continue;
-            }
-            if (opts.strip_body_headers) {
-                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Encoding")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Language")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Location")) continue;
-                if (std.ascii.eqlIgnoreCase(entry.key, "Content-Type")) continue;
-            }
+            if (shouldStripHeader(entry.key, opts.strip_sensitive_headers, opts.strip_body_headers)) continue;
 
             try http.validateHeaderName(entry.key);
             try http.validateHeaderValue(entry.value);

--- a/src/client.zig
+++ b/src/client.zig
@@ -853,6 +853,7 @@ pub const Client = struct {
                 .path = path,
                 .req_headers = state.options.headers,
                 .req_body = state.options.body orelse &.{},
+                .accept_encoding = if (state.options.decompress) "gzip, deflate" else null,
                 .parsed = .{ .arena = a, .version_major = 2, .version_minor = 0 },
                 .max_body = self.config.max_response_size,
             };
@@ -878,7 +879,33 @@ pub const Client = struct {
             if (stream.parsed.headers.get("Content-Type")) |ct| stream.parsed.content_type = ContentType.fromContentType(ct);
             if (stream.parsed.headers.get("Content-Encoding")) |ce| stream.parsed.content_encoding = http.ContentEncoding.fromString(ce);
 
-            const body = stream.body.items;
+            // Eagerly decompress the buffered body (the response is delivered in
+            // fixed-body mode, so decompression can't be deferred to reader()).
+            var body = stream.body.items;
+            if (state.options.decompress) {
+                switch (stream.parsed.content_encoding) {
+                    .identity => {},
+                    .unknown => {
+                        arena_ptr.deinit();
+                        self.allocator.destroy(arena_ptr);
+                        return error.UnsupportedContentEncoding;
+                    },
+                    .gzip, .deflate => |enc| {
+                        var in = std.Io.Reader.fixed(body);
+                        var win: [std.compress.flate.max_window_len]u8 = undefined;
+                        var dec = std.compress.flate.Decompress.init(&in, if (enc == .gzip) .gzip else .zlib, &win);
+                        body = dec.reader.allocRemaining(a, .limited(self.config.max_response_size)) catch |err| {
+                            arena_ptr.deinit();
+                            self.allocator.destroy(arena_ptr);
+                            return switch (err) {
+                                error.StreamTooLong => error.ResponseTooLarge,
+                                else => err,
+                            };
+                        };
+                        stream.parsed.content_encoding = .identity;
+                    },
+                }
+            }
             return ClientResponse{
                 .arena = a,
                 .parsed = &stream.parsed,
@@ -1053,7 +1080,13 @@ pub const Client = struct {
         // dialing a new one.
         if (build_options.use_http2 and self.config.http2 and state.protocol == .https) {
             if (self.acquireH2(host, state.port)) |h2conn| {
-                return self.requestHttp2(h2conn, state, host);
+                var resp = try self.requestHttp2(h2conn, state, host);
+                var resolve_buf: [2048]u8 = undefined;
+                var referer_buf: [2048]u8 = undefined;
+                if (try self.h2Redirect(&resp, state, host, &resolve_buf, &referer_buf)) |next| {
+                    return self.fetchInternal(next);
+                }
+                return resp;
             }
         }
 
@@ -1062,7 +1095,13 @@ pub const Client = struct {
 
         // Freshly negotiated HTTP/2: the h2 layer takes ownership of the transport.
         if (conn.http_version == .http_2) {
-            return self.startHttp2(conn, state, host);
+            var resp = try self.startHttp2(conn, state, host);
+            var resolve_buf: [2048]u8 = undefined;
+            var referer_buf: [2048]u8 = undefined;
+            if (try self.h2Redirect(&resp, state, host, &resolve_buf, &referer_buf)) |next| {
+                return self.fetchInternal(next);
+            }
+            return resp;
         }
 
         errdefer self.pool.release(conn);
@@ -1097,8 +1136,8 @@ pub const Client = struct {
             return error.UnsupportedContentEncoding;
         }
 
-        // Check for redirects
-        const status_code = @intFromEnum(conn.parsed_response.status);
+        // Check for redirects (capture before any pool release resets parsed_response)
+        const status_code: u16 = @intCast(@intFromEnum(conn.parsed_response.status));
         if (status_code >= 300 and status_code < 400 and state.redirects_remaining > 0) {
             if (conn.parsed_response.headers.get("Location")) |location| {
                 // Resolve redirect URL using RFC 3986
@@ -1107,7 +1146,6 @@ pub const Client = struct {
                 @memcpy(resolve_buf[0..location.len], location);
                 var aux_buf: []u8 = resolve_buf[0..];
                 const redirect_uri = Uri.resolveInPlace(state.uri, location.len, &aux_buf) catch return error.InvalidUrl;
-                const redirect_info = try uriPortAndProtocol(redirect_uri);
 
                 // Drain small redirect bodies (up to 2KB) so the connection can
                 // be returned to the pool rather than closed.
@@ -1126,65 +1164,9 @@ pub const Client = struct {
                 if (!conn.parser.shouldKeepAlive()) conn.closing = true;
                 self.pool.release(conn);
 
-                // 301/302/303 with a non-GET/HEAD method: switch to GET and drop body.
-                // 307/308 preserve the original method and body.
-                var redirect_options = state.options;
-                if (status_code == 301 or status_code == 302 or status_code == 303) {
-                    if (redirect_options.method != .get and redirect_options.method != .head) {
-                        redirect_options.method = .get;
-                        redirect_options.body = null;
-                    } else if (status_code == 303) {
-                        redirect_options.body = null;
-                    }
-                }
-
-                // Strip sensitive headers when:
-                //   - already stripping from a previous hop, OR
-                //   - crossing to a different domain/host (same-domain and subdomain keep headers), OR
-                //   - downgrading from https to http (credentials would travel in plaintext).
-                var redirect_host_buffer: [255]u8 = undefined;
-                const redirect_host = try uriHost(redirect_uri, &redirect_host_buffer);
-                const effective_initial_host = if (state.initial_host.len == 0) host else state.initial_host;
-                const redirect_strip_sensitive = state.strip_sensitive_headers or
-                    !isDomainOrSubdomain(redirect_host, effective_initial_host) or
-                    (state.protocol == .https and redirect_info.protocol == .http);
-
-                // Strip body-related headers when there is no body to send.
-                const redirect_strip_body = redirect_options.body == null;
-
-                // Compute Referer for the next hop (RFC 7231 §5.5.2).
-                // Don't send Referer when downgrading https→http (would leak in plaintext).
-                // If the user already set a Referer header, forward it as-is.
                 var referer_buf: [2048]u8 = undefined;
-                const redirect_referer: ?[]const u8 = blk: {
-                    if (state.protocol == .https and redirect_info.protocol == .http) break :blk null;
-                    if (redirect_options.headers) |h| {
-                        if (h.get("Referer")) |existing| break :blk existing;
-                    }
-                    var w = std.Io.Writer.fixed(&referer_buf);
-                    state.uri.writeToStream(&w, .{
-                        .scheme = true,
-                        .authority = true,
-                        .authentication = false, // strip userinfo — never leak credentials in Referer
-                        .path = true,
-                        .query = true,
-                        .fragment = false, // strip fragment — not sent to servers per RFC 7231
-                        .port = true,
-                    }) catch break :blk null;
-                    break :blk w.buffered();
-                };
-
-                return self.fetchInternal(.{
-                    .uri = redirect_uri,
-                    .port = redirect_info.port,
-                    .protocol = redirect_info.protocol,
-                    .options = redirect_options,
-                    .redirects_remaining = state.redirects_remaining - 1,
-                    .initial_host = effective_initial_host,
-                    .strip_sensitive_headers = redirect_strip_sensitive,
-                    .strip_body_headers = redirect_strip_body,
-                    .referer = redirect_referer,
-                });
+                const next = try self.buildRedirectState(state, host, status_code, redirect_uri, &referer_buf);
+                return self.fetchInternal(next);
             }
         }
 
@@ -1198,6 +1180,94 @@ pub const Client = struct {
             .decompress = state.options.decompress,
             .owner = conn,
         };
+    }
+
+    /// Compute the next request's FetchState from a 3xx redirect. Does NOT
+    /// recurse (the caller does, so fetchInternal stays the only recursion point
+    /// and the inferred error sets don't form a cycle). `redirect_uri` and
+    /// `referer_buf` must stay alive until the caller's recursive call returns.
+    /// Shared by both the HTTP/1.1 and HTTP/2 paths.
+    fn buildRedirectState(self: *Client, state: FetchState, host: []const u8, status_code: u16, redirect_uri: Uri, referer_buf: []u8) !FetchState {
+        _ = self;
+        const redirect_info = try uriPortAndProtocol(redirect_uri);
+
+        // 301/302/303 with a non-GET/HEAD method: switch to GET and drop body.
+        // 307/308 preserve the original method and body.
+        var redirect_options = state.options;
+        if (status_code == 301 or status_code == 302 or status_code == 303) {
+            if (redirect_options.method != .get and redirect_options.method != .head) {
+                redirect_options.method = .get;
+                redirect_options.body = null;
+            } else if (status_code == 303) {
+                redirect_options.body = null;
+            }
+        }
+
+        // Strip sensitive headers when:
+        //   - already stripping from a previous hop, OR
+        //   - crossing to a different domain/host (same-domain and subdomain keep headers), OR
+        //   - downgrading from https to http (credentials would travel in plaintext).
+        var redirect_host_buffer: [255]u8 = undefined;
+        const redirect_host = try uriHost(redirect_uri, &redirect_host_buffer);
+        const effective_initial_host = if (state.initial_host.len == 0) host else state.initial_host;
+        const redirect_strip_sensitive = state.strip_sensitive_headers or
+            !isDomainOrSubdomain(redirect_host, effective_initial_host) or
+            (state.protocol == .https and redirect_info.protocol == .http);
+
+        // Strip body-related headers when there is no body to send.
+        const redirect_strip_body = redirect_options.body == null;
+
+        // Compute Referer for the next hop (RFC 7231 §5.5.2).
+        // Don't send Referer when downgrading https→http (would leak in plaintext).
+        // If the user already set a Referer header, forward it as-is.
+        const redirect_referer: ?[]const u8 = blk: {
+            if (state.protocol == .https and redirect_info.protocol == .http) break :blk null;
+            if (redirect_options.headers) |h| {
+                if (h.get("Referer")) |existing| break :blk existing;
+            }
+            var w = std.Io.Writer.fixed(referer_buf);
+            state.uri.writeToStream(&w, .{
+                .scheme = true,
+                .authority = true,
+                .authentication = false, // strip userinfo — never leak credentials in Referer
+                .path = true,
+                .query = true,
+                .fragment = false, // strip fragment — not sent to servers per RFC 7231
+                .port = true,
+            }) catch break :blk null;
+            break :blk w.buffered();
+        };
+
+        return FetchState{
+            .uri = redirect_uri,
+            .port = redirect_info.port,
+            .protocol = redirect_info.protocol,
+            .options = redirect_options,
+            .redirects_remaining = state.redirects_remaining - 1,
+            .initial_host = effective_initial_host,
+            .strip_sensitive_headers = redirect_strip_sensitive,
+            .strip_body_headers = redirect_strip_body,
+            .referer = redirect_referer,
+        };
+    }
+
+    /// If `resp` is a 3xx redirect we should follow, free it and return the next
+    /// FetchState; otherwise return null (the caller returns `resp` as-is). Does
+    /// not recurse. `resolve_buf`/`referer_buf` (caller-owned) must outlive the
+    /// caller's recursive fetchInternal call.
+    fn h2Redirect(self: *Client, resp: *ClientResponse, state: FetchState, host: []const u8, resolve_buf: []u8, referer_buf: []u8) !?FetchState {
+        const status_code: u16 = @intCast(@intFromEnum(resp.parsed.status));
+        if (!(status_code >= 300 and status_code < 400 and state.redirects_remaining > 0)) return null;
+        const location = resp.parsed.headers.get("Location") orelse return null;
+        if (location.len > resolve_buf.len) return null;
+        @memcpy(resolve_buf[0..location.len], location);
+        var aux_buf: []u8 = resolve_buf[0..];
+        const redirect_uri = Uri.resolveInPlace(state.uri, location.len, &aux_buf) catch return null;
+        // redirect_uri now lives in resolve_buf (caller's frame), so the response
+        // (and its arena, which `location` pointed into) can be freed.
+        const next = try self.buildRedirectState(state, host, status_code, redirect_uri, referer_buf);
+        resp.deinit();
+        return next;
     }
 };
 

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -1,0 +1,344 @@
+//! HTTP/2 client support, built on the vendored nghttp2 (src/nghttp2). nghttp2
+//! is a pure, I/O-free protocol state machine: we feed it bytes read from the
+//! socket via `nghttp2_session_mem_recv2`, it invokes our callbacks to surface
+//! headers/data/stream events, and we pull bytes to write via
+//! `nghttp2_session_mem_send2`.
+//!
+//! This file is only compiled when the `use_http2` build option is set; callers
+//! must guard `@import("http2.zig")` behind `build_options.use_http2` so the
+//! `nghttp2` module (and this file) are never analyzed in builds without it.
+
+const std = @import("std");
+
+const http = @import("http.zig");
+const Method = http.Method;
+const Status = http.Status;
+const Headers = http.Headers;
+const ContentType = http.ContentType;
+const ContentEncoding = http.ContentEncoding;
+const ParsedResponse = @import("parser.zig").ParsedResponse;
+
+const c = @import("nghttp2");
+
+const log = std.log.scoped(.dusty_h2);
+
+pub const Http2Error = error{
+    /// Failed to allocate/initialize an nghttp2 session or callbacks.
+    Http2Init,
+    /// nghttp2 reported a protocol/session error while processing frames.
+    Http2Protocol,
+    /// The peer reset our stream (RST_STREAM with a non-zero error code).
+    Http2StreamReset,
+    /// The peer closed the stream before a complete response was received.
+    Http2IncompleteResponse,
+    /// Response body exceeded the configured maximum size.
+    ResponseTooLarge,
+};
+
+/// The pieces of a request needed to build the HTTP/2 HEADERS frame.
+pub const RequestInfo = struct {
+    method: Method,
+    /// ":authority" pseudo-header, e.g. "example.com" or "example.com:8443".
+    authority: []const u8,
+    /// ":path" pseudo-header, e.g. "/index.html?q=1". Must be non-empty.
+    path: []const u8,
+    /// ":scheme" pseudo-header, normally "https".
+    scheme: []const u8 = "https",
+    /// Optional request body (fully buffered; sent via a DATA provider).
+    body: ?[]const u8 = null,
+    /// Optional user-supplied headers (names are lower-cased for h2).
+    headers: ?*const Headers = null,
+};
+
+/// Per-request stream state, referenced from nghttp2 callbacks via the stream's
+/// user data pointer.
+const Stream = struct {
+    arena: std.mem.Allocator,
+    parsed: *ParsedResponse,
+    body: std.ArrayListUnmanaged(u8) = .empty,
+    max_body: usize,
+    /// Set if the body exceeded max_body; further data is dropped.
+    too_large: bool = false,
+    /// Set by on_stream_close once the stream is fully finished.
+    done: bool = false,
+    /// RST_STREAM / abnormal close error code (0 == NO_ERROR/clean).
+    close_error: u32 = 0,
+    /// Set if a callback hit an allocation failure (aborts the session).
+    alloc_failed: bool = false,
+
+    // Request body provider state.
+    req_body: []const u8 = &.{},
+    req_sent: usize = 0,
+};
+
+fn streamFor(session: ?*c.nghttp2_session, stream_id: i32) ?*Stream {
+    const ptr = c.nghttp2_session_get_stream_user_data(session, stream_id) orelse return null;
+    return @ptrCast(@alignCast(ptr));
+}
+
+fn onHeader(
+    session: ?*c.nghttp2_session,
+    frame: [*c]const c.nghttp2_frame,
+    name: [*c]const u8,
+    namelen: usize,
+    value: [*c]const u8,
+    valuelen: usize,
+    flags: u8,
+    user_data: ?*anyopaque,
+) callconv(.c) c_int {
+    _ = flags;
+    _ = user_data;
+    const s = streamFor(session, frame.*.hd.stream_id) orelse return 0;
+    const n = name[0..namelen];
+    const v = value[0..valuelen];
+
+    // Pseudo-headers (":status", etc.) are not stored as regular headers.
+    if (n.len > 0 and n[0] == ':') {
+        if (std.mem.eql(u8, n, ":status")) {
+            const code = std.fmt.parseInt(u16, v, 10) catch return 0;
+            // Status is an exhaustive enum; map unknown codes defensively rather
+            // than risk illegal behavior from a bare @enumFromInt.
+            if (std.enums.fromInt(Status, code)) |st| s.parsed.status = st;
+        }
+        return 0;
+    }
+
+    // Regular header: nghttp2's buffers are only valid during this callback, so
+    // copy into the response arena before storing.
+    const name_copy = s.arena.dupe(u8, n) catch {
+        s.alloc_failed = true;
+        return c.NGHTTP2_ERR_CALLBACK_FAILURE;
+    };
+    const value_copy = s.arena.dupe(u8, v) catch {
+        s.alloc_failed = true;
+        return c.NGHTTP2_ERR_CALLBACK_FAILURE;
+    };
+    // Ignore overflow past max_header_count (matches HTTP/1.1 leniency).
+    s.parsed.headers.add(name_copy, value_copy) catch {};
+    return 0;
+}
+
+fn onDataChunk(
+    session: ?*c.nghttp2_session,
+    flags: u8,
+    stream_id: i32,
+    data: [*c]const u8,
+    len: usize,
+    user_data: ?*anyopaque,
+) callconv(.c) c_int {
+    _ = flags;
+    _ = user_data;
+    const s = streamFor(session, stream_id) orelse return 0;
+    if (s.too_large) return 0;
+    if (s.body.items.len + len > s.max_body) {
+        s.too_large = true;
+        return 0;
+    }
+    s.body.appendSlice(s.arena, data[0..len]) catch {
+        s.alloc_failed = true;
+        return c.NGHTTP2_ERR_CALLBACK_FAILURE;
+    };
+    return 0;
+}
+
+fn onStreamClose(
+    session: ?*c.nghttp2_session,
+    stream_id: i32,
+    error_code: u32,
+    user_data: ?*anyopaque,
+) callconv(.c) c_int {
+    _ = user_data;
+    const s = streamFor(session, stream_id) orelse return 0;
+    s.close_error = error_code;
+    s.done = true;
+    return 0;
+}
+
+fn readReqBody(
+    session: ?*c.nghttp2_session,
+    stream_id: i32,
+    buf: [*c]u8,
+    length: usize,
+    data_flags: [*c]u32,
+    source: [*c]c.nghttp2_data_source,
+    user_data: ?*anyopaque,
+) callconv(.c) isize {
+    _ = session;
+    _ = stream_id;
+    _ = user_data;
+    const s: *Stream = @ptrCast(@alignCast(source.*.ptr.?));
+    const remaining = s.req_body[s.req_sent..];
+    const n = @min(length, remaining.len);
+    if (n > 0) @memcpy(buf[0..n], remaining[0..n]);
+    s.req_sent += n;
+    if (s.req_sent == s.req_body.len) {
+        data_flags.* |= @as(u32, @intCast(c.NGHTTP2_DATA_FLAG_EOF));
+    }
+    return @intCast(n);
+}
+
+fn addNv(
+    list: *std.ArrayListUnmanaged(c.nghttp2_nv),
+    arena: std.mem.Allocator,
+    name: []const u8,
+    value: []const u8,
+) !void {
+    // nghttp2 copies name/value during submit_request (default NV flags), so the
+    // arena copies only need to outlive that call.
+    const n = try arena.dupe(u8, name);
+    const v = try arena.dupe(u8, value);
+    try list.append(arena, .{
+        .name = n.ptr,
+        .value = v.ptr,
+        .namelen = n.len,
+        .valuelen = v.len,
+        .flags = @as(u8, @intCast(c.NGHTTP2_NV_FLAG_NONE)),
+    });
+}
+
+/// Headers that must not be forwarded as HTTP/2 fields (carried as pseudo-headers
+/// or forbidden by RFC 9113 §8.2.2).
+fn isSkippedHeader(name: []const u8) bool {
+    const skip = [_][]const u8{
+        "host",              "connection", "keep-alive", "proxy-connection",
+        "transfer-encoding", "upgrade",    "te",
+    };
+    for (skip) |s| {
+        if (std.ascii.eqlIgnoreCase(name, s)) return true;
+    }
+    return false;
+}
+
+/// Perform a single HTTP/2 request over an already-established (ALPN-negotiated)
+/// connection and return the fully-buffered response body. Status and headers
+/// are written into `parsed`. Drives the nghttp2 session synchronously: this
+/// owns the reader/writer for the duration of the call (one request at a time).
+pub fn fetchBuffered(
+    reader: *std.Io.Reader,
+    writer: *std.Io.Writer,
+    arena: std.mem.Allocator,
+    info: RequestInfo,
+    parsed: *ParsedResponse,
+    max_body: usize,
+    max_header_count: usize,
+) (Http2Error || error{ ReadFailed, WriteFailed })![]const u8 {
+    parsed.headers = Headers.init(arena, max_header_count) catch return error.Http2Init;
+    parsed.version_major = 2;
+    parsed.version_minor = 0;
+
+    var callbacks: ?*c.nghttp2_session_callbacks = null;
+    if (c.nghttp2_session_callbacks_new(&callbacks) != 0) return error.Http2Init;
+    defer c.nghttp2_session_callbacks_del(callbacks);
+    c.nghttp2_session_callbacks_set_on_header_callback(callbacks, onHeader);
+    c.nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks, onDataChunk);
+    c.nghttp2_session_callbacks_set_on_stream_close_callback(callbacks, onStreamClose);
+
+    var stream: Stream = .{
+        .arena = arena,
+        .parsed = parsed,
+        .max_body = max_body,
+        .req_body = info.body orelse &.{},
+    };
+
+    var session: ?*c.nghttp2_session = null;
+    if (c.nghttp2_session_client_new(&session, callbacks, null) != 0) return error.Http2Init;
+    defer c.nghttp2_session_del(session);
+
+    // Client connection preface: SETTINGS is mandatory and must be the first
+    // frame. Disable server push (we don't support it) and advertise a 1 MiB
+    // stream window.
+    const iv = [_]c.nghttp2_settings_entry{
+        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_ENABLE_PUSH), .value = 0 },
+        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE), .value = 1 << 20 },
+    };
+    if (c.nghttp2_submit_settings(session, @intCast(c.NGHTTP2_FLAG_NONE), &iv, iv.len) != 0) {
+        return error.Http2Init;
+    }
+
+    // Build the request header list (pseudo-headers first, then user headers).
+    var nva: std.ArrayListUnmanaged(c.nghttp2_nv) = .empty;
+    addNv(&nva, arena, ":method", info.method.name()) catch return error.Http2Init;
+    addNv(&nva, arena, ":scheme", info.scheme) catch return error.Http2Init;
+    addNv(&nva, arena, ":authority", info.authority) catch return error.Http2Init;
+    addNv(&nva, arena, ":path", info.path) catch return error.Http2Init;
+    if (info.headers) |hs| {
+        for (hs.keys[0..hs.len], hs.values[0..hs.len]) |k, v| {
+            if (isSkippedHeader(k)) continue;
+            const lower = std.ascii.allocLowerString(arena, k) catch return error.Http2Init;
+            addNv(&nva, arena, lower, v) catch return error.Http2Init;
+        }
+    }
+
+    // Attach a DATA provider only when there is a request body.
+    var data_prd: c.nghttp2_data_provider = .{
+        .source = .{ .ptr = &stream },
+        .read_callback = readReqBody,
+    };
+    const prd_ptr: [*c]const c.nghttp2_data_provider = if (info.body != null) &data_prd else null;
+
+    const stream_id = c.nghttp2_submit_request(session, null, nva.items.ptr, nva.items.len, prd_ptr, &stream);
+    if (stream_id < 0) {
+        log.debug("nghttp2_submit_request failed: {s}", .{c.nghttp2_strerror(stream_id)});
+        return error.Http2Protocol;
+    }
+
+    try drive(session, &stream, reader, writer);
+
+    if (stream.alloc_failed) return error.Http2Init;
+    if (stream.too_large) return error.ResponseTooLarge;
+    if (stream.close_error != 0) return error.Http2StreamReset;
+
+    // Derive content metadata exactly like the HTTP/1.1 parser does.
+    if (parsed.headers.get("Content-Type")) |ct| parsed.content_type = ContentType.fromContentType(ct);
+    if (parsed.headers.get("Content-Encoding")) |ce| parsed.content_encoding = ContentEncoding.fromString(ce);
+
+    return stream.body.items;
+}
+
+/// The synchronous send/recv loop: flush everything nghttp2 wants to send, then
+/// read and feed bytes, until the stream completes.
+fn drive(
+    session: ?*c.nghttp2_session,
+    stream: *Stream,
+    reader: *std.Io.Reader,
+    writer: *std.Io.Writer,
+) (Http2Error || error{ ReadFailed, WriteFailed })!void {
+    while (true) {
+        // Send: drain all pending output frames.
+        while (c.nghttp2_session_want_write(session) != 0) {
+            var data: [*c]const u8 = undefined;
+            const n = c.nghttp2_session_mem_send2(session, &data);
+            if (n < 0) return error.Http2Protocol;
+            if (n == 0) break;
+            writer.writeAll(data[0..@intCast(n)]) catch return error.WriteFailed;
+        }
+        writer.flush() catch return error.WriteFailed;
+
+        if (stream.done) return;
+        if (stream.alloc_failed) return;
+
+        if (c.nghttp2_session_want_read(session) == 0 and c.nghttp2_session_want_write(session) == 0) {
+            // Session is idle but the stream never completed.
+            return error.Http2IncompleteResponse;
+        }
+
+        // Receive: feed buffered bytes to nghttp2, or block for more.
+        const buffered = reader.buffered();
+        if (buffered.len > 0) {
+            const rv = c.nghttp2_session_mem_recv2(session, buffered.ptr, buffered.len);
+            if (rv < 0) {
+                log.debug("nghttp2_session_mem_recv2 failed: {s}", .{c.nghttp2_strerror(@intCast(rv))});
+                return error.Http2Protocol;
+            }
+            reader.toss(@intCast(rv));
+        } else {
+            reader.fillMore() catch |err| switch (err) {
+                error.EndOfStream => {
+                    if (stream.done) return;
+                    return error.Http2IncompleteResponse;
+                },
+                else => return error.ReadFailed,
+            };
+        }
+    }
+}

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -117,9 +117,21 @@ pub const Stream = struct {
     }
 };
 
+/// Called when a Connection's last reference is dropped, to release the
+/// Connection itself, its transport, and its pool entry. Provided by the owner
+/// (client.zig) since those types live there. Must call `conn.freeSession()`.
+pub const ReapFn = *const fn (conn: *Connection) void;
+
 /// A multiplexed HTTP/2 connection. Heap-allocated and never moved (coroutines
 /// hold its address). The underlying transport (socket + TLS) is owned by the
 /// caller (client.zig); this only borrows `reader`/`writer`.
+///
+/// Lifetime is reference-counted (`refs`): one reference is held by the session
+/// coroutine (dropped when it exits) and one by each caller from acquire until
+/// its response is deinit'd. When the count reaches zero the `reaper` frees
+/// everything. The session and net-reader coroutines are spawned into a shared,
+/// Client-owned group; the net-reader is a child of the session (spawned into a
+/// group on the session's stack), so the session joins it before reaping.
 pub const Connection = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -133,26 +145,28 @@ pub const Connection = struct {
     events_buf: [event_queue_cap]Event = undefined,
     /// session -> net-reader ack that the last net_data slice was consumed.
     consumed: std.Io.Event = .unset,
-    group: std.Io.Group = .init,
 
     /// In-flight streams, owned exclusively by the session coroutine.
     streams: std.DoublyLinkedList = .{},
 
-    /// Set true once the connection is unusable (GOAWAY/EOF/error/shutdown).
-    /// Read by the pool to decide reuse; written by the session coroutine.
+    /// Set true once the connection is unusable (GOAWAY/EOF/error). Read by the
+    /// pool to skip it for reuse; written by the session coroutine / on cancel.
     closed: std.atomic.Value(bool) = .init(false),
-    /// Count of in-flight streams, for pool bookkeeping.
-    active: std.atomic.Value(usize) = .init(0),
+    /// Reference count; starts at 1 for the session coroutine. The thread that
+    /// decrements it to zero invokes `reaper`.
+    refs: std.atomic.Value(usize) = .init(1),
+    reaper: ?ReapFn = null,
+    /// Opaque back-reference to the owner's pool entry, used by `reaper`.
+    owner: ?*anyopaque = null,
 
     // Pool key.
     host_buf: [255]u8 = undefined,
     host_len: u8 = 0,
     port: u16 = 0,
-    pool_node: std.DoublyLinkedList.Node = .{},
 
-    /// Create and start a multiplexed HTTP/2 connection over the given
-    /// (ALPN-negotiated) reader/writer. Spawns the session and net-reader
-    /// coroutines.
+    /// Allocate and initialize a connection over the given (ALPN-negotiated)
+    /// reader/writer. Does NOT spawn coroutines — call `spawn` once the reaper
+    /// and pool entry are wired up.
     pub fn create(
         allocator: std.mem.Allocator,
         io: std.Io,
@@ -185,58 +199,67 @@ pub const Connection = struct {
         c.nghttp2_session_callbacks_set_on_stream_close_callback(conn.callbacks, onStreamClose);
 
         if (c.nghttp2_session_client_new(&conn.session, conn.callbacks, conn) != 0) return error.Http2Init;
-        errdefer c.nghttp2_session_del(conn.session);
-
-        // Spawn the two long-lived coroutines. They run until cancelled by
-        // deinit() or until a fatal error makes them return.
-        conn.group.concurrent(io, sessionLoop, .{conn}) catch return error.Http2Init;
-        conn.group.concurrent(io, netReaderLoop, .{conn}) catch {
-            // Tear down the already-spawned session coroutine before failing.
-            conn.events.close(io);
-            conn.group.cancel(io);
-            return error.Http2Init;
-        };
 
         return conn;
     }
 
-    /// Stop the coroutines and free the session. The transport (socket/TLS) is
-    /// the caller's responsibility.
-    pub fn destroy(conn: *Connection) void {
-        conn.closed.store(true, .release);
-        conn.events.close(conn.io);
-        conn.consumed.set(conn.io); // unblock net-reader if waiting on the ack
-        conn.group.cancel(conn.io); // cancel + join both coroutines
+    /// Spawn the session coroutine into the (shared, Client-owned) group. The
+    /// session spawns and owns the net-reader itself. Must be called after the
+    /// reaper/owner are set.
+    pub fn spawn(conn: *Connection, group: *std.Io.Group) !void {
+        group.concurrent(conn.io, sessionLoop, .{conn}) catch return error.Http2Init;
+    }
+
+    /// Release the nghttp2 session/callbacks. Called by the reaper; the reaper
+    /// also frees the Connection struct and transport.
+    pub fn freeSession(conn: *Connection) void {
         if (conn.session) |s| c.nghttp2_session_del(s);
         if (conn.callbacks) |cb| c.nghttp2_session_callbacks_del(cb);
-        conn.allocator.destroy(conn);
     }
 
     pub fn isClosed(conn: *Connection) bool {
         return conn.closed.load(.acquire);
     }
 
+    /// Try to take a reference. Returns false if the connection is already being
+    /// reaped (refcount hit zero), which prevents resurrecting a dead conn that
+    /// is racing with its reaper. Callers hold the pool mutex.
+    pub fn tryAcquire(conn: *Connection) bool {
+        var r = conn.refs.load(.monotonic);
+        while (true) {
+            if (r == 0) return false;
+            r = conn.refs.cmpxchgWeak(r, r + 1, .acq_rel, .monotonic) orelse return true;
+        }
+    }
+
+    /// Drop a reference; the dropper that reaches zero invokes the reaper.
+    pub fn dropRef(conn: *Connection) void {
+        if (conn.refs.fetchSub(1, .acq_rel) == 1) {
+            conn.reaper.?(conn);
+        }
+    }
+
     /// Submit a request on `stream` and block until the response is complete or
-    /// the stream fails. The caller owns `stream` and its arena.
+    /// the stream fails. The caller owns `stream` and its arena and must already
+    /// hold a connection reference.
     pub fn request(conn: *Connection, stream: *Stream) !void {
-        _ = conn.active.fetchAdd(1, .acq_rel);
         conn.events.putOne(conn.io, .{ .submit = stream }) catch {
-            _ = conn.active.fetchSub(1, .acq_rel);
             return error.Http2ConnectionClosed;
         };
         stream.done.wait(conn.io) catch |err| {
             // Cancellation while waiting: the session coroutine may still touch
-            // the stream, so the caller must not free it here. Mark the
-            // connection unusable so it is retired rather than reused.
+            // the stream, so the caller must not free it here. Retire the
+            // connection so it is not reused.
             conn.closed.store(true, .release);
             return err;
         };
     }
 
-    /// Release a completed stream. Must be called after `request` returns.
+    /// Drop the caller's reference once it is done with the connection. (Named
+    /// for symmetry with the request lifecycle; the stream arg is unused.)
     pub fn releaseStream(conn: *Connection, stream: *Stream) void {
-        _ = conn.active.fetchSub(1, .acq_rel);
         _ = stream;
+        conn.dropRef();
     }
 };
 
@@ -246,6 +269,22 @@ pub const Connection = struct {
 
 fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
     const io = conn.io;
+
+    // The net-reader is a child of this coroutine: spawning it into a group on
+    // our own stack lets us join it (cancel) before reaping, without making it a
+    // peer in the shared Client group.
+    var nr_group: std.Io.Group = .init;
+    defer {
+        // Join the net-reader (cancel interrupts its blocking read), then drop
+        // the session's reference — which reaps the connection if it was the
+        // last one. Nothing touches `conn` after dropRef.
+        nr_group.cancel(io);
+        conn.dropRef();
+    }
+    nr_group.concurrent(io, netReaderLoop, .{conn}) catch {
+        fatalAll(conn, error.Http2Init);
+        return;
+    };
 
     submitSettings(conn) catch {
         fatalAll(conn, error.Http2Init);

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -102,12 +102,13 @@ pub const Stream = struct {
     scheme: []const u8,
     authority: []const u8,
     path: []const u8,
+    /// Final outgoing headers (the client already applied request/redirect
+    /// policy: Host/Content-Length removed, sensitive/body headers stripped,
+    /// Referer/User-Agent/Accept-Encoding added). This layer only drops
+    /// h2-forbidden connection headers and lower-cases names.
     req_headers: ?*const Headers,
     req_body: []const u8 = &.{},
     req_sent: usize = 0,
-    /// When set, sent as the "accept-encoding" header (unless the user already
-    /// provided one).
-    accept_encoding: ?[]const u8 = null,
 
     // Response (set by the session coroutine).
     parsed: ParsedResponse,
@@ -276,8 +277,9 @@ pub const Connection = struct {
     /// The caller owns `stream` and its arena and must already hold a connection
     /// reference.
     pub fn request(conn: *Connection, stream: *Stream) !void {
-        conn.events.putOne(conn.io, .{ .submit = stream }) catch {
-            return error.Http2ConnectionClosed;
+        conn.events.putOne(conn.io, .{ .submit = stream }) catch |err| switch (err) {
+            error.Canceled => return error.Canceled,
+            error.Closed => return error.Http2ConnectionClosed,
         };
         stream.headers_done.wait(conn.io) catch |err| {
             // Cancellation while waiting: the session coroutine may still touch
@@ -383,7 +385,14 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
     };
 
     while (true) {
-        const ev = conn.events.getOne(io) catch return; // Closed or Canceled
+        // On cancel/close, wake any in-flight streams (callers may be blocked on
+        // headers_done/done or on a body read) before unwinding. Cancellation
+        // must still propagate — never swallow error.Canceled.
+        const ev = conn.events.getOne(io) catch |err| {
+            fatalAll(conn, error.Http2ConnectionClosed);
+            if (err == error.Canceled) return error.Canceled;
+            return; // error.Closed
+        };
         switch (ev) {
             .submit => |s| handleSubmit(conn, s),
             .consume => |x| {
@@ -447,17 +456,12 @@ fn handleSubmit(conn: *Connection, s: *Stream) void {
     addNv(&nva, arena, ":scheme", s.scheme) catch return s.finish(error.Http2Init);
     addNv(&nva, arena, ":authority", s.authority) catch return s.finish(error.Http2Init);
     addNv(&nva, arena, ":path", s.path) catch return s.finish(error.Http2Init);
-    var user_has_accept_encoding = false;
     if (s.req_headers) |hs| {
         for (hs.keys[0..hs.len], hs.values[0..hs.len]) |k, v| {
             if (isSkippedHeader(k)) continue;
-            if (std.ascii.eqlIgnoreCase(k, "accept-encoding")) user_has_accept_encoding = true;
             const lower = std.ascii.allocLowerString(arena, k) catch return s.finish(error.Http2Init);
             addNv(&nva, arena, lower, v) catch return s.finish(error.Http2Init);
         }
-    }
-    if (!user_has_accept_encoding) {
-        if (s.accept_encoding) |ae| addNv(&nva, arena, "accept-encoding", ae) catch return s.finish(error.Http2Init);
     }
 
     var data_prd: c.nghttp2_data_provider = .{
@@ -495,6 +499,9 @@ fn fatalAll(conn: *Connection, err: anyerror) void {
         it = node.next;
         const s: *Stream = @fieldParentPtr("node", node);
         conn.streams.remove(node);
+        // Close the body pipe too: a caller blocked in BodyReader.readStream is
+        // waiting on body.get(), not on the headers_done/done events.
+        s.body.close(s.io);
         s.finish(err);
     }
 }
@@ -508,20 +515,30 @@ fn netReaderLoop(conn: *Connection) std.Io.Cancelable!void {
     while (true) {
         const buffered = conn.reader.buffered();
         if (buffered.len > 0) {
-            conn.events.putOne(io, .{ .net_data = buffered }) catch return; // Closed/Canceled
-            conn.consumed.wait(io) catch return;
+            conn.events.putOne(io, .{ .net_data = buffered }) catch |err| switch (err) {
+                error.Canceled => return error.Canceled,
+                error.Closed => return, // session gone
+            };
+            try conn.consumed.wait(io); // propagate cancellation
             conn.consumed.reset();
             conn.reader.toss(buffered.len);
         } else {
             conn.reader.fillMore() catch |err| switch (err) {
+                // NOTE: std.Io.Reader maps a cancelled read to ReadFailed (not
+                // Canceled), so cancellation surfaces here as the `else` arm; the
+                // queue posts below still propagate Canceled if it races.
                 error.EndOfStream => {
-                    conn.events.putOne(io, .net_eof) catch {};
+                    conn.events.putOne(io, .net_eof) catch |e| switch (e) {
+                        error.Canceled => return error.Canceled,
+                        error.Closed => {},
+                    };
                     return;
                 },
-                // ReadFailed also covers cancellation during teardown; the real
-                // cause is stashed in the underlying reader. Either way we stop.
                 else => {
-                    conn.events.putOne(io, .net_err) catch {};
+                    conn.events.putOne(io, .net_err) catch |e| switch (e) {
+                        error.Canceled => return error.Canceled,
+                        error.Closed => {},
+                    };
                     return;
                 },
             };

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -4,9 +4,29 @@
 //! headers/data/stream events, and we pull bytes to write via
 //! `nghttp2_session_mem_send2`.
 //!
+//! Concurrency model (the "actor"): one `Connection` owns a single nghttp2
+//! session and multiplexes many concurrent request streams over one socket.
+//! Two coroutines run per connection:
+//!
+//!   * the session coroutine is the SOLE caller of every `nghttp2_*` function.
+//!     It blocks on one queue (`events`) carrying both inbound socket data and
+//!     request submissions, dispatches each, and drains nghttp2's output to the
+//!     socket. nghttp2's callbacks (run inside mem_recv on this coroutine) fill
+//!     per-stream response state and signal completion.
+//!   * the net-reader coroutine is the sole socket reader: it reads ciphertext,
+//!     hands the decrypted bytes to the session coroutine via `events`, and
+//!     waits for an ack before reading again.
+//!
+//! Caller coroutines (one per in-flight `fetch`) submit a `Stream` through the
+//! queue and block on its `done` event; they never touch the session directly.
+//! This keeps the non-reentrant nghttp2 session single-owner without a mutex.
+//!
+//! Concurrent read (net-reader) and write (session coroutine) touch disjoint
+//! TLS cipher state (separate encrypt/decrypt fields), so sharing one
+//! tls.Connection across the two coroutines is safe.
+//!
 //! This file is only compiled when the `use_http2` build option is set; callers
-//! must guard `@import("http2.zig")` behind `build_options.use_http2` so the
-//! `nghttp2` module (and this file) are never analyzed in builds without it.
+//! must guard `@import("http2.zig")` behind `build_options.use_http2`.
 
 const std = @import("std");
 
@@ -22,6 +42,10 @@ const c = @import("nghttp2");
 
 const log = std.log.scoped(.dusty_h2);
 
+/// Backing capacity of the per-connection event queue. Holds at most one
+/// in-flight net_data item plus queued submissions.
+const event_queue_cap = 256;
+
 pub const Http2Error = error{
     /// Failed to allocate/initialize an nghttp2 session or callbacks.
     Http2Init,
@@ -29,47 +53,344 @@ pub const Http2Error = error{
     Http2Protocol,
     /// The peer reset our stream (RST_STREAM with a non-zero error code).
     Http2StreamReset,
-    /// The peer closed the stream before a complete response was received.
+    /// The peer closed the stream/connection before a complete response.
     Http2IncompleteResponse,
+    /// The connection was torn down (GOAWAY, socket error, or shutdown).
+    Http2ConnectionClosed,
     /// Response body exceeded the configured maximum size.
     ResponseTooLarge,
 };
 
-/// The pieces of a request needed to build the HTTP/2 HEADERS frame.
-pub const RequestInfo = struct {
-    method: Method,
-    /// ":authority" pseudo-header, e.g. "example.com" or "example.com:8443".
-    authority: []const u8,
-    /// ":path" pseudo-header, e.g. "/index.html?q=1". Must be non-empty.
-    path: []const u8,
-    /// ":scheme" pseudo-header, normally "https".
-    scheme: []const u8 = "https",
-    /// Optional request body (fully buffered; sent via a DATA provider).
-    body: ?[]const u8 = null,
-    /// Optional user-supplied headers (names are lower-cased for h2).
-    headers: ?*const Headers = null,
+/// Items carried on a connection's single event queue. Producers are the caller
+/// coroutines (`submit`) and the net-reader coroutine (`net_*`); the sole
+/// consumer is the session coroutine.
+const Event = union(enum) {
+    /// A caller wants to start a request on this stream.
+    submit: *Stream,
+    /// Decrypted bytes from the socket; the slice points into the net-reader's
+    /// buffer and stays valid until the session acks via `consumed`.
+    net_data: []const u8,
+    /// The peer closed the connection cleanly (EOF).
+    net_eof,
+    /// A socket read error occurred.
+    net_err,
 };
 
-/// Per-request stream state, referenced from nghttp2 callbacks via the stream's
-/// user data pointer.
-const Stream = struct {
+/// Per-request stream state. Created and owned by the calling coroutine; the
+/// request fields are filled before `submit`, the response fields are filled by
+/// the session coroutine before `done` is set.
+pub const Stream = struct {
+    io: std.Io,
     arena: std.mem.Allocator,
-    parsed: *ParsedResponse,
-    body: std.ArrayListUnmanaged(u8) = .empty,
-    max_body: usize,
-    /// Set if the body exceeded max_body; further data is dropped.
-    too_large: bool = false,
-    /// Set by on_stream_close once the stream is fully finished.
-    done: bool = false,
-    /// RST_STREAM / abnormal close error code (0 == NO_ERROR/clean).
-    close_error: u32 = 0,
-    /// Set if a callback hit an allocation failure (aborts the session).
-    alloc_failed: bool = false,
 
-    // Request body provider state.
+    // Request (set by caller before submit).
+    method: Method,
+    scheme: []const u8,
+    authority: []const u8,
+    path: []const u8,
+    req_headers: ?*const Headers,
     req_body: []const u8 = &.{},
     req_sent: usize = 0,
+
+    // Response (set by the session coroutine).
+    parsed: ParsedResponse,
+    body: std.ArrayListUnmanaged(u8) = .empty,
+    max_body: usize,
+    too_large: bool = false,
+    alloc_failed: bool = false,
+    close_error: u32 = 0,
+    err: ?anyerror = null,
+    stream_id: i32 = -1,
+
+    /// Set once by the session coroutine when the response is complete (or
+    /// failed); awaited by the caller.
+    done: std.Io.Event = .unset,
+    /// Intrusive node in Connection.streams; touched only by the session coro.
+    node: std.DoublyLinkedList.Node = .{},
+
+    fn finish(s: *Stream, err: ?anyerror) void {
+        if (err != null and s.err == null) s.err = err;
+        s.done.set(s.io);
+    }
 };
+
+/// A multiplexed HTTP/2 connection. Heap-allocated and never moved (coroutines
+/// hold its address). The underlying transport (socket + TLS) is owned by the
+/// caller (client.zig); this only borrows `reader`/`writer`.
+pub const Connection = struct {
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    reader: *std.Io.Reader,
+    writer: *std.Io.Writer,
+
+    session: ?*c.nghttp2_session = null,
+    callbacks: ?*c.nghttp2_session_callbacks = null,
+
+    events: std.Io.Queue(Event),
+    events_buf: [event_queue_cap]Event = undefined,
+    /// session -> net-reader ack that the last net_data slice was consumed.
+    consumed: std.Io.Event = .unset,
+    group: std.Io.Group = .init,
+
+    /// In-flight streams, owned exclusively by the session coroutine.
+    streams: std.DoublyLinkedList = .{},
+
+    /// Set true once the connection is unusable (GOAWAY/EOF/error/shutdown).
+    /// Read by the pool to decide reuse; written by the session coroutine.
+    closed: std.atomic.Value(bool) = .init(false),
+    /// Count of in-flight streams, for pool bookkeeping.
+    active: std.atomic.Value(usize) = .init(0),
+
+    // Pool key.
+    host_buf: [255]u8 = undefined,
+    host_len: u8 = 0,
+    port: u16 = 0,
+    pool_node: std.DoublyLinkedList.Node = .{},
+
+    /// Create and start a multiplexed HTTP/2 connection over the given
+    /// (ALPN-negotiated) reader/writer. Spawns the session and net-reader
+    /// coroutines.
+    pub fn create(
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        reader: *std.Io.Reader,
+        writer: *std.Io.Writer,
+        host: []const u8,
+        port: u16,
+    ) !*Connection {
+        const conn = try allocator.create(Connection);
+        errdefer allocator.destroy(conn);
+
+        conn.* = .{
+            .allocator = allocator,
+            .io = io,
+            .reader = reader,
+            .writer = writer,
+            .events = undefined,
+        };
+        conn.events = .init(&conn.events_buf);
+
+        const host_len: u8 = @intCast(@min(host.len, conn.host_buf.len));
+        @memcpy(conn.host_buf[0..host_len], host[0..host_len]);
+        conn.host_len = host_len;
+        conn.port = port;
+
+        if (c.nghttp2_session_callbacks_new(&conn.callbacks) != 0) return error.Http2Init;
+        errdefer c.nghttp2_session_callbacks_del(conn.callbacks);
+        c.nghttp2_session_callbacks_set_on_header_callback(conn.callbacks, onHeader);
+        c.nghttp2_session_callbacks_set_on_data_chunk_recv_callback(conn.callbacks, onDataChunk);
+        c.nghttp2_session_callbacks_set_on_stream_close_callback(conn.callbacks, onStreamClose);
+
+        if (c.nghttp2_session_client_new(&conn.session, conn.callbacks, conn) != 0) return error.Http2Init;
+        errdefer c.nghttp2_session_del(conn.session);
+
+        // Spawn the two long-lived coroutines. They run until cancelled by
+        // deinit() or until a fatal error makes them return.
+        conn.group.concurrent(io, sessionLoop, .{conn}) catch return error.Http2Init;
+        conn.group.concurrent(io, netReaderLoop, .{conn}) catch {
+            // Tear down the already-spawned session coroutine before failing.
+            conn.events.close(io);
+            conn.group.cancel(io);
+            return error.Http2Init;
+        };
+
+        return conn;
+    }
+
+    /// Stop the coroutines and free the session. The transport (socket/TLS) is
+    /// the caller's responsibility.
+    pub fn destroy(conn: *Connection) void {
+        conn.closed.store(true, .release);
+        conn.events.close(conn.io);
+        conn.consumed.set(conn.io); // unblock net-reader if waiting on the ack
+        conn.group.cancel(conn.io); // cancel + join both coroutines
+        if (conn.session) |s| c.nghttp2_session_del(s);
+        if (conn.callbacks) |cb| c.nghttp2_session_callbacks_del(cb);
+        conn.allocator.destroy(conn);
+    }
+
+    pub fn isClosed(conn: *Connection) bool {
+        return conn.closed.load(.acquire);
+    }
+
+    /// Submit a request on `stream` and block until the response is complete or
+    /// the stream fails. The caller owns `stream` and its arena.
+    pub fn request(conn: *Connection, stream: *Stream) !void {
+        _ = conn.active.fetchAdd(1, .acq_rel);
+        conn.events.putOne(conn.io, .{ .submit = stream }) catch {
+            _ = conn.active.fetchSub(1, .acq_rel);
+            return error.Http2ConnectionClosed;
+        };
+        stream.done.wait(conn.io) catch |err| {
+            // Cancellation while waiting: the session coroutine may still touch
+            // the stream, so the caller must not free it here. Mark the
+            // connection unusable so it is retired rather than reused.
+            conn.closed.store(true, .release);
+            return err;
+        };
+    }
+
+    /// Release a completed stream. Must be called after `request` returns.
+    pub fn releaseStream(conn: *Connection, stream: *Stream) void {
+        _ = conn.active.fetchSub(1, .acq_rel);
+        _ = stream;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Session coroutine
+// ---------------------------------------------------------------------------
+
+fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
+    const io = conn.io;
+
+    submitSettings(conn) catch {
+        fatalAll(conn, error.Http2Init);
+        return;
+    };
+    drainSend(conn) catch {
+        fatalAll(conn, error.Http2ConnectionClosed);
+        return;
+    };
+
+    while (true) {
+        const ev = conn.events.getOne(io) catch return; // Closed or Canceled
+        switch (ev) {
+            .submit => |s| handleSubmit(conn, s),
+            .net_data => |bytes| {
+                const rv = c.nghttp2_session_mem_recv2(conn.session, bytes.ptr, bytes.len);
+                conn.consumed.set(io); // let the net-reader toss and read more
+                if (rv < 0) {
+                    log.debug("mem_recv2 failed: {s}", .{c.nghttp2_strerror(@intCast(rv))});
+                    fatalAll(conn, error.Http2Protocol);
+                    return;
+                }
+            },
+            .net_eof => {
+                fatalAll(conn, error.Http2IncompleteResponse);
+                return;
+            },
+            .net_err => {
+                fatalAll(conn, error.Http2ConnectionClosed);
+                return;
+            },
+        }
+
+        drainSend(conn) catch {
+            fatalAll(conn, error.Http2ConnectionClosed);
+            return;
+        };
+
+        // The peer closed the session cleanly (e.g. GOAWAY then no more work).
+        if (c.nghttp2_session_want_read(conn.session) == 0 and
+            c.nghttp2_session_want_write(conn.session) == 0)
+        {
+            fatalAll(conn, error.Http2ConnectionClosed);
+            return;
+        }
+    }
+}
+
+fn submitSettings(conn: *Connection) !void {
+    // Client preface SETTINGS (mandatory, first frame). Disable push and
+    // advertise a 1 MiB initial stream window.
+    const iv = [_]c.nghttp2_settings_entry{
+        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_ENABLE_PUSH), .value = 0 },
+        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE), .value = 1 << 20 },
+    };
+    if (c.nghttp2_submit_settings(conn.session, @intCast(c.NGHTTP2_FLAG_NONE), &iv, iv.len) != 0) {
+        return error.Http2Init;
+    }
+}
+
+fn handleSubmit(conn: *Connection, s: *Stream) void {
+    const arena = s.arena;
+
+    var nva: std.ArrayListUnmanaged(c.nghttp2_nv) = .empty;
+    addNv(&nva, arena, ":method", s.method.name()) catch return s.finish(error.Http2Init);
+    addNv(&nva, arena, ":scheme", s.scheme) catch return s.finish(error.Http2Init);
+    addNv(&nva, arena, ":authority", s.authority) catch return s.finish(error.Http2Init);
+    addNv(&nva, arena, ":path", s.path) catch return s.finish(error.Http2Init);
+    if (s.req_headers) |hs| {
+        for (hs.keys[0..hs.len], hs.values[0..hs.len]) |k, v| {
+            if (isSkippedHeader(k)) continue;
+            const lower = std.ascii.allocLowerString(arena, k) catch return s.finish(error.Http2Init);
+            addNv(&nva, arena, lower, v) catch return s.finish(error.Http2Init);
+        }
+    }
+
+    var data_prd: c.nghttp2_data_provider = .{
+        .source = .{ .ptr = s },
+        .read_callback = readReqBody,
+    };
+    const prd_ptr: [*c]const c.nghttp2_data_provider =
+        if (s.req_body.len > 0) &data_prd else null;
+
+    const sid = c.nghttp2_submit_request(conn.session, null, nva.items.ptr, nva.items.len, prd_ptr, s);
+    if (sid < 0) {
+        log.debug("submit_request failed: {s}", .{c.nghttp2_strerror(sid)});
+        return s.finish(error.Http2Protocol);
+    }
+    s.stream_id = sid;
+    conn.streams.append(&s.node);
+}
+
+fn drainSend(conn: *Connection) !void {
+    while (c.nghttp2_session_want_write(conn.session) != 0) {
+        var data: [*c]const u8 = undefined;
+        const n = c.nghttp2_session_mem_send2(conn.session, &data);
+        if (n < 0) return error.Http2Protocol;
+        if (n == 0) break;
+        try conn.writer.writeAll(data[0..@intCast(n)]);
+    }
+    try conn.writer.flush();
+}
+
+/// Fail every in-flight stream and mark the connection closed.
+fn fatalAll(conn: *Connection, err: anyerror) void {
+    conn.closed.store(true, .release);
+    var it = conn.streams.first;
+    while (it) |node| {
+        it = node.next;
+        const s: *Stream = @fieldParentPtr("node", node);
+        conn.streams.remove(node);
+        s.finish(err);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Net-reader coroutine
+// ---------------------------------------------------------------------------
+
+fn netReaderLoop(conn: *Connection) std.Io.Cancelable!void {
+    const io = conn.io;
+    while (true) {
+        const buffered = conn.reader.buffered();
+        if (buffered.len > 0) {
+            conn.events.putOne(io, .{ .net_data = buffered }) catch return; // Closed/Canceled
+            conn.consumed.wait(io) catch return;
+            conn.consumed.reset();
+            conn.reader.toss(buffered.len);
+        } else {
+            conn.reader.fillMore() catch |err| switch (err) {
+                error.EndOfStream => {
+                    conn.events.putOne(io, .net_eof) catch {};
+                    return;
+                },
+                // ReadFailed also covers cancellation during teardown; the real
+                // cause is stashed in the underlying reader. Either way we stop.
+                else => {
+                    conn.events.putOne(io, .net_err) catch {};
+                    return;
+                },
+            };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// nghttp2 callbacks (run on the session coroutine, inside mem_recv2)
+// ---------------------------------------------------------------------------
 
 fn streamFor(session: ?*c.nghttp2_session, stream_id: i32) ?*Stream {
     const ptr = c.nghttp2_session_get_stream_user_data(session, stream_id) orelse return null;
@@ -92,19 +413,15 @@ fn onHeader(
     const n = name[0..namelen];
     const v = value[0..valuelen];
 
-    // Pseudo-headers (":status", etc.) are not stored as regular headers.
     if (n.len > 0 and n[0] == ':') {
         if (std.mem.eql(u8, n, ":status")) {
             const code = std.fmt.parseInt(u16, v, 10) catch return 0;
-            // Status is an exhaustive enum; map unknown codes defensively rather
-            // than risk illegal behavior from a bare @enumFromInt.
             if (std.enums.fromInt(Status, code)) |st| s.parsed.status = st;
         }
         return 0;
     }
 
-    // Regular header: nghttp2's buffers are only valid during this callback, so
-    // copy into the response arena before storing.
+    // nghttp2's buffers are valid only during this callback; copy before storing.
     const name_copy = s.arena.dupe(u8, n) catch {
         s.alloc_failed = true;
         return c.NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -113,8 +430,7 @@ fn onHeader(
         s.alloc_failed = true;
         return c.NGHTTP2_ERR_CALLBACK_FAILURE;
     };
-    // Ignore overflow past max_header_count (matches HTTP/1.1 leniency).
-    s.parsed.headers.add(name_copy, value_copy) catch {};
+    s.parsed.headers.add(name_copy, value_copy) catch {}; // ignore overflow
     return 0;
 }
 
@@ -147,10 +463,20 @@ fn onStreamClose(
     error_code: u32,
     user_data: ?*anyopaque,
 ) callconv(.c) c_int {
-    _ = user_data;
+    const conn: *Connection = @ptrCast(@alignCast(user_data.?));
     const s = streamFor(session, stream_id) orelse return 0;
     s.close_error = error_code;
-    s.done = true;
+    conn.streams.remove(&s.node);
+
+    var err: ?anyerror = null;
+    if (s.alloc_failed) {
+        err = error.Http2Init;
+    } else if (error_code != 0) {
+        err = error.Http2StreamReset;
+    } else if (s.too_large) {
+        err = error.ResponseTooLarge;
+    }
+    s.finish(err);
     return 0;
 }
 
@@ -177,6 +503,10 @@ fn readReqBody(
     return @intCast(n);
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 fn addNv(
     list: *std.ArrayListUnmanaged(c.nghttp2_nv),
     arena: std.mem.Allocator,
@@ -196,8 +526,7 @@ fn addNv(
     });
 }
 
-/// Headers that must not be forwarded as HTTP/2 fields (carried as pseudo-headers
-/// or forbidden by RFC 9113 §8.2.2).
+/// Headers carried as pseudo-headers or forbidden as HTTP/2 fields (RFC 9113 §8.2.2).
 fn isSkippedHeader(name: []const u8) bool {
     const skip = [_][]const u8{
         "host",              "connection", "keep-alive", "proxy-connection",
@@ -207,138 +536,4 @@ fn isSkippedHeader(name: []const u8) bool {
         if (std.ascii.eqlIgnoreCase(name, s)) return true;
     }
     return false;
-}
-
-/// Perform a single HTTP/2 request over an already-established (ALPN-negotiated)
-/// connection and return the fully-buffered response body. Status and headers
-/// are written into `parsed`. Drives the nghttp2 session synchronously: this
-/// owns the reader/writer for the duration of the call (one request at a time).
-pub fn fetchBuffered(
-    reader: *std.Io.Reader,
-    writer: *std.Io.Writer,
-    arena: std.mem.Allocator,
-    info: RequestInfo,
-    parsed: *ParsedResponse,
-    max_body: usize,
-    max_header_count: usize,
-) (Http2Error || error{ ReadFailed, WriteFailed })![]const u8 {
-    parsed.headers = Headers.init(arena, max_header_count) catch return error.Http2Init;
-    parsed.version_major = 2;
-    parsed.version_minor = 0;
-
-    var callbacks: ?*c.nghttp2_session_callbacks = null;
-    if (c.nghttp2_session_callbacks_new(&callbacks) != 0) return error.Http2Init;
-    defer c.nghttp2_session_callbacks_del(callbacks);
-    c.nghttp2_session_callbacks_set_on_header_callback(callbacks, onHeader);
-    c.nghttp2_session_callbacks_set_on_data_chunk_recv_callback(callbacks, onDataChunk);
-    c.nghttp2_session_callbacks_set_on_stream_close_callback(callbacks, onStreamClose);
-
-    var stream: Stream = .{
-        .arena = arena,
-        .parsed = parsed,
-        .max_body = max_body,
-        .req_body = info.body orelse &.{},
-    };
-
-    var session: ?*c.nghttp2_session = null;
-    if (c.nghttp2_session_client_new(&session, callbacks, null) != 0) return error.Http2Init;
-    defer c.nghttp2_session_del(session);
-
-    // Client connection preface: SETTINGS is mandatory and must be the first
-    // frame. Disable server push (we don't support it) and advertise a 1 MiB
-    // stream window.
-    const iv = [_]c.nghttp2_settings_entry{
-        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_ENABLE_PUSH), .value = 0 },
-        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE), .value = 1 << 20 },
-    };
-    if (c.nghttp2_submit_settings(session, @intCast(c.NGHTTP2_FLAG_NONE), &iv, iv.len) != 0) {
-        return error.Http2Init;
-    }
-
-    // Build the request header list (pseudo-headers first, then user headers).
-    var nva: std.ArrayListUnmanaged(c.nghttp2_nv) = .empty;
-    addNv(&nva, arena, ":method", info.method.name()) catch return error.Http2Init;
-    addNv(&nva, arena, ":scheme", info.scheme) catch return error.Http2Init;
-    addNv(&nva, arena, ":authority", info.authority) catch return error.Http2Init;
-    addNv(&nva, arena, ":path", info.path) catch return error.Http2Init;
-    if (info.headers) |hs| {
-        for (hs.keys[0..hs.len], hs.values[0..hs.len]) |k, v| {
-            if (isSkippedHeader(k)) continue;
-            const lower = std.ascii.allocLowerString(arena, k) catch return error.Http2Init;
-            addNv(&nva, arena, lower, v) catch return error.Http2Init;
-        }
-    }
-
-    // Attach a DATA provider only when there is a request body.
-    var data_prd: c.nghttp2_data_provider = .{
-        .source = .{ .ptr = &stream },
-        .read_callback = readReqBody,
-    };
-    const prd_ptr: [*c]const c.nghttp2_data_provider = if (info.body != null) &data_prd else null;
-
-    const stream_id = c.nghttp2_submit_request(session, null, nva.items.ptr, nva.items.len, prd_ptr, &stream);
-    if (stream_id < 0) {
-        log.debug("nghttp2_submit_request failed: {s}", .{c.nghttp2_strerror(stream_id)});
-        return error.Http2Protocol;
-    }
-
-    try drive(session, &stream, reader, writer);
-
-    if (stream.alloc_failed) return error.Http2Init;
-    if (stream.too_large) return error.ResponseTooLarge;
-    if (stream.close_error != 0) return error.Http2StreamReset;
-
-    // Derive content metadata exactly like the HTTP/1.1 parser does.
-    if (parsed.headers.get("Content-Type")) |ct| parsed.content_type = ContentType.fromContentType(ct);
-    if (parsed.headers.get("Content-Encoding")) |ce| parsed.content_encoding = ContentEncoding.fromString(ce);
-
-    return stream.body.items;
-}
-
-/// The synchronous send/recv loop: flush everything nghttp2 wants to send, then
-/// read and feed bytes, until the stream completes.
-fn drive(
-    session: ?*c.nghttp2_session,
-    stream: *Stream,
-    reader: *std.Io.Reader,
-    writer: *std.Io.Writer,
-) (Http2Error || error{ ReadFailed, WriteFailed })!void {
-    while (true) {
-        // Send: drain all pending output frames.
-        while (c.nghttp2_session_want_write(session) != 0) {
-            var data: [*c]const u8 = undefined;
-            const n = c.nghttp2_session_mem_send2(session, &data);
-            if (n < 0) return error.Http2Protocol;
-            if (n == 0) break;
-            writer.writeAll(data[0..@intCast(n)]) catch return error.WriteFailed;
-        }
-        writer.flush() catch return error.WriteFailed;
-
-        if (stream.done) return;
-        if (stream.alloc_failed) return;
-
-        if (c.nghttp2_session_want_read(session) == 0 and c.nghttp2_session_want_write(session) == 0) {
-            // Session is idle but the stream never completed.
-            return error.Http2IncompleteResponse;
-        }
-
-        // Receive: feed buffered bytes to nghttp2, or block for more.
-        const buffered = reader.buffered();
-        if (buffered.len > 0) {
-            const rv = c.nghttp2_session_mem_recv2(session, buffered.ptr, buffered.len);
-            if (rv < 0) {
-                log.debug("nghttp2_session_mem_recv2 failed: {s}", .{c.nghttp2_strerror(@intCast(rv))});
-                return error.Http2Protocol;
-            }
-            reader.toss(@intCast(rv));
-        } else {
-            reader.fillMore() catch |err| switch (err) {
-                error.EndOfStream => {
-                    if (stream.done) return;
-                    return error.Http2IncompleteResponse;
-                },
-                else => return error.ReadFailed,
-            };
-        }
-    }
 }

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -588,7 +588,14 @@ fn onHeader(
         s.alloc_failed = true;
         return c.NGHTTP2_ERR_CALLBACK_FAILURE;
     };
-    s.parsed.headers.add(name_copy, value_copy) catch {}; // ignore overflow
+    s.parsed.headers.add(name_copy, value_copy) catch {
+        // Too many response headers (past max_response_header_count). Reset just
+        // this stream rather than failing the whole connection: returning
+        // CALLBACK_FAILURE here would tear down every multiplexed stream, so use
+        // TEMPORAL_CALLBACK_FAILURE, which makes nghttp2 RST only this stream.
+        if (s.err == null) s.err = error.TooManyHeaders;
+        return c.NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
+    };
     return 0;
 }
 

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -371,16 +371,16 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
         conn.dropRef();
     }
     nr_group.concurrent(io, netReaderLoop, .{conn}) catch {
-        fatalAll(conn, error.Http2Init);
+        shutdown(conn, error.Http2Init);
         return;
     };
 
     submitSettings(conn) catch {
-        fatalAll(conn, error.Http2Init);
+        shutdown(conn, error.Http2Init);
         return;
     };
     drainSend(conn) catch {
-        fatalAll(conn, error.Http2ConnectionClosed);
+        shutdown(conn, error.Http2ConnectionClosed);
         return;
     };
 
@@ -389,7 +389,7 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
         // headers_done/done or on a body read) before unwinding. Cancellation
         // must still propagate — never swallow error.Canceled.
         const ev = conn.events.getOne(io) catch |err| {
-            fatalAll(conn, error.Http2ConnectionClosed);
+            shutdown(conn, error.Http2ConnectionClosed);
             if (err == error.Canceled) return error.Canceled;
             return; // error.Closed
         };
@@ -407,22 +407,22 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
                 conn.consumed.set(io); // let the net-reader toss and read more
                 if (rv < 0) {
                     log.debug("mem_recv2 failed: {s}", .{c.nghttp2_strerror(@intCast(rv))});
-                    fatalAll(conn, error.Http2Protocol);
+                    shutdown(conn, error.Http2Protocol);
                     return;
                 }
             },
             .net_eof => {
-                fatalAll(conn, error.Http2IncompleteResponse);
+                shutdown(conn, error.Http2IncompleteResponse);
                 return;
             },
             .net_err => {
-                fatalAll(conn, error.Http2ConnectionClosed);
+                shutdown(conn, error.Http2ConnectionClosed);
                 return;
             },
         }
 
         drainSend(conn) catch {
-            fatalAll(conn, error.Http2ConnectionClosed);
+            shutdown(conn, error.Http2ConnectionClosed);
             return;
         };
 
@@ -430,7 +430,7 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
         if (c.nghttp2_session_want_read(conn.session) == 0 and
             c.nghttp2_session_want_write(conn.session) == 0)
         {
-            fatalAll(conn, error.Http2ConnectionClosed);
+            shutdown(conn, error.Http2ConnectionClosed);
             return;
         }
     }
@@ -489,6 +489,31 @@ fn drainSend(conn: *Connection) !void {
         try conn.writer.writeAll(data[0..@intCast(n)]);
     }
     try conn.writer.flush();
+}
+
+/// Terminal cleanup for any path where the session coroutine is about to
+/// return. Rejects further submits, fails every queued-but-unlinked `.submit`
+/// (whose caller is blocked on `headers_done` and would otherwise hang), then
+/// fails every in-flight (linked) stream.
+fn shutdown(conn: *Connection, err: anyerror) void {
+    // Close the queue so future `request()` puts return error.Closed (mapped to
+    // Http2ConnectionClosed) instead of enqueuing a submit no one will handle.
+    // Buffered events are still drained by getOne before Closed is reported.
+    conn.events.close(conn.io);
+    while (conn.events.getOneUncancelable(conn.io)) |ev| {
+        switch (ev) {
+            // A submit that never got linked into conn.streams: its caller is
+            // parked on headers_done. Fail it here or it waits forever.
+            .submit => |s| {
+                s.body.close(s.io);
+                s.finish(err);
+            },
+            // consume/cancel reference streams we're failing anyway; net_* are
+            // terminal signals we're already acting on. Nothing to drain.
+            else => {},
+        }
+    } else |_| {} // error.Closed: queue fully drained.
+    fatalAll(conn, err);
 }
 
 /// Fail every in-flight stream and mark the connection closed.

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -43,8 +43,17 @@ const c = @import("nghttp2");
 const log = std.log.scoped(.dusty_h2);
 
 /// Backing capacity of the per-connection event queue. Holds at most one
-/// in-flight net_data item plus queued submissions.
+/// in-flight net_data item plus queued submissions/consume/cancel events.
 const event_queue_cap = 256;
+
+/// Per-stream receive window, and the size of each stream's body pipe buffer.
+/// The buffer is sized to the window so the session coroutine's pipe writes
+/// never block: HTTP/2 flow control bounds outstanding data to the window, and
+/// the window only reopens (via `nghttp2_session_consume`) as the caller reads.
+pub const stream_window_bytes = 256 * 1024;
+/// Connection-level receive window — kept large so it isn't the bottleneck
+/// across multiplexed streams (per-stream windows provide the backpressure).
+const conn_window_bytes = 16 * 1024 * 1024;
 
 pub const Http2Error = error{
     /// Failed to allocate/initialize an nghttp2 session or callbacks.
@@ -67,6 +76,11 @@ pub const Http2Error = error{
 const Event = union(enum) {
     /// A caller wants to start a request on this stream.
     submit: *Stream,
+    /// A caller consumed `n` body bytes of `stream_id`; return that flow-control
+    /// credit to the peer (emits WINDOW_UPDATE).
+    consume: struct { stream_id: i32, n: usize },
+    /// A caller is abandoning `stream_id`; send RST_STREAM.
+    cancel: i32,
     /// Decrypted bytes from the socket; the slice points into the net-reader's
     /// buffer and stays valid until the session acks via `consumed`.
     net_data: []const u8,
@@ -97,22 +111,28 @@ pub const Stream = struct {
 
     // Response (set by the session coroutine).
     parsed: ParsedResponse,
-    body: std.ArrayListUnmanaged(u8) = .empty,
-    max_body: usize,
-    too_large: bool = false,
+    /// Body pipe: the session coroutine pushes DATA frames in, the caller's
+    /// reader pulls them out. Backed by a buffer on the request arena, sized to
+    /// the stream window so pushes never block. Closed (graceful) at end-of-body.
+    body: std.Io.Queue(u8),
     alloc_failed: bool = false,
     close_error: u32 = 0,
     err: ?anyerror = null,
     stream_id: i32 = -1,
 
-    /// Set once by the session coroutine when the response is complete (or
-    /// failed); awaited by the caller.
+    /// Set when the response headers are available (or the stream failed before
+    /// them); the caller blocks on this and then reads the body via the pipe.
+    headers_done: std.Io.Event = .unset,
+    /// Set once the stream is fully finished (END_STREAM, RST, or error).
     done: std.Io.Event = .unset,
     /// Intrusive node in Connection.streams; touched only by the session coro.
     node: std.DoublyLinkedList.Node = .{},
 
+    /// Mark the stream finished: record the error, then wake both a caller still
+    /// waiting on headers and one reading the body.
     fn finish(s: *Stream, err: ?anyerror) void {
         if (err != null and s.err == null) s.err = err;
+        s.headers_done.set(s.io);
         s.done.set(s.io);
     }
 };
@@ -195,10 +215,22 @@ pub const Connection = struct {
         if (c.nghttp2_session_callbacks_new(&conn.callbacks) != 0) return error.Http2Init;
         errdefer c.nghttp2_session_callbacks_del(conn.callbacks);
         c.nghttp2_session_callbacks_set_on_header_callback(conn.callbacks, onHeader);
+        c.nghttp2_session_callbacks_set_on_frame_recv_callback(conn.callbacks, onFrameRecv);
         c.nghttp2_session_callbacks_set_on_data_chunk_recv_callback(conn.callbacks, onDataChunk);
         c.nghttp2_session_callbacks_set_on_stream_close_callback(conn.callbacks, onStreamClose);
 
-        if (c.nghttp2_session_client_new(&conn.session, conn.callbacks, conn) != 0) return error.Http2Init;
+        // Manual flow control: nghttp2 must NOT auto-send WINDOW_UPDATE. We
+        // return credit via nghttp2_session_consume only as the caller reads,
+        // which is what bounds the body pipe and provides backpressure.
+        var option: ?*c.nghttp2_option = null;
+        if (c.nghttp2_option_new(&option) != 0) return error.Http2Init;
+        defer c.nghttp2_option_del(option);
+        c.nghttp2_option_set_no_auto_window_update(option, 1);
+
+        if (c.nghttp2_session_client_new2(&conn.session, conn.callbacks, conn, option) != 0) return error.Http2Init;
+        // Raise the connection-level receive window so it doesn't throttle
+        // multiplexed streams (per-stream windows handle backpressure).
+        _ = c.nghttp2_session_set_local_window_size(conn.session, @intCast(c.NGHTTP2_FLAG_NONE), 0, conn_window_bytes);
 
         return conn;
     }
@@ -239,14 +271,15 @@ pub const Connection = struct {
         }
     }
 
-    /// Submit a request on `stream` and block until the response is complete or
-    /// the stream fails. The caller owns `stream` and its arena and must already
-    /// hold a connection reference.
+    /// Submit a request on `stream` and block until the response headers are
+    /// available (or the stream fails). The body then streams via `stream.body`.
+    /// The caller owns `stream` and its arena and must already hold a connection
+    /// reference.
     pub fn request(conn: *Connection, stream: *Stream) !void {
         conn.events.putOne(conn.io, .{ .submit = stream }) catch {
             return error.Http2ConnectionClosed;
         };
-        stream.done.wait(conn.io) catch |err| {
+        stream.headers_done.wait(conn.io) catch |err| {
             // Cancellation while waiting: the session coroutine may still touch
             // the stream, so the caller must not free it here. Retire the
             // connection so it is not reused.
@@ -255,11 +288,65 @@ pub const Connection = struct {
         };
     }
 
+    /// Post flow-control credit for `n` consumed body bytes of `stream_id`.
+    pub fn consume(conn: *Connection, stream_id: i32, n: usize) void {
+        conn.events.putOne(conn.io, .{ .consume = .{ .stream_id = stream_id, .n = n } }) catch {};
+    }
+
+    /// Ask the session to RST a stream the caller is abandoning.
+    pub fn cancelStream(conn: *Connection, stream_id: i32) void {
+        conn.events.putOne(conn.io, .{ .cancel = stream_id }) catch {};
+    }
+
     /// Drop the caller's reference once it is done with the connection. (Named
     /// for symmetry with the request lifecycle; the stream arg is unused.)
     pub fn releaseStream(conn: *Connection, stream: *Stream) void {
         _ = stream;
         conn.dropRef();
+    }
+};
+
+/// Streaming reader over a stream's body pipe. Pulls DATA bytes the session
+/// coroutine pushed, and returns flow-control credit to the peer as it reads.
+pub const BodyReader = struct {
+    stream_obj: *Stream,
+    conn: *Connection,
+    interface: std.Io.Reader,
+
+    pub fn init(stream_obj: *Stream, conn: *Connection, buffer: []u8) BodyReader {
+        return .{
+            .stream_obj = stream_obj,
+            .conn = conn,
+            .interface = .{
+                .vtable = &.{ .stream = readStream },
+                .buffer = buffer,
+                .seek = 0,
+                .end = 0,
+            },
+        };
+    }
+
+    fn readStream(io_r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+        const self: *BodyReader = @alignCast(@fieldParentPtr("interface", io_r));
+        const s = self.stream_obj;
+        const io = self.conn.io;
+
+        const dest = limit.slice(try w.writableSliceGreedy(1));
+        if (dest.len == 0) return 0;
+
+        const n = s.body.get(io, dest, 1) catch |err| switch (err) {
+            error.Closed => {
+                // Pipe drained and closed: end of body. Surface a stream error
+                // (e.g. RST mid-body) instead of a clean EOF if one was recorded.
+                if (s.err) |_| return error.ReadFailed;
+                return error.EndOfStream;
+            },
+            error.Canceled => return error.ReadFailed,
+        };
+        w.advance(n);
+        // Return the flow-control credit so the peer may send more.
+        self.conn.consume(s.stream_id, n);
+        return n;
     }
 };
 
@@ -299,6 +386,13 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
         const ev = conn.events.getOne(io) catch return; // Closed or Canceled
         switch (ev) {
             .submit => |s| handleSubmit(conn, s),
+            .consume => |x| {
+                // Ignore errors: the stream may already be closed.
+                _ = c.nghttp2_session_consume(conn.session, x.stream_id, x.n);
+            },
+            .cancel => |stream_id| {
+                _ = c.nghttp2_submit_rst_stream(conn.session, @intCast(c.NGHTTP2_FLAG_NONE), stream_id, @intCast(c.NGHTTP2_CANCEL));
+            },
             .net_data => |bytes| {
                 const rv = c.nghttp2_session_mem_recv2(conn.session, bytes.ptr, bytes.len);
                 conn.consumed.set(io); // let the net-reader toss and read more
@@ -335,10 +429,10 @@ fn sessionLoop(conn: *Connection) std.Io.Cancelable!void {
 
 fn submitSettings(conn: *Connection) !void {
     // Client preface SETTINGS (mandatory, first frame). Disable push and
-    // advertise a 1 MiB initial stream window.
+    // advertise the per-stream window that matches the body pipe size.
     const iv = [_]c.nghttp2_settings_entry{
         .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_ENABLE_PUSH), .value = 0 },
-        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE), .value = 1 << 20 },
+        .{ .settings_id = @intCast(c.NGHTTP2_SETTINGS_INITIAL_WINDOW_SIZE), .value = stream_window_bytes },
     };
     if (c.nghttp2_submit_settings(conn.session, @intCast(c.NGHTTP2_FLAG_NONE), &iv, iv.len) != 0) {
         return error.Http2Init;
@@ -481,6 +575,23 @@ fn onHeader(
     return 0;
 }
 
+fn onFrameRecv(
+    session: ?*c.nghttp2_session,
+    frame: [*c]const c.nghttp2_frame,
+    user_data: ?*anyopaque,
+) callconv(.c) c_int {
+    _ = user_data;
+    // Response headers complete: hand the response to the waiting caller. (1xx
+    // informational responses use a different category and don't wake it.)
+    if (frame.*.hd.type == @as(u8, @intCast(c.NGHTTP2_HEADERS)) and
+        frame.*.headers.cat == @as(c.nghttp2_headers_category, @intCast(c.NGHTTP2_HCAT_RESPONSE)))
+    {
+        const s = streamFor(session, frame.*.hd.stream_id) orelse return 0;
+        s.headers_done.set(s.io);
+    }
+    return 0;
+}
+
 fn onDataChunk(
     session: ?*c.nghttp2_session,
     flags: u8,
@@ -492,15 +603,17 @@ fn onDataChunk(
     _ = flags;
     _ = user_data;
     const s = streamFor(session, stream_id) orelse return 0;
-    if (s.too_large) return 0;
-    if (s.body.items.len + len > s.max_body) {
-        s.too_large = true;
-        return 0;
-    }
-    s.body.appendSlice(s.arena, data[0..len]) catch {
+    // Non-blocking push (min=0). Flow control keeps outstanding data within the
+    // window, which equals the pipe capacity, so everything fits; a short write
+    // would mean a flow-control accounting bug, so fail the stream rather than
+    // silently drop bytes.
+    const placed = s.body.putUncancelable(s.io, data[0..len], 0) catch |err| switch (err) {
+        error.Closed => return 0, // reader gone; drop
+    };
+    if (placed != len) {
         s.alloc_failed = true;
         return c.NGHTTP2_ERR_CALLBACK_FAILURE;
-    };
+    }
     return 0;
 }
 
@@ -520,9 +633,9 @@ fn onStreamClose(
         err = error.Http2Init;
     } else if (error_code != 0) {
         err = error.Http2StreamReset;
-    } else if (s.too_large) {
-        err = error.ResponseTooLarge;
     }
+    // Close the body pipe (graceful: the reader drains buffered bytes, then EOF).
+    s.body.close(s.io);
     s.finish(err);
     return 0;
 }

--- a/src/http2.zig
+++ b/src/http2.zig
@@ -91,6 +91,9 @@ pub const Stream = struct {
     req_headers: ?*const Headers,
     req_body: []const u8 = &.{},
     req_sent: usize = 0,
+    /// When set, sent as the "accept-encoding" header (unless the user already
+    /// provided one).
+    accept_encoding: ?[]const u8 = null,
 
     // Response (set by the session coroutine).
     parsed: ParsedResponse,
@@ -311,12 +314,17 @@ fn handleSubmit(conn: *Connection, s: *Stream) void {
     addNv(&nva, arena, ":scheme", s.scheme) catch return s.finish(error.Http2Init);
     addNv(&nva, arena, ":authority", s.authority) catch return s.finish(error.Http2Init);
     addNv(&nva, arena, ":path", s.path) catch return s.finish(error.Http2Init);
+    var user_has_accept_encoding = false;
     if (s.req_headers) |hs| {
         for (hs.keys[0..hs.len], hs.values[0..hs.len]) |k, v| {
             if (isSkippedHeader(k)) continue;
+            if (std.ascii.eqlIgnoreCase(k, "accept-encoding")) user_has_accept_encoding = true;
             const lower = std.ascii.allocLowerString(arena, k) catch return s.finish(error.Http2Init);
             addNv(&nva, arena, lower, v) catch return s.finish(error.Http2Init);
         }
+    }
+    if (!user_has_accept_encoding) {
+        if (s.accept_encoding) |ae| addNv(&nva, arena, "accept-encoding", ae) catch return s.finish(error.Http2Init);
     }
 
     var data_prd: c.nghttp2_data_provider = .{


### PR DESCRIPTION
> **Stacked on #104** (nghttp2 + build/ALPN setup). Review/merge #104 first; this PR's diff is just the HTTP/2 client implementation on top of it.

Implements the HTTP/2 client over the nghttp2 + ALPN foundation from #104.

## What works
- GET/POST with request bodies, status, headers.
- **Request multiplexing** over a single connection per origin (shared across sequential and concurrent requests); transparent HTTP/1.1 fallback when a server doesn't negotiate `h2`.
- Redirects (h1↔h2), gzip/deflate decompression, and **streaming response bodies** with HTTP/2 flow-control backpressure (`response.reader()`).
- Public API unchanged: `client.fetch(...)` returns the same `ClientResponse`; `response.version()` reports 2.0 when h2 was used.

## Architecture (actor model)
Each connection runs a session coroutine (sole owner of the nghttp2 session) and a net-reader coroutine, communicating over one `std.Io.Queue`; callers submit a stream and block on a per-stream event, so the non-reentrant session needs no mutex. Session coroutines share one Client-owned group; each net-reader is a child of its session. Connection lifetime is reference-counted and connections self-reap when the last reference drops. Concurrent TLS read+write is safe because tls.zig keeps disjoint encrypt/decrypt cipher state.

## Verification
Tested against nghttp2.org, google.com, and cloudflare.com (incl. incremental reads of a 1.29 MB body exercising flow control, 8 concurrent requests over one connection, a redirect chain ending over h2, gzip, and mid-body abort). Leak-clean under `DebugAllocator`. Default build unchanged; full test suite passes with and without `-Duse_http2=true`.

## Deferred (follow-ups)
- No GOAWAY/connection-death request retry.
- Mid-request cancellation can leak the per-request arena.
- Automated coverage of the h2 path (currently real-server verification + a link smoke test only).