### PR TITLE
Preserve concrete HTTP I/O errors

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -19,6 +19,31 @@ const ResponseBodyReader = @import("parser.zig").ResponseBodyReader;
 const KeepAliveParams = @import("parser.zig").KeepAliveParams;
 const parseKeepAliveHeader = @import("parser.zig").parseKeepAliveHeader;
 
+fn recoverAdapterError(marker: anyerror, fallback: anyerror, causes: []const ?anyerror) anyerror {
+    if (fallback != marker) return fallback;
+    // Prefer a concrete cause over another adapter marker. With TLS, for example,
+    // the TLS reader may hold ReadFailed while the underlying TCP reader holds
+    // Canceled.
+    for (causes) |cause| if (cause) |err| if (err != marker) return err;
+    for (causes) |cause| if (cause) |err| return err;
+    return fallback;
+}
+
+test "adapter errors recover the deepest concrete cause" {
+    try std.testing.expectEqual(error.Canceled, recoverAdapterError(
+        error.ReadFailed,
+        error.ReadFailed,
+        &.{ error.Canceled, error.ReadFailed },
+    ));
+    try std.testing.expectEqual(error.InvalidChunkSize, recoverAdapterError(
+        error.ReadFailed,
+        error.ReadFailed,
+        &.{ error.ReadFailed, error.InvalidChunkSize },
+    ));
+    try std.testing.expectEqual(error.ReadFailed, recoverAdapterError(error.ReadFailed, error.ReadFailed, &.{}));
+    try std.testing.expectEqual(error.OutOfMemory, recoverAdapterError(error.ReadFailed, error.OutOfMemory, &.{error.Canceled}));
+}
+
 /// Protocol type for HTTP/HTTPS connections.
 pub const Protocol = enum {
     http,
@@ -510,7 +535,17 @@ pub const Connection = struct {
     pub fn flush(self: *Connection) !void {
         // For HTTPS this drains the cleartext writer, which encrypts and flushes
         // the underlying TCP writer in one step; for HTTP it flushes the socket directly.
-        try self.writer.flush();
+        self.writer.flush() catch |err| return self.writeError(err);
+    }
+
+    pub fn readError(self: *const Connection, fallback: anyerror) anyerror {
+        const tls_err: ?anyerror = if (self.tls_conn != null) self.tls_reader.err else null;
+        return recoverAdapterError(error.ReadFailed, fallback, &.{ self.tcp_reader.err, tls_err });
+    }
+
+    pub fn writeError(self: *const Connection, fallback: anyerror) anyerror {
+        const tls_err: ?anyerror = if (self.tls_conn != null) self.tls_writer.err else null;
+        return recoverAdapterError(error.WriteFailed, fallback, &.{ self.tcp_writer.err, tls_err });
     }
 
     pub fn host(self: *const Connection) []const u8 {
@@ -615,6 +650,16 @@ pub const ClientResponse = struct {
         return &self.parsed.headers;
     }
 
+    /// Recover the concrete transport/parser error hidden by std.Io.Reader's
+    /// error.ReadFailed marker. Streaming callers should use this when an API fed
+    /// by reader() returns ReadFailed.
+    pub fn readError(self: *const ClientResponse, fallback: anyerror) anyerror {
+        if (fallback != error.ReadFailed) return fallback;
+        const transport_err = if (self.owner) |conn| conn.readError(fallback) else fallback;
+        const body_err: ?anyerror = if (self._body_reader_init) self._body_reader.cause else null;
+        return recoverAdapterError(error.ReadFailed, transport_err, &.{body_err});
+    }
+
     /// Get HTTP version.
     pub fn version(self: *const ClientResponse) struct { major: u8, minor: u8 } {
         return .{
@@ -638,7 +683,7 @@ pub const ClientResponse = struct {
         const r = self.reader();
         const result = r.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
-            else => return err,
+            else => return self.readError(err),
         };
 
         self._body_read = true;
@@ -875,7 +920,7 @@ pub const Client = struct {
 
         // Parse response headers
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {
-            error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
+            error.ReadFailed => return conn.readError(err),
             else => |e| return e,
         };
 
@@ -946,7 +991,7 @@ pub const Client = struct {
             .user_agent = self.config.user_agent,
         }) catch |err| {
             conn.closing = true;
-            return err;
+            return conn.writeError(err);
         };
 
         conn.flush() catch |err| {
@@ -959,7 +1004,7 @@ pub const Client = struct {
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| {
             conn.closing = true;
             switch (err) {
-                error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
+                error.ReadFailed => return conn.readError(err),
                 else => |e| return e,
             }
         };
@@ -991,7 +1036,7 @@ pub const Client = struct {
                     _ = body_reader.interface.discardShort(max_drain + 1) catch |err| switch (err) {
                         error.ReadFailed => {
                             conn.closing = true;
-                            return conn.tcp_reader.err orelse error.ReadFailed;
+                            return recoverAdapterError(error.ReadFailed, conn.readError(err), &.{body_reader.cause});
                         },
                     };
                     if (!conn.parser.isBodyComplete()) conn.closing = true;

--- a/src/client.zig
+++ b/src/client.zig
@@ -538,12 +538,12 @@ pub const Connection = struct {
         self.writer.flush() catch |err| return self.writeError(err);
     }
 
-    pub fn readError(self: *const Connection, fallback: anyerror) anyerror {
+    fn readError(self: *const Connection, fallback: anyerror) anyerror {
         const tls_err: ?anyerror = if (self.tls_conn != null) self.tls_reader.err else null;
         return recoverAdapterError(error.ReadFailed, fallback, &.{ self.tcp_reader.err, tls_err });
     }
 
-    pub fn writeError(self: *const Connection, fallback: anyerror) anyerror {
+    fn writeError(self: *const Connection, fallback: anyerror) anyerror {
         const tls_err: ?anyerror = if (self.tls_conn != null) self.tls_writer.err else null;
         return recoverAdapterError(error.WriteFailed, fallback, &.{ self.tcp_writer.err, tls_err });
     }
@@ -650,14 +650,18 @@ pub const ClientResponse = struct {
         return &self.parsed.headers;
     }
 
-    /// Recover the concrete transport/parser error hidden by std.Io.Reader's
-    /// error.ReadFailed marker. Streaming callers should use this when an API fed
-    /// by reader() returns ReadFailed.
-    pub fn readError(self: *const ClientResponse, fallback: anyerror) anyerror {
+    fn readError(self: *const ClientResponse, fallback: anyerror) anyerror {
         if (fallback != error.ReadFailed) return fallback;
         const transport_err = if (self.owner) |conn| conn.readError(fallback) else fallback;
         const body_err: ?anyerror = if (self._body_reader_init) self._body_reader.cause else null;
         return recoverAdapterError(error.ReadFailed, transport_err, &.{body_err});
+    }
+
+    /// Run one streaming body operation and restore the concrete transport/parser
+    /// error before it crosses the response boundary. `args` is appended after the
+    /// reader argument when calling `readFn`.
+    pub fn withBodyReader(self: *ClientResponse, comptime readFn: anytype, args: anytype) @typeInfo(@TypeOf(readFn)).@"fn".return_type.? {
+        return @call(.auto, readFn, .{self.reader()} ++ args) catch |err| return self.readError(err);
     }
 
     /// Get HTTP version.

--- a/src/client.zig
+++ b/src/client.zig
@@ -650,18 +650,13 @@ pub const ClientResponse = struct {
         return &self.parsed.headers;
     }
 
-    fn readError(self: *const ClientResponse, fallback: anyerror) anyerror {
+    /// Recover the concrete transport/parser error after one complete streaming
+    /// operation using reader() returns a std.Io ReadFailed marker.
+    pub fn readError(self: *const ClientResponse, fallback: anyerror) anyerror {
         if (fallback != error.ReadFailed) return fallback;
         const transport_err = if (self.owner) |conn| conn.readError(fallback) else fallback;
         const body_err: ?anyerror = if (self._body_reader_init) self._body_reader.cause else null;
         return recoverAdapterError(error.ReadFailed, transport_err, &.{body_err});
-    }
-
-    /// Run one streaming body operation and restore the concrete transport/parser
-    /// error before it crosses the response boundary. `args` is appended after the
-    /// reader argument when calling `readFn`.
-    pub fn withBodyReader(self: *ClientResponse, comptime readFn: anytype, args: anytype) @typeInfo(@TypeOf(readFn)).@"fn".return_type.? {
-        return @call(.auto, readFn, .{self.reader()} ++ args) catch |err| return self.readError(err);
     }
 
     /// Get HTTP version.

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -102,6 +102,64 @@ test "Client: fetch GET request" {
     try client_future.await(io);
 }
 
+test "Client: cancellation while reading a response body stays Canceled" {
+    const io = std.testing.io;
+    const socket_path = "/tmp/dusty-client-canceled-body.sock";
+    std.Io.Dir.cwd().deleteFile(io, socket_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, socket_path) catch {};
+
+    var ready: std.Io.Event = .unset;
+    var body_started: std.Io.Event = .unset;
+    var keep_open: std.Io.Event = .unset;
+
+    var server_future = try io.concurrent(struct {
+        fn run(path: []const u8, ready_event: *std.Io.Event, body_event: *std.Io.Event, wait_event: *std.Io.Event, task_io: std.Io) !void {
+            const addr = try std.Io.net.UnixAddress.init(path);
+            var server = try addr.listen(task_io, .{});
+            defer server.deinit(task_io);
+            ready_event.set(task_io);
+
+            const stream = try server.accept(task_io);
+            defer stream.close(task_io);
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(task_io, &read_buf);
+            while (true) {
+                const line = try reader.interface.takeDelimiterExclusive('\n');
+                reader.interface.toss(1);
+                if (std.mem.trimEnd(u8, line, "\r").len == 0) break;
+            }
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(task_io, &write_buf);
+            try writer.interface.writeAll(
+                "HTTP/1.1 200 OK\r\n" ++
+                    "Content-Length: 100\r\n" ++
+                    "Connection: close\r\n\r\n" ++
+                    "partial",
+            );
+            try writer.interface.flush();
+            body_event.set(task_io);
+            try wait_event.wait(task_io);
+        }
+    }.run, .{ socket_path, &ready, &body_started, &keep_open, io });
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(path: []const u8, ready_event: *std.Io.Event, task_io: std.Io) !void {
+            try ready_event.wait(task_io);
+            var client = dusty.Client.init(std.testing.allocator, task_io, .{});
+            defer client.deinit();
+            var response = try client.fetch("http://localhost/test", .{ .unix_socket_path = path });
+            defer response.deinit();
+            _ = try response.body();
+        }
+    }.run, .{ socket_path, &ready, io });
+
+    try body_started.wait(io);
+    try std.testing.expectError(error.Canceled, client_future.cancel(io));
+}
+
 test "Client: connection pooling" {
     const io = std.testing.io;
 

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -472,6 +472,7 @@ pub fn BodyReader(comptime Parser: type) type {
         conn: *std.Io.Reader,
         interface: std.Io.Reader,
         request: ?*Request = null,
+        cause: ?anyerror = null,
 
         const Self = @This();
 
@@ -535,8 +536,9 @@ pub fn BodyReader(comptime Parser: type) type {
                     conn.fillMore() catch |err| switch (err) {
                         error.EndOfStream => {
                             // Connection closed - call finish() to complete the message
-                            parser.finish() catch {
+                            parser.finish() catch |finish_err| {
                                 // finish() failed - message was not complete
+                                self.cause = finish_err;
                                 return error.ReadFailed;
                             };
 
@@ -546,9 +548,13 @@ pub fn BodyReader(comptime Parser: type) type {
                             }
 
                             // Message not complete despite EOF
+                            self.cause = error.UnexpectedEndOfStream;
                             return error.ReadFailed;
                         },
-                        else => return error.ReadFailed,
+                        else => {
+                            self.cause = err;
+                            return error.ReadFailed;
+                        },
                     };
                 }
 
@@ -573,7 +579,10 @@ pub fn BodyReader(comptime Parser: type) type {
                             const consumed = parser.getConsumedBytes(buffered.ptr);
                             conn.toss(consumed);
                         },
-                        else => return error.ReadFailed,
+                        else => {
+                            self.cause = err;
+                            return error.ReadFailed;
+                        },
                     }
                 }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -322,7 +322,10 @@ pub fn Server(comptime Ctx: type) type {
                         // Unknown Expect value - return 417
                         response.status = .expectation_failed;
                         response.keepalive = false;
-                        try response.write();
+                        response.write() catch |err| switch (err) {
+                            error.WriteFailed => return writer.err orelse err,
+                            else => |e| return e,
+                        };
                         return;
                     }
                 }
@@ -378,7 +381,10 @@ pub fn Server(comptime Ctx: type) type {
                     response.keepalive = false;
                 }
 
-                try response.write();
+                response.write() catch |err| switch (err) {
+                    error.WriteFailed => return writer.err orelse err,
+                    else => |e| return e,
+                };
 
                 if (!response.keepalive) {
                     break;


### PR DESCRIPTION
## Summary

- retain the concrete failure inside HTTP body-reader adapters
- expose `ClientResponse.readError` for streaming consumers
- make buffered response bodies recover transport/parser errors automatically
- recover TCP/TLS errors from client request writes, flushes, header reads, and redirect drains
- recover server response-write errors at the concrete socket boundary
- add a real partial-body cancellation regression

## Why

`std.Io.Reader` and `Writer` adapters must return the narrow `ReadFailed`/`WriteFailed` markers. The concrete adapter therefore has to retain the underlying error, and the owner must unwrap it. Mid-body cancellation previously surfaced as `ReadFailed`, preventing callers from distinguishing timeouts and shutdown.

## Verification

- `zig build test` — 222 passed
- regression sends valid HTTP headers plus a partial body, stalls the socket, cancels the client, and asserts exact `error.Canceled`
