### PR TITLE
Client: don't release the connection twice when a redirect fails after early release

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -860,9 +860,12 @@ pub const Client = struct {
             break :blk try self.ensureCaBundle();
         } else null;
 
-        // Acquire or create a connection
+        // Acquire or create a connection. The redirect path releases it early
+        // and continues with fallible work, so the errdefer must be disarmed
+        // after that release to avoid releasing the connection twice.
         const conn = try self.acquireConnection(host, state.port, state.protocol, ca_bundle, state.options.unix_socket_path, build_options.use_http2 and self.config.http2 and state.protocol == .https);
-        errdefer self.pool.release(conn);
+        var conn_released = false;
+        errdefer if (!conn_released) self.pool.release(conn);
 
         // HTTP/2 was negotiated via ALPN but the h2 path isn't implemented yet.
         // The TLS connection is already committed to h2 (we can't speak HTTP/1.1
@@ -942,6 +945,7 @@ pub const Client = struct {
                 }
                 if (!conn.parser.shouldKeepAlive()) conn.closing = true;
                 self.pool.release(conn);
+                conn_released = true;
 
                 // 301/302/303 with a non-GET/HEAD method: switch to GET and drop body.
                 // 307/308 preserve the original method and body.

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -225,6 +225,91 @@ test "Client: pool evicts dead connection after server goes away" {
     try std.testing.expectEqual(@as(usize, 0), client.pool.idle_len);
 }
 
+test "Client: redirect failing after connection release does not double-release" {
+    const io = std.testing.io;
+
+    const Ctx = struct {
+        location: []const u8,
+    };
+
+    // Find a port with no listener behind it: bind, note the port, close.
+    // Redirecting there makes the redirect fetch fail at dial time, after
+    // the first connection was already released back to the pool.
+    const dead_port = blk: {
+        const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+        var listener = try addr.listen(io, .{});
+        const p = listener.socket.address.getPort();
+        listener.deinit(io);
+        break :blk p;
+    };
+
+    var location_buf: [64]u8 = undefined;
+    var ctx: Ctx = .{
+        .location = try std.fmt.bufPrint(&location_buf, "http://127.0.0.1:{d}/", .{dead_port}),
+    };
+
+    var server = dusty.Server(Ctx).init(std.testing.allocator, io, .{}, &ctx);
+    defer server.deinit();
+
+    server.router.get("/redirect", struct {
+        fn handle(c: *Ctx, req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.status = .found;
+            try res.header("Location", c.location);
+        }
+    }.handle);
+
+    server.router.get("/ok", struct {
+        fn handle(c: *Ctx, req: *dusty.Request, res: *dusty.Response) !void {
+            _ = c;
+            _ = req;
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(Ctx)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const port = server.address.ip.getPort();
+    var url_buf: [64]u8 = undefined;
+    const redirect_url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/redirect", .{port});
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{});
+    defer client.deinit();
+
+    var failed = false;
+    if (client.fetch(redirect_url, .{})) |response| {
+        var r = response;
+        r.deinit();
+    } else |_| {
+        failed = true;
+    }
+    try std.testing.expect(failed);
+
+    // The connection was released back to the pool before the redirect
+    // failed; the failure must not release it a second time.
+    try std.testing.expectEqual(1, client.pool.idle_len);
+
+    // The pooled connection is still usable.
+    var ok_url_buf: [64]u8 = undefined;
+    const ok_url = try std.fmt.bufPrint(&ok_url_buf, "http://127.0.0.1:{d}/ok", .{port});
+    {
+        var response = try client.fetch(ok_url, .{});
+        defer response.deinit();
+
+        try std.testing.expectEqual(.ok, response.status());
+        _ = try response.body();
+    }
+    try std.testing.expectEqual(1, client.pool.idle_len);
+}
+
 test "Client: WebSocket upgrade" {
     const io = std.testing.io;
 


### PR DESCRIPTION
Fixes #111.

The redirect path in `fetchInternal` releases the connection back to the pool early (so the redirected request can reuse it) and then continues with fallible work: `uriHost` on the redirect target and the recursive `fetchInternal` call. The `errdefer self.pool.release(conn)` from connection acquisition was still armed during that window, so any error there released the connection a second time — appending the same node to the idle list twice (list corruption, inflated `idle_len`) if it was pooled, or touching freed memory if it was destroyed.

Fix: track the early release with a `conn_released` flag and disarm the errdefer once the redirect path has handed the connection back.

Includes a regression test: the server redirects to a port with no listener, so the redirected fetch fails at dial time, exactly in the post-release window. Before the fix it fails with `expected 1, found 2` (the connection was pooled twice); after the fix the pool holds the connection once and it remains usable.