### PR TITLE
Client: evict dead connections from the pool on write/parse failure

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -872,8 +872,10 @@ pub const Client = struct {
             return error.Http2NotImplemented;
         }
 
-        // Send request
-        try writeRequest(conn.writer, .{
+        // Send request. On write/flush failure the connection is dead or has
+        // a partially written request, so mark it closing before the errdefer
+        // releases it — otherwise it gets pooled again and poisons the pool.
+        writeRequest(conn.writer, .{
             .method = state.options.method,
             .uri = state.uri,
             .host = host,
@@ -886,14 +888,24 @@ pub const Client = struct {
             .strip_body_headers = state.strip_body_headers,
             .referer = state.referer,
             .user_agent = self.config.user_agent,
-        });
+        }) catch |err| {
+            conn.closing = true;
+            return err;
+        };
 
-        try conn.flush();
+        conn.flush() catch |err| {
+            conn.closing = true;
+            return err;
+        };
 
-        // Parse response headers
-        parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {
-            error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
-            else => |e| return e,
+        // Parse response headers. Any failure leaves the connection at an
+        // unknown stream position, so it must not be pooled.
+        parseResponseHeaders(conn.reader, &conn.parser) catch |err| {
+            conn.closing = true;
+            switch (err) {
+                error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
+                else => |e| return e,
+            }
         };
 
         // Check for unsupported content encoding

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -167,6 +167,64 @@ test "Client: connection pooling" {
     try client_future.await(io);
 }
 
+test "Client: pool evicts dead connection after server goes away" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const port = server.address.ip.getPort();
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/test", .{port});
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{});
+    defer client.deinit();
+
+    // A healthy fetch parks a keep-alive connection in the pool.
+    {
+        var response = try client.fetch(url, .{});
+        defer response.deinit();
+
+        try std.testing.expectEqual(.ok, response.status());
+        _ = try response.body();
+    }
+    try std.testing.expectEqual(@as(usize, 1), client.pool.idle_len);
+
+    // The server goes away, killing the pooled connection.
+    server_future.cancel(io) catch {};
+
+    // The fetch over the dead pooled connection fails...
+    var failed = false;
+    if (client.fetch(url, .{})) |response| {
+        var r = response;
+        r.deinit();
+    } else |_| {
+        failed = true;
+    }
+    try std.testing.expect(failed);
+
+    // ...and the dead connection must be evicted, not returned to the pool,
+    // so the next fetch dials fresh instead of re-acquiring it forever.
+    try std.testing.expectEqual(@as(usize, 0), client.pool.idle_len);
+}
+
 test "Client: WebSocket upgrade" {
     const io = std.testing.io;
 


### PR DESCRIPTION
If a pooled keep-alive connection dies (server restart, idle close), every subsequent fetch fails with `WriteFailed` and never dials. No write-failure path sets `conn.closing`, so the `errdefer pool.release(conn)` in `fetchInternal` puts the dead connection back in the pool, and MRU `acquire` picks it again every time. The client can never recover.

Fix: mark the connection `closing` when `writeRequest`, `flush`, or `parseResponseHeaders` fails, it's dead or at an unknown stream position either way, so `release` tears it down and the next fetch dials fresh.

Includes a regression test (fails with `expected 0, found 1` before the fix).