### PR TITLE
Server: replace the shutdown drain event with a futex wait on the connection count

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -44,10 +44,9 @@ pub fn Server(comptime Ctx: type) type {
         ctx: if (Ctx == void) void else *Ctx,
         config: ServerConfig,
         shutting_down: std.atomic.Value(bool),
-        active_connections: std.atomic.Value(usize),
+        active_connections: std.atomic.Value(u32),
         address: Address,
         ready: std.Io.Event,
-        last_connection_closed: std.Io.Event,
         _middleware_registry: std.SinglyLinkedList,
         /// Server certificate/key, loaded once in listen() when config.tls is set.
         tls_auth: ?tls.config.CertKeyPair = null,
@@ -60,10 +59,9 @@ pub fn Server(comptime Ctx: type) type {
                 .ctx = ctx,
                 .config = config,
                 .shutting_down = std.atomic.Value(bool).init(false),
-                .active_connections = std.atomic.Value(usize).init(0),
+                .active_connections = std.atomic.Value(u32).init(0),
                 .address = undefined,
                 .ready = .unset,
-                .last_connection_closed = .unset,
                 ._middleware_registry = .{},
             };
         }
@@ -157,13 +155,15 @@ pub fn Server(comptime Ctx: type) type {
                         log.info("Graceful shutdown requested", .{});
                         self.shutting_down.store(true, .release);
                         while (true) { // TODO: add graceful shutdown timeout
-                            // Re-arm the latched event, or waitTimeout returns
-                            // immediately forever once any connection has closed.
-                            self.last_connection_closed.reset();
                             const remaining = self.active_connections.load(.acquire);
                             if (remaining == 0) break;
                             log.info("Waiting for {} remaining connections to close", .{remaining});
-                            try self.last_connection_closed.waitTimeout(self.io, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } });
+                            // Returns immediately if the count already changed, otherwise
+                            // blocks until a close wakes it or the timeout expires.
+                            try self.io.futexWaitTimeout(u32, &self.active_connections.raw, remaining, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } });
+                            // No connection closed within the timeout. Let the deferred
+                            // group.cancel tear down the remaining handlers.
+                            if (self.active_connections.load(.acquire) == remaining) return error.Timeout;
                         }
                         return err;
                     }
@@ -189,10 +189,8 @@ pub fn Server(comptime Ctx: type) type {
 
         pub fn handleConnection(self: *Self, stream: std.Io.net.Stream) !void {
             defer {
-                const v = self.active_connections.fetchSub(1, .acq_rel);
-                if (v == 1) {
-                    self.last_connection_closed.set(self.io);
-                }
+                _ = self.active_connections.fetchSub(1, .acq_rel);
+                self.io.futexWake(u32, &self.active_connections.raw, 1);
             }
 
             defer stream.close(self.io);

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -447,13 +447,6 @@ test "Server: void context handlers" {
 test "Server: graceful shutdown drain still blocks after an earlier connection closed" {
     const io = std.testing.io;
 
-    // `last_connection_closed` latches once set. Before the fix, any
-    // connection closing at any earlier point in the server's life made the
-    // drain's waitTimeout return immediately forever, so the drain loop
-    // busy-spun instead of blocking, and the 100ms shutdown timeout could
-    // never fire. This test latches the event with a short-lived connection,
-    // then shuts down while a slow handler is active: the drain must block
-    // and propagate error.Timeout, not spin until the handler finishes.
     const sync = struct {
         var slow_started: std.Io.Event = .unset;
     };
@@ -489,7 +482,7 @@ test "Server: graceful shutdown drain still blocks after an earlier connection c
 
     try server.ready.wait(io);
 
-    // A short-lived connection closes, latching last_connection_closed.
+    // A connection closes before shutdown begins.
     {
         const stream = try server.address.ip.connect(io, .{ .mode = .stream });
         defer stream.close(io);
@@ -523,9 +516,8 @@ test "Server: graceful shutdown drain still blocks after an earlier connection c
 
     try sync.slow_started.wait(io);
 
-    // Graceful shutdown: the drain must block on the (re-armed) event and hit
-    // its 100ms timeout long before the 2s handler completes. Before the fix
-    // the latched event made the wait a no-op, so the drain spun hot until
+    // Graceful shutdown: the drain must block and hit its 100ms timeout long
+    // before the 2s handler completes. Before the fix the drain spun hot until
     // the handler finished and returned error.Canceled instead.
     const start = std.Io.Timestamp.now(io, .awake);
     try std.testing.expectError(error.Timeout, server_future.cancel(io));


### PR DESCRIPTION
Sorry, I was going to respond and implement this but I was at work! Agree that the futex is the better shape ([#110](https://github.com/lalinsky/dusty/pull/110#issuecomment-4933559836)).

Here is a fresh PR to make up for it. Also, `futexWaitTimeout` doesn't distinguish wake from timeout, so I recheck the count after the wait and return `error.Timeout` if it didn't change, which preserves existing shutdown behavior.
