### PR TITLE
Client: guard the connection pool with a mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - Added TLS support to both the client and server.
 - Fix memory leak in WebSocket clients: message allocations are now freed before each `receive()` call instead of accumulating for the lifetime of the connection.
 - Added default `User-Agent` header to HTTP client.
+- Fix connection pool corruption when a `Client` is shared by tasks running in parallel. `ConnectionPool` list and counter updates are now guarded by a mutex.
+- `ConnectionPool.init` now takes an `std.Io`, and `ConnectionPool.acquire` no longer does.
 
 ## [0.2.0] - 2026-04-26
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -184,15 +184,26 @@ fn uriPath(uri: Uri) []const u8 {
 }
 
 /// Pool of idle connections for reuse.
+///
+/// `acquire`/`release` are safe to call from multiple tasks running in
+/// parallel: `idle`/`idle_len` are guarded by `mutex`, and the critical
+/// sections only touch the list, so they never suspend. Closing an evicted
+/// connection does suspend, so that always happens after the lock has been
+/// dropped. `init`/`deinit` are not part of that contract — they must not run
+/// concurrently with `acquire`/`release`.
 pub const ConnectionPool = struct {
     allocator: std.mem.Allocator,
+    io: std.Io,
+    mutex: std.Io.Mutex,
     idle: std.DoublyLinkedList,
     idle_len: usize,
     max_idle: u8,
 
-    pub fn init(allocator: std.mem.Allocator, max_idle: u8) ConnectionPool {
+    pub fn init(allocator: std.mem.Allocator, io: std.Io, max_idle: u8) ConnectionPool {
         return .{
             .allocator = allocator,
+            .io = io,
+            .mutex = .init,
             .idle = .{},
             .idle_len = 0,
             .max_idle = max_idle,
@@ -209,34 +220,49 @@ pub const ConnectionPool = struct {
     }
 
     /// Try to acquire an existing connection for the given host:port, protocol, and optional unix socket path.
-    pub fn acquire(self: *ConnectionPool, io: std.Io, remote_host: []const u8, remote_port: u16, protocol: Protocol, unix_socket_path: ?[]const u8) ?*Connection {
+    pub fn acquire(self: *ConnectionPool, remote_host: []const u8, remote_port: u16, protocol: Protocol, unix_socket_path: ?[]const u8) ?*Connection {
+        const io = self.io;
         const now = std.Io.Timestamp.now(io, .awake);
 
-        // Search from end (most recently used)
-        var node = self.idle.last;
-        while (node) |n| {
-            const conn: *Connection = @alignCast(@fieldParentPtr("pool_node", n));
-            node = n.prev;
+        // Connections found expired along the way. They are already out of the
+        // pool and owned by us, so they get closed after the lock is dropped.
+        var expired: std.DoublyLinkedList = .{};
 
-            if (conn.matches(remote_host, remote_port, protocol, unix_socket_path)) {
-                // Check if connection has expired due to idle timeout
-                if (conn.idle_deadline) |deadline| {
-                    if (now.nanoseconds >= deadline.nanoseconds) {
-                        // Connection expired, remove and close it
-                        self.idle.remove(n);
-                        self.idle_len -= 1;
-                        conn.deinit();
-                        self.allocator.destroy(conn);
-                        continue;
+        const found = found: {
+            self.mutex.lockUncancelable(io);
+            defer self.mutex.unlock(io);
+
+            // Search from end (most recently used)
+            var node = self.idle.last;
+            while (node) |n| {
+                const conn: *Connection = @alignCast(@fieldParentPtr("pool_node", n));
+                node = n.prev;
+
+                if (conn.matches(remote_host, remote_port, protocol, unix_socket_path)) {
+                    self.idle.remove(n);
+                    self.idle_len -= 1;
+
+                    // Check if connection has expired due to idle timeout
+                    if (conn.idle_deadline) |deadline| {
+                        if (now.nanoseconds >= deadline.nanoseconds) {
+                            expired.append(n);
+                            continue;
+                        }
                     }
-                }
 
-                self.idle.remove(n);
-                self.idle_len -= 1;
-                return conn;
+                    break :found conn;
+                }
             }
+            break :found null;
+        };
+
+        while (expired.popFirst()) |n| {
+            const conn: *Connection = @alignCast(@fieldParentPtr("pool_node", n));
+            conn.deinit();
+            self.allocator.destroy(conn);
         }
-        return null;
+
+        return found;
     }
 
     /// Release a connection back to the pool, or close it if pool is full or connection is closing.
@@ -248,24 +274,36 @@ pub const ConnectionPool = struct {
             return;
         }
 
-        // If pool is full, close the oldest connection
-        if (self.idle_len >= self.max_idle) {
-            if (self.idle.popFirst()) |old_node| {
-                const old: *Connection = @alignCast(@fieldParentPtr("pool_node", old_node));
-                old.deinit();
-                self.allocator.destroy(old);
-                self.idle_len -= 1;
-            }
-        }
-
-        // Reset and add to pool
+        // Reset before taking the lock; it only touches this connection.
         conn.reset() catch {
             conn.deinit();
             self.allocator.destroy(conn);
             return;
         };
-        self.idle.append(&conn.pool_node);
-        self.idle_len += 1;
+
+        const evicted: ?*Connection = evicted: {
+            self.mutex.lockUncancelable(self.io);
+            defer self.mutex.unlock(self.io);
+
+            // If pool is full, evict the oldest connection
+            var old: ?*Connection = null;
+            if (self.idle_len >= self.max_idle) {
+                if (self.idle.popFirst()) |old_node| {
+                    old = @alignCast(@fieldParentPtr("pool_node", old_node));
+                    self.idle_len -= 1;
+                }
+            }
+
+            self.idle.append(&conn.pool_node);
+            self.idle_len += 1;
+            break :evicted old;
+        };
+
+        // Closing suspends, so it must happen outside the critical section.
+        if (evicted) |old| {
+            old.deinit();
+            self.allocator.destroy(old);
+        }
     }
 };
 
@@ -648,6 +686,15 @@ pub const ClientResponse = struct {
 };
 
 /// HTTP client for making requests.
+///
+/// A single client can be shared by tasks running in parallel: the connection
+/// pool and the CA bundle are both internally synchronized. Sharing one client
+/// is also what makes connection reuse and a single CA bundle scan possible.
+/// `init`/`deinit` are not part of that contract — they must not run
+/// concurrently with requests.
+///
+/// Parallel requests allocate and free concurrently, so `allocator` must be
+/// thread-safe when the client is shared that way.
 pub const Client = struct {
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -662,7 +709,7 @@ pub const Client = struct {
             .allocator = allocator,
             .io = io,
             .config = config,
-            .pool = ConnectionPool.init(allocator, config.max_idle_connections),
+            .pool = ConnectionPool.init(allocator, io, config.max_idle_connections),
             .ca_bundle = .empty,
             .ca_bundle_lock = .init,
             .ca_bundle_loaded = std.atomic.Value(bool).init(false),
@@ -720,7 +767,7 @@ pub const Client = struct {
         advertise_http2: bool,
     ) !*Connection {
         // Try to get a connection from the pool
-        const conn = self.pool.acquire(self.io, host, port, protocol, unix_socket_path) orelse blk: {
+        const conn = self.pool.acquire(host, port, protocol, unix_socket_path) orelse blk: {
             // No pooled connection, create a new one
             const stream = if (unix_socket_path) |path| unix: {
                 const unix_addr = try std.Io.net.UnixAddress.init(path);

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -362,6 +362,84 @@ test "Client: connection with unread response body is not pooled" {
     try std.testing.expectEqual(1, client.pool.idle_len);
 }
 
+test "Client: pool survives concurrent fetches on a shared client" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/test", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const port = server.address.ip.getPort();
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/test", .{port});
+
+    // More workers than idle slots, so releases keep racing against evictions.
+    const max_idle = 4;
+    const workers = 8;
+    const rounds = 20;
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{ .max_idle_connections = max_idle });
+    defer client.deinit();
+
+    const worker = struct {
+        fn run(c: *dusty.Client, u: []const u8) !void {
+            for (0..rounds) |_| {
+                var response = try c.fetch(u, .{});
+                defer response.deinit();
+
+                try std.testing.expectEqual(.ok, response.status());
+                const body = try response.body();
+                try std.testing.expectEqualStrings("OK", body.?);
+            }
+        }
+    }.run;
+
+    const WorkerFuture = std.Io.Future(@typeInfo(@TypeOf(worker)).@"fn".return_type.?);
+    var futures: [workers]WorkerFuture = undefined;
+    var started: usize = 0;
+    errdefer for (futures[0..started]) |*f| f.cancel(io) catch {};
+
+    while (started < workers) : (started += 1) {
+        futures[started] = try io.concurrent(worker, .{ &client, url });
+    }
+
+    var first_err: ?anyerror = null;
+    for (&futures) |*f| {
+        f.await(io) catch |err| {
+            if (first_err == null) first_err = err;
+        };
+    }
+    if (first_err) |err| return err;
+
+    // idle_len must still agree with the list, and must respect max_idle.
+    var counted: usize = 0;
+    var node = client.pool.idle.first;
+    while (node) |n| : (node = n.next) counted += 1;
+
+    try std.testing.expectEqual(counted, client.pool.idle_len);
+    try std.testing.expect(client.pool.idle_len <= max_idle);
+
+    // Guard against the invariants above passing on a pool that never pooled
+    // anything: connections must actually be getting reused.
+    try std.testing.expect(client.pool.idle_len > 0);
+}
+
 test "Client: WebSocket upgrade" {
     const io = std.testing.io;
 


### PR DESCRIPTION
Fixes #116.

`ConnectionPool` was a plain `std.DoublyLinkedList` plus a `usize` with no synchronization, while the rest of `Client` is written to be shared — the CA bundle already uses double-checked locking over an `std.Io.RwLock`. Under a multi-threaded `std.Io` (zio with `.executors = .auto`, or `std.Io.Threaded`), two tasks calling `fetch` on the same client interleave `acquire`/`release` at the machine level rather than at suspension points, which corrupts the list, drifts `idle_len`, and can hand the same connection to two request cycles.

## Changes

- Guard `idle`/`idle_len` with an `std.Io.Mutex`.
- The critical sections only do list surgery and never suspend. Closing a connection *does* suspend (`Connection.deinit` → `stream.close(io)`), so expired and evicted connections are collected under the lock and closed after it is dropped.
- `release()` now resets before locking. Besides keeping the fallible, allocating `reset()` out of the critical section, this fixes a pre-existing wart: under the old order a full pool had already evicted its oldest connection before `reset()` could fail, losing two connections instead of one.
- `ConnectionPool` stores its own `io`, so lock and unlock provably use the same value. Previously `acquire` took an `io` parameter while `release` read it back out of `conn.io`.

## Breaking

`ConnectionPool.init` now takes an `std.Io`, and `ConnectionPool.acquire` no longer does. `Client`'s own API is unchanged.

## Testing

New test `Client: pool survives concurrent fetches on a shared client` — 8 workers × 20 rounds against one client with `max_idle_connections = 4`, so releases keep racing evictions. It then checks `idle_len` agrees with a manual walk of the list, respects `max_idle`, and is non-zero (so the invariants can't pass on a pool that never pooled anything).

`std.testing.io` is `std.Io.Threaded`, so this is real parallelism. With the locks removed the test fails every run — `integer overflow` on the `idle_len` underflow, `reached unreachable code` from list corruption, and `BADF` from a double close. With the fix, `./check.sh` is green at 220/220.

The change was also reviewed by a subagent, which independently reproduced the failures and prompted the `io`-ownership cleanup, a note that a shared client needs a thread-safe allocator, and the non-zero test assertion.