### PR TITLE
Client: don't pool connections with an unread response body

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -495,6 +495,12 @@ pub const Connection = struct {
 
     /// Release this connection back to its pool, handling keep-alive logic.
     pub fn release(self: *Connection) void {
+        // A response body that wasn't fully read leaves the connection at an
+        // unknown stream position, so it must not be reused.
+        if (!self.parser.isBodyComplete()) {
+            self.closing = true;
+        }
+
         // Increment request count
         self.request_count +|= 1;
 

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -310,6 +310,58 @@ test "Client: redirect failing after connection release does not double-release"
     try std.testing.expectEqual(1, client.pool.idle_len);
 }
 
+test "Client: connection with unread response body is not pooled" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "some response body";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const port = server.address.ip.getPort();
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/test", .{port});
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{});
+    defer client.deinit();
+
+    // Deinit the response without reading the body: the connection sits at
+    // an unknown stream position and must be closed, not pooled, or the
+    // next request on it would read leftover body bytes as its response.
+    {
+        var response = try client.fetch(url, .{});
+        defer response.deinit();
+
+        try std.testing.expectEqual(.ok, response.status());
+    }
+    try std.testing.expectEqual(0, client.pool.idle_len);
+
+    // A fully read response is still pooled as usual.
+    {
+        var response = try client.fetch(url, .{});
+        defer response.deinit();
+
+        try std.testing.expectEqual(.ok, response.status());
+        _ = try response.body();
+    }
+    try std.testing.expectEqual(1, client.pool.idle_len);
+}
+
 test "Client: WebSocket upgrade" {
     const io = std.testing.io;
 


### PR DESCRIPTION
Fixes #112.

`Connection.release` — the path taken by `ClientResponse.deinit()` — checked `shouldKeepAlive()` and the Keep-Alive `max` count, but never `parser.isBodyComplete()`. Deiniting a response without fully reading the body (or after a streaming read failed mid-stream) returned the connection to the pool with unread body bytes still on the wire, i.e. at an unknown stream position. The next request on that connection would parse leftover body bytes as its response. `fetchInternal` already guards its internal paths with exactly this check; only the user-facing deinit path was missing it.

Fix: mark the connection `closing` in `Connection.release` when the body is incomplete, so the pool tears it down instead of reusing it.

Includes a regression test: fetch, deinit without reading the body, and assert the connection was closed rather than pooled (fails with `expected 0, found 1` before the fix), plus a check that a fully read response is still pooled as before.

Possible follow-up (not done here): drain small unread remainders before pooling, like the redirect path already does with its 2KB drain, so status-only fetches with small bodies keep benefiting from keep-alive.