### PR TITLE
examples/zio: bump zio to v0.15.0 and add CLI options

### DIFF
--- a/examples/zio/build.zig.zon
+++ b/examples/zio/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "../..",
         },
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio?ref=v0.11.0#53abdf9ce5e6279e29703a39180ce1cedd8ac4ca",
-            .hash = "zio-0.11.0-xHbVVEqQGwDz0MYoQ0j7Ke0Y9E_iZVe5eLAWK4gd9U0i",
+            .url = "git+https://github.com/lalinsky/zio?ref=v0.15.0#d1ef67f0e9cfb6515da6770e726a7230812e7d25",
+            .hash = "zio-0.15.0-xHbVVOZuIQDCnTb07LLt5fVQN54KJjWgIgxrDu15TJ4M",
         },
     },
     .paths = .{

--- a/examples/zio/src/main.zig
+++ b/examples/zio/src/main.zig
@@ -6,14 +6,49 @@ fn handleRoot(_: *http.Request, res: *http.Response) !void {
     res.body = "Hello World!\n";
 }
 
+/// Parses `--<name>=<uint>` and returns the value, or null if `arg` doesn't
+/// match the flag or the value doesn't parse.
+fn uintFlag(arg: []const u8, comptime name: []const u8) ?u64 {
+    const prefix = "--" ++ name ++ "=";
+    if (!std.mem.startsWith(u8, arg, prefix)) return null;
+    return std.fmt.parseUnsigned(u64, arg[prefix.len..], 10) catch null;
+}
+
 pub fn main(init: std.process.Init) !void {
-    var rt = try zio.Runtime.init(init.gpa, .{ .executors = .auto });
+    // Options (all optional):
+    //   --threads=N             executor threads (default: auto = all cores)
+    //   --request-timeout=SECS  max time to receive a request (default: none)
+    //   --keepalive-timeout=SECS max idle time on a keepalive connection (default: none)
+    var threads: usize = 0; // 0 = auto
+    var request_timeout: ?std.Io.Duration = null;
+    var keepalive_timeout: ?std.Io.Duration = null;
+    {
+        var args = try init.minimal.args.iterateAllocator(init.gpa);
+        defer args.deinit();
+        _ = args.next(); // argv0
+        while (args.next()) |arg| {
+            if (uintFlag(arg, "threads")) |v| {
+                threads = @intCast(v);
+            } else if (uintFlag(arg, "request-timeout")) |v| {
+                request_timeout = .fromSeconds(@intCast(v));
+            } else if (uintFlag(arg, "keepalive-timeout")) |v| {
+                keepalive_timeout = .fromSeconds(@intCast(v));
+            } else {
+                std.log.warn("ignoring unknown argument: {s}", .{arg});
+            }
+        }
+    }
+
+    var rt = if (threads == 0)
+        try zio.Runtime.init(init.gpa, .{ .executors = .auto })
+    else
+        try zio.Runtime.init(init.gpa, .{ .executors = .exact(@intCast(threads)) });
     defer rt.deinit();
 
     var server = http.Server(void).init(init.gpa, rt.io(), .{
         .timeout = .{
-            .request = .fromSeconds(30),
-            .keepalive = .fromSeconds(5),
+            .request = request_timeout,
+            .keepalive = keepalive_timeout,
         },
     }, {});
     defer server.deinit();
@@ -21,6 +56,10 @@ pub fn main(init: std.process.Init) !void {
     server.router.get("/", handleRoot);
 
     const addr: http.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 8080) };
-    std.log.info("Starting server on http://127.0.0.1:8080", .{});
+    std.log.info("Starting server on http://127.0.0.1:8080 (threads={d}, request_timeout={}, keepalive_timeout={})", .{
+        threads,
+        request_timeout != null,
+        keepalive_timeout != null,
+    });
     try server.listen(addr);
 }


### PR DESCRIPTION
Upgrades the standalone `examples/zio` server and makes it configurable.

## Changes
- Bump the example's `zio` dependency from **v0.11.0 → v0.15.0**.
- Add command-line options to the server:
  - `--threads=N` — executor threads (default: `auto` = all cores)
  - `--request-timeout=SECS` — max time to receive a request (default: none)
  - `--keepalive-timeout=SECS` — max idle time on keepalive connections (default: none)

Timeouts default to disabled and can be enabled via the flags, so the example runs
with no per-request timeout overhead out of the box while still demonstrating how to
configure them.

## Notes
Builds and runs on Zig 0.16.0 against zio v0.15.0. The zio native API needed no
changes across the version bump.