### PR TITLE
Server: own the connection, surface real errors past WriteFailed/ReadFailed

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .tls = .{
-            .url = "git+https://github.com/ianic/tls.zig#5452bafc98d23e304209cb24d81fd2d19434e52d",
-            .hash = "tls-0.1.0-ER2e0hOsBQA6IN_UFrQFn0A_dIdW8HleuHi3oTT059RI",
+            .url = "git+https://github.com/lalinsky/tls.zig#4ff3e5a2e6c9b2624fba1de3792bb29afa8de0d3",
+            .hash = "tls-0.1.0-ER2e0vs0BgCXLcL87UB__FMdgDryWw5ZO0G--qeog8sF",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .tls = .{
-            .url = "git+https://github.com/lalinsky/tls.zig#4ff3e5a2e6c9b2624fba1de3792bb29afa8de0d3",
-            .hash = "tls-0.1.0-ER2e0vs0BgCXLcL87UB__FMdgDryWw5ZO0G--qeog8sF",
+            .url = "git+https://github.com/lalinsky/tls.zig#4fe2266990e7defac62b1eff3386f5baef498714",
+            .hash = "tls-0.1.0-ER2e0r04BgA6ETtLL8dR9uTEHA_Q4H7nwgXu2MzlU-F0",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .tls = .{
-            .url = "git+https://github.com/lalinsky/tls.zig#4fe2266990e7defac62b1eff3386f5baef498714",
-            .hash = "tls-0.1.0-ER2e0r04BgA6ETtLL8dR9uTEHA_Q4H7nwgXu2MzlU-F0",
+            .url = "git+https://github.com/lalinsky/tls.zig#bd94b5f7ac10d3b1e38ff2e5ea031e0f9d0e8eec",
+            .hash = "tls-0.1.0-ER2e0m1EBgCVgWGBNlO_sDIKKXFj8eY4MTA1SZNmCgEA",
             .lazy = true,
         },
     },

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -498,8 +498,8 @@ pub fn BodyReader(comptime Parser: type) type {
                 if (req.expects_continue) {
                     req.expects_continue = false;
                     if (req.response) |res| {
-                        try res.conn.writeAll("HTTP/1.1 100 Continue\r\n\r\n");
-                        try res.conn.flush();
+                        try res.conn.writer.writeAll("HTTP/1.1 100 Continue\r\n\r\n");
+                        try res.conn.writer.flush();
                     }
                 }
             }

--- a/src/response.zig
+++ b/src/response.zig
@@ -4,6 +4,7 @@ const Request = @import("request.zig").Request;
 pub const WebSocket = @import("websocket.zig").WebSocket;
 pub const CookieOpts = @import("cookie.zig").CookieOpts;
 const serializeCookie = @import("cookie.zig").serializeCookie;
+const Connection = @import("server.zig").Connection;
 
 var no_buf: [0]u8 = .{};
 
@@ -104,14 +105,14 @@ pub const Response = struct {
     content_type: ?http.ContentType = null,
     arena: std.mem.Allocator,
     buffer: std.Io.Writer.Allocating,
-    conn: *std.Io.Writer,
+    conn: *Connection,
     written: bool = false,
     headers_written: bool = false,
     keepalive: bool = true,
     chunked: bool = false,
     streaming: bool = false,
 
-    pub fn init(arena: std.mem.Allocator, conn: *std.Io.Writer, max_headers: usize) !Response {
+    pub fn init(arena: std.mem.Allocator, conn: *Connection, max_headers: usize) !Response {
         return .{
             .arena = arena,
             .buffer = .init(arena),
@@ -149,7 +150,7 @@ pub const Response = struct {
     pub fn chunk(self: *Response, data: []const u8) !void {
         if (!self.chunked) {
             self.chunked = true;
-            try self.writeHeader();
+            self.writeHeader() catch |err| return self.conn.checkWriteError(err);
         }
 
         // A zero-length chunk is the chunked-encoding terminator; skip it so
@@ -162,11 +163,15 @@ pub const Response = struct {
         var buf: [16]u8 = undefined;
         const chunk_header = try std.fmt.bufPrint(&buf, "{x}\r\n", .{data.len});
 
+        self.writeChunkBytes(chunk_header, data) catch |err| return self.conn.checkWriteError(err);
+    }
+
+    fn writeChunkBytes(self: *Response, chunk_header: []const u8, data: []const u8) !void {
         // Write chunk size header, data, and trailing CRLF
-        try self.conn.writeAll(chunk_header);
-        try self.conn.writeAll(data);
-        try self.conn.writeAll("\r\n");
-        try self.conn.flush();
+        try self.conn.writer.writeAll(chunk_header);
+        try self.conn.writer.writeAll(data);
+        try self.conn.writer.writeAll("\r\n");
+        try self.conn.writer.flush();
     }
 
     pub fn startEventStream(self: *Response) !EventStream {
@@ -175,8 +180,8 @@ pub const Response = struct {
         self.keepalive = false;
         self.streaming = true;
         try self.writeHeader();
-        try self.conn.flush();
-        return .{ .conn = self.conn };
+        try self.conn.writer.flush();
+        return .{ .conn = self.conn.writer };
     }
 
     /// Upgrade HTTP connection to WebSocket.
@@ -205,11 +210,11 @@ pub const Response = struct {
         try self.header("Sec-WebSocket-Accept", &accept_key);
         self.streaming = true;
         try self.writeHeader();
-        try self.conn.flush();
+        try self.conn.writer.flush();
 
         var seed: u64 = undefined;
         req.io.random(std.mem.asBytes(&seed));
-        return WebSocket.init(self.conn, req.conn, self.arena, seed);
+        return WebSocket.init(self.conn.writer, req.conn, self.arena, seed);
     }
 
     pub fn writeHeader(self: *Response) !void {
@@ -219,7 +224,7 @@ pub const Response = struct {
         self.headers_written = true;
 
         // Write status line
-        try self.conn.print("HTTP/1.1 {d} {f}\r\n", .{ @intFromEnum(self.status), self.status });
+        try self.conn.writer.print("HTTP/1.1 {d} {f}\r\n", .{ @intFromEnum(self.status), self.status });
 
         // Set the Content-Type header
         if (self.content_type) |content_type| {
@@ -229,29 +234,29 @@ pub const Response = struct {
         // Write headers
         var iter = self.headers.iterator();
         while (iter.next()) |entry| {
-            try self.conn.print("{s}: {s}\r\n", .{ entry.key, entry.value });
+            try self.conn.writer.print("{s}: {s}\r\n", .{ entry.key, entry.value });
         }
 
         // Write Connection header based on keepalive
         if (!self.keepalive) {
-            try self.conn.writeAll("Connection: close\r\n");
+            try self.conn.writer.writeAll("Connection: close\r\n");
         }
 
         // Write Transfer-Encoding or Content-Length
         if (self.chunked) {
-            try self.conn.writeAll("Transfer-Encoding: chunked\r\n");
+            try self.conn.writer.writeAll("Transfer-Encoding: chunked\r\n");
         } else if (!self.streaming) {
             // Write Content-Length if not manually set (skip for streaming responses like SSE)
             const has_content_length = self.headers.get("Content-Length") != null;
             if (!has_content_length) {
                 const buffer_end = self.buffer.writer.end;
                 const body_len = if (buffer_end > 0) buffer_end else self.body.len;
-                try self.conn.print("Content-Length: {d}\r\n", .{body_len});
+                try self.conn.writer.print("Content-Length: {d}\r\n", .{body_len});
             }
         }
 
         // End of headers (applies to both chunked and non-chunked)
-        try self.conn.writeAll("\r\n");
+        try self.conn.writer.writeAll("\r\n");
 
         // Don't flush here - let the caller flush after writing (the first part of) the body
     }
@@ -265,8 +270,8 @@ pub const Response = struct {
         if (self.chunked) {
             // For chunked responses, headers are already written by chunk()
             // We just need to write the final zero-length chunk terminator
-            try self.conn.writeAll("0\r\n\r\n");
-            try self.conn.flush();
+            try self.conn.writer.writeAll("0\r\n\r\n");
+            try self.conn.writer.flush();
             return;
         }
 
@@ -276,9 +281,9 @@ pub const Response = struct {
         // Write body (either from buffer or body field)
         const buffered = self.buffer.writer.buffered();
         const body = if (buffered.len > 0) buffered else self.body;
-        try self.conn.writeAll(body);
+        try self.conn.writer.writeAll(body);
 
-        try self.conn.flush();
+        try self.conn.writer.flush();
     }
 };
 
@@ -289,7 +294,10 @@ test "Response: basic writer usage" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const w = response.writer();
 
     try w.writeAll("Hello, ");
@@ -306,7 +314,10 @@ test "Response: writer with formatted output" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const w = response.writer();
 
     try w.print("Hello, {s}! You are {d} years old.", .{ "Alice", 30 });
@@ -322,7 +333,10 @@ test "Response: buffer takes precedence over body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "body content";
 
     const w = response.writer();
@@ -344,7 +358,10 @@ test "Response: body used when buffer is empty" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "body content";
 
     // Don't write to buffer
@@ -363,7 +380,10 @@ test "Response: write() with body" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "Hello World";
 
     try response.write();
@@ -381,7 +401,10 @@ test "Response: write() with writer buffer" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const w = response.writer();
     try w.print("Count: {d}", .{42});
 
@@ -400,7 +423,10 @@ test "Response: write() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "First";
 
     try response.write();
@@ -421,7 +447,10 @@ test "Response: writeHeader() basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.status = .created;
     try response.header("X-Custom", "value");
     response.body = "Hello";
@@ -443,7 +472,10 @@ test "Response: writeHeader() only writes once" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "Test";
 
     try response.writeHeader();
@@ -464,7 +496,10 @@ test "Response: write() after writeHeader() doesn't duplicate headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.body = "Body content";
 
     // Write headers first
@@ -491,7 +526,10 @@ test "Response: clearWriter()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const w = response.writer();
 
     try w.writeAll("First content");
@@ -511,7 +549,10 @@ test "Response: keepalive defaults to true" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectEqual(true, response.keepalive);
 
     response.body = "test";
@@ -529,7 +570,10 @@ test "Response: Connection close header when keepalive is false" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.keepalive = false;
     response.body = "test";
 
@@ -546,7 +590,10 @@ test "Response: chunked with single chunk" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.status = .ok;
 
     try response.chunk("Hello");
@@ -573,7 +620,10 @@ test "Response: chunked with multiple chunks" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
 
     try response.chunk("First");
     try response.chunk("Second chunk");
@@ -602,7 +652,10 @@ test "Response: chunked with custom headers" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.status = .created;
     try response.header("X-Custom", "value");
 
@@ -630,8 +683,10 @@ test "Response: chunked flag defaults to false" {
 
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
 
-    const response = try Response.init(arena.allocator(), &conn_writer, 32);
+    const response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectEqual(false, response.chunked);
 }
 
@@ -642,7 +697,10 @@ test "Response: chunk() skips empty data so it doesn't terminate the stream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
 
     try response.chunk("first");
     try response.chunk(""); // would be the chunked terminator if written; must be skipped
@@ -660,6 +718,38 @@ test "Response: chunk() skips empty data so it doesn't terminate the stream" {
     try std.testing.expectEqualStrings(expected, written);
 }
 
+test "Response: chunk() surfaces the real error behind error.WriteFailed" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Buffer too small to hold the headers, so the very first write fails.
+    var buf: [4]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+    connection.tcp_writer.err = error.ConnectionResetByPeer;
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    try std.testing.expectError(error.ConnectionResetByPeer, response.chunk("first"));
+}
+
+test "Response: chunk() falls back to error.WriteFailed when no real error was recorded" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [4]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    try std.testing.expectError(error.WriteFailed, response.chunk("first"));
+}
+
 test "Response: chunked mode doesn't write Content-Length" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -667,7 +757,10 @@ test "Response: chunked mode doesn't write Content-Length" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
 
     try response.chunk("test");
     try response.write();
@@ -688,7 +781,10 @@ test "Response: json() with simple object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try response.json(.{ .name = "Alice", .age = 30 }, .{});
 
     const buffered = response.buffer.writer.buffered();
@@ -707,7 +803,10 @@ test "Response: json() writes complete response" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     response.status = .created;
     try response.json(.{ .id = 123, .message = "Created" }, .{});
     try response.write();
@@ -732,7 +831,10 @@ test "Response: json() with array" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const items = [_]i32{ 1, 2, 3, 4, 5 };
     try response.json(items, .{});
 
@@ -747,7 +849,10 @@ test "Response: json() with nested object" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try response.json(.{
         .user = .{
             .name = "Bob",
@@ -812,7 +917,10 @@ test "Response: startEventStream" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     const stream = try response.startEventStream();
 
     try stream.send("connected", .{});
@@ -832,7 +940,10 @@ test "Response: setCookie basic" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try response.setCookie("session", "abc123", .{});
     response.body = "OK";
 
@@ -849,7 +960,10 @@ test "Response: setCookie with options" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try response.setCookie("auth", "token123", .{
         .path = "/",
         .http_only = true,
@@ -871,7 +985,10 @@ test "Response: header() rejects CRLF in value" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectError(error.InvalidHeaderValue, response.header("Location", "/ok\r\nX-Evil: 1"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\nbaz"));
     try std.testing.expectError(error.InvalidHeaderValue, response.header("X-Foo", "bar\x00baz"));
@@ -884,7 +1001,10 @@ test "Response: header() rejects invalid name" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectError(error.InvalidHeaderName, response.header("", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X-Bad\r\n", "value"));
     try std.testing.expectError(error.InvalidHeaderName, response.header("X: Bad", "value"));
@@ -898,7 +1018,10 @@ test "Response: setCookie rejects CRLF via header()" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var response = try Response.init(arena.allocator(), &conn_writer, 32);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectError(error.InvalidHeaderValue, response.setCookie("session", "abc\r\nSet-Cookie: evil=1", .{}));
 }
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -150,7 +150,10 @@ pub const Response = struct {
     pub fn chunk(self: *Response, data: []const u8) !void {
         if (!self.chunked) {
             self.chunked = true;
-            self.writeHeader() catch |err| return self.conn.checkWriteError(err);
+            self.writeHeader() catch |err| switch (err) {
+                error.WriteFailed => return self.conn.getWriteError() orelse err,
+                else => |e| return e,
+            };
         }
 
         // A zero-length chunk is the chunked-encoding terminator; skip it so
@@ -163,7 +166,7 @@ pub const Response = struct {
         var buf: [16]u8 = undefined;
         const chunk_header = try std.fmt.bufPrint(&buf, "{x}\r\n", .{data.len});
 
-        self.writeChunkBytes(chunk_header, data) catch |err| return self.conn.checkWriteError(err);
+        self.writeChunkBytes(chunk_header, data) catch |err| return self.conn.getWriteError() orelse err;
     }
 
     fn writeChunkBytes(self: *Response, chunk_header: []const u8, data: []const u8) !void {

--- a/src/server.zig
+++ b/src/server.zig
@@ -107,17 +107,16 @@ pub const Connection = struct {
         self.arena.deinit();
     }
 
-    // A transport failure under TLS is recorded twice: tls.zig gets only the
-    // generic `ReadFailed`/`WriteFailed` from the ciphertext reader/writer and
-    // stores that, while the real cause sits on the TCP layer underneath. So
-    // the generic errors are not answers; keep descending when we see one.
-    // A TLS-level failure (bad record mac, bad version, ...) is stored as
-    // itself and stops the search.
+    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
+    // layer below it failed, because all it saw was the ciphertext
+    // reader/writer's generic error; the real cause is on the TCP layer.
+    // So those two mean "keep descending". A TLS-level failure (bad record
+    // mac, bad version, ...) is recorded as itself and stops the search.
 
     fn checkReadError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
-                if (self.tls_reader.err) |e| if (e != error.ReadFailed) return e;
+                if (self.tls_reader.err) |e| if (e != error.TransportReadFailed) return e;
             }
         }
         if (self.tcp_reader.err) |e| return e;
@@ -131,7 +130,7 @@ pub const Connection = struct {
     fn checkWriteError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
-                if (self.tls_writer.err) |e| if (e != error.WriteFailed) return e;
+                if (self.tls_writer.err) |e| if (e != error.TransportWriteFailed) return e;
             }
         }
         if (self.tcp_writer.err) |e| return e;
@@ -565,13 +564,13 @@ test "Connection: error accessors descend past the TLS layer's generic error" {
 
     { // a transport write failure: TLS records WriteFailed, TCP has the cause
         var conn = testTlsConnection();
-        conn.tls_writer.err = error.WriteFailed;
+        conn.tls_writer.err = error.TransportWriteFailed;
         conn.tcp_writer.err = error.ConnectionResetByPeer;
         try std.testing.expectEqual(error.ConnectionResetByPeer, conn.getWriteError().?);
     }
     { // same on the read side
         var conn = testTlsConnection();
-        conn.tls_reader.err = error.ReadFailed;
+        conn.tls_reader.err = error.TransportReadFailed;
         conn.tcp_reader.err = error.Canceled;
         try std.testing.expectEqual(error.Canceled, conn.getReadError().?);
     }

--- a/src/server.zig
+++ b/src/server.zig
@@ -18,13 +18,15 @@ const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
 const log = std.log.scoped(.dusty);
 
 /// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
-/// layer) for one accepted connection. Initialized in place: `tls_conn`
-/// stores pointers into `tcp_reader`/`tcp_writer`, and `tls_reader`/
-/// `tls_writer` store a pointer back into `tls_conn`, so a `Connection` must
-/// never be moved after `initPlain`/`initTls` runs.
+/// layer), plus the arena backing their buffers, for one accepted
+/// connection. Initialized in place: `tls_conn` stores pointers into
+/// `tcp_reader`/`tcp_writer`, and `tls_reader`/`tls_writer` store a pointer
+/// back into `tls_conn`, so a `Connection` must never be moved after
+/// `initPlain`/`initTls` runs.
 pub const Connection = struct {
     io: std.Io,
     stream: std.Io.net.Stream,
+    arena: std.heap.ArenaAllocator = undefined,
 
     tcp_reader: std.Io.net.Stream.Reader = undefined,
     tcp_writer: std.Io.net.Stream.Writer = undefined,
@@ -43,8 +45,9 @@ pub const Connection = struct {
     reader: *std.Io.Reader = undefined,
     writer: *std.Io.Writer = undefined,
 
-    pub fn initPlain(self: *Connection, io: std.Io, stream: std.Io.net.Stream) void {
+    pub fn initPlain(self: *Connection, allocator: std.mem.Allocator, io: std.Io, stream: std.Io.net.Stream) void {
         self.* = .{ .io = io, .stream = stream };
+        self.arena = .init(allocator);
         self.tcp_reader = stream.reader(io, &.{});
         self.tcp_writer = stream.writer(io, &self.write_buffer);
         self.reader = &self.tcp_reader.interface;
@@ -53,13 +56,30 @@ pub const Connection = struct {
 
     pub fn initTls(
         self: *Connection,
+        allocator: std.mem.Allocator,
         io: std.Io,
         stream: std.Io.net.Stream,
-        tcp_read_buffer: []u8,
-        tcp_write_buffer: []u8,
+        request_buffer_size: usize,
         auth: *tls.config.CertKeyPair,
     ) !void {
         self.* = .{ .io = io, .stream = stream };
+        self.arena = .init(allocator);
+
+        // Aim for a single backing allocation per connection: prime the
+        // arena with room for the two TLS record buffers plus a working
+        // budget, then recycle it (reset keeps the memory). The TLS buffers
+        // and the per-request arena are then carved from that one
+        // allocation; only unusually large requests grow it.
+        const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + 1024);
+        _ = try self.arena.allocator().alloc(u8, conn_reserve);
+        _ = self.arena.reset(.retain_capacity);
+
+        // The TLS record buffers live for the whole connection (the
+        // tls.Connection points into them) and must survive the per-request
+        // arena resets, so they come from the connection arena.
+        const tcp_read_buffer = try self.arena.allocator().alloc(u8, tls.input_buffer_len);
+        const tcp_write_buffer = try self.arena.allocator().alloc(u8, tls.output_buffer_len);
+
         self.tcp_reader = stream.reader(io, tcp_read_buffer);
         self.tcp_writer = stream.writer(io, tcp_write_buffer);
         self.tls_rng = .{ .io = io };
@@ -82,39 +102,44 @@ pub const Connection = struct {
         self.tcp_writer.err = null;
     }
 
-    /// If `err` is the generic `error.ReadFailed`, returns the real error
-    /// behind it (falling back to `err` itself if none was recorded);
-    /// otherwise returns `err` unchanged.
-    pub fn checkReadError(self: *Connection, err: anytype) !void {
-        if (err != error.ReadFailed) return err;
+    pub fn deinit(self: *Connection) void {
+        self.arena.deinit();
+    }
+
+    fn checkReadError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
                 if (self.tls_reader.err) |e| return e;
-                return err;
+                return;
             }
         }
         if (self.tcp_reader.err) |e| return e;
-        return err;
     }
 
-    /// If `err` is the generic `error.WriteFailed`, returns the real error
-    /// behind it (falling back to `err` itself if none was recorded);
-    /// otherwise returns `err` unchanged. For TLS, a write can fail because
-    /// the TLS layer needed to read internally, so both the TLS reader and
-    /// writer (and the raw TCP pair underneath) are scanned.
-    pub fn checkWriteError(self: *Connection, err: anytype) !void {
-        if (err != error.WriteFailed) return err;
+    /// The real error behind a generic `error.ReadFailed`, if any was recorded.
+    pub fn getReadError(self: *Connection) ?@typeInfo(@TypeOf(checkReadError(self))).error_union.error_set {
+        if (checkReadError(self)) |_| return null else |e| return e;
+    }
+
+    fn checkWriteError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
                 if (self.tls_writer.err) |e| return e;
                 if (self.tcp_writer.err) |e| return e;
                 if (self.tls_reader.err) |e| return e;
                 if (self.tcp_reader.err) |e| return e;
-                return err;
+                return;
             }
         }
         if (self.tcp_writer.err) |e| return e;
-        return err;
+    }
+
+    /// The real error behind a generic `error.WriteFailed`, if any was
+    /// recorded. For TLS, a write can fail because the TLS layer needed to
+    /// read internally, so both the TLS reader and writer (and the raw TCP
+    /// pair underneath) are scanned.
+    pub fn getWriteError(self: *Connection) ?@typeInfo(@TypeOf(checkWriteError(self))).error_union.error_set {
+        if (checkWriteError(self)) |_| return null else |e| return e;
     }
 };
 
@@ -301,33 +326,15 @@ pub fn Server(comptime Ctx: type) type {
                 log.warn("Failed to shutdown client connection: {}", .{err});
             };
 
-            var conn_arena = std.heap.ArenaAllocator.init(self.allocator);
-            defer conn_arena.deinit();
-
             var connection: Connection = undefined;
+            defer connection.deinit();
 
             // When TLS is configured, upgrade the accepted stream and run the
             // request loop over the cleartext reader/writer. Otherwise run it
             // directly over the raw stream.
             if (build_options.use_tls) {
                 if (self.tls_auth) |*auth| {
-                    // Aim for a single backing allocation per connection: prime the
-                    // connection arena with room for the two TLS record buffers plus
-                    // a working budget, then recycle it (reset keeps the memory). The
-                    // TLS buffers and the per-request arena are then carved from that
-                    // one allocation; only unusually large requests grow it.
-                    const conn_reserve = tls.input_buffer_len + tls.output_buffer_len +
-                        2 * (self.config.request.buffer_size + 1024);
-                    _ = try conn_arena.allocator().alloc(u8, conn_reserve);
-                    _ = conn_arena.reset(.retain_capacity);
-
-                    // The TLS record buffers live for the whole connection (the
-                    // tls.Connection points into them) and must survive the
-                    // per-request arena resets, so they come from the connection arena.
-                    const tcp_read_buffer = try conn_arena.allocator().alloc(u8, tls.input_buffer_len);
-                    const tcp_write_buffer = try conn_arena.allocator().alloc(u8, tls.output_buffer_len);
-
-                    connection.initTls(self.io, stream, tcp_read_buffer, tcp_write_buffer, auth) catch |err| {
+                    connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth) catch |err| {
                         log.err("TLS handshake failed: {}", .{err});
                         return;
                     };
@@ -335,13 +342,13 @@ pub fn Server(comptime Ctx: type) type {
                     // Per-request arena nested on the connection arena: resetting it
                     // between keepalive requests reuses the connection's memory
                     // without touching the TLS buffers carved above.
-                    var request_arena = std.heap.ArenaAllocator.init(conn_arena.allocator());
+                    var request_arena = std.heap.ArenaAllocator.init(connection.arena.allocator());
                     return self.handleRequests(&connection, &request_arena, &needs_shutdown);
                 }
             }
 
-            connection.initPlain(self.io, stream);
-            return self.handleRequests(&connection, &conn_arena, &needs_shutdown);
+            connection.initPlain(self.allocator, self.io, stream);
+            return self.handleRequests(&connection, &connection.arena, &needs_shutdown);
         }
 
         /// Runs the HTTP request/keepalive loop over a connection.
@@ -388,7 +395,7 @@ pub fn Server(comptime Ctx: type) type {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return connection.checkReadError(err),
+                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
                     else => |e| return e,
                 };
 
@@ -431,8 +438,8 @@ pub fn Server(comptime Ctx: type) type {
                     .middlewares = if (found) |r| r.middlewares else self.router.middlewares,
                 };
                 executor.run() catch |err| switch (err) {
-                    error.ReadFailed => return connection.checkReadError(err),
-                    error.WriteFailed => return connection.checkWriteError(err),
+                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
+                    error.WriteFailed => return connection.getWriteError() orelse error.WriteFailed,
                     else => |e| return e,
                 };
 
@@ -448,8 +455,8 @@ pub fn Server(comptime Ctx: type) type {
                         var body_reader = RequestBodyReader.init(&parser, connection.reader, &scratch);
                         if (body_reader.interface.discardShort(max + 1)) |consumed| {
                             if (consumed > max) response.keepalive = false;
-                        } else |drain_err| {
-                            connection.checkReadError(drain_err) catch |e| if (e == error.Canceled) return error.Canceled;
+                        } else |_| {
+                            if (connection.getReadError()) |e| if (e == error.Canceled) return error.Canceled;
                             response.keepalive = false;
                         }
                     } else {
@@ -495,7 +502,7 @@ pub fn Server(comptime Ctx: type) type {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return connection.checkReadError(err),
+                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
                 };
             }
         }

--- a/src/server.zig
+++ b/src/server.zig
@@ -99,6 +99,7 @@ pub const Connection = struct {
     /// error a write failure should surface.
     pub fn initWriterForTesting(self: *Connection, w: *std.Io.Writer) void {
         self.* = .{ .io = undefined, .stream = undefined, .reader = undefined, .writer = w };
+        self.tcp_reader.err = null;
         self.tcp_writer.err = null;
     }
 
@@ -106,11 +107,17 @@ pub const Connection = struct {
         self.arena.deinit();
     }
 
+    // A transport failure under TLS is recorded twice: tls.zig gets only the
+    // generic `ReadFailed`/`WriteFailed` from the ciphertext reader/writer and
+    // stores that, while the real cause sits on the TCP layer underneath. So
+    // the generic errors are not answers; keep descending when we see one.
+    // A TLS-level failure (bad record mac, bad version, ...) is stored as
+    // itself and stops the search.
+
     fn checkReadError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
-                if (self.tls_reader.err) |e| return e;
-                return;
+                if (self.tls_reader.err) |e| if (e != error.ReadFailed) return e;
             }
         }
         if (self.tcp_reader.err) |e| return e;
@@ -124,22 +131,35 @@ pub const Connection = struct {
     fn checkWriteError(self: *Connection) !void {
         if (build_options.use_tls) {
             if (self.tls_conn != null) {
-                if (self.tls_writer.err) |e| return e;
-                if (self.tcp_writer.err) |e| return e;
-                if (self.tls_reader.err) |e| return e;
-                if (self.tcp_reader.err) |e| return e;
-                return;
+                if (self.tls_writer.err) |e| if (e != error.WriteFailed) return e;
             }
         }
         if (self.tcp_writer.err) |e| return e;
     }
 
     /// The real error behind a generic `error.WriteFailed`, if any was
-    /// recorded. For TLS, a write can fail because the TLS layer needed to
-    /// read internally, so both the TLS reader and writer (and the raw TCP
-    /// pair underneath) are scanned.
+    /// recorded.
     pub fn getWriteError(self: *Connection) ?@typeInfo(@TypeOf(checkWriteError(self))).error_union.error_set {
         if (checkWriteError(self)) |_| return null else |e| return e;
+    }
+
+    /// True when `err` means the peer is gone rather than something being
+    /// wrong. Teardown is the same either way; this only decides whether the
+    /// connection is worth a log line and whether shutdown() is worth a
+    /// syscall.
+    pub fn isPeerGone(err: anyerror) bool {
+        return switch (err) {
+            error.EndOfStream,
+            // Peer closed the transport between TLS records without
+            // close_notify. Rude, but routine from clients that just close
+            // the socket. `TlsTruncated`, where a record was cut in half, is
+            // deliberately not here.
+            error.TlsUnexpectedEof,
+            error.ConnectionResetByPeer,
+            error.BrokenPipe,
+            => true,
+            else => false,
+        };
     }
 };
 
@@ -309,7 +329,13 @@ pub fn Server(comptime Ctx: type) type {
         fn handleConnectionWrapper(self: *Self, stream: std.Io.net.Stream) std.Io.Cancelable!void {
             handleConnection(self, stream) catch |err| {
                 if (err == error.Canceled) return error.Canceled;
-                log.err("Connection error: {}", .{err});
+                // A peer disappearing mid-request is ordinary and would drown
+                // out the failures worth looking at.
+                if (Connection.isPeerGone(err)) {
+                    log.debug("Connection closed by peer: {}", .{err});
+                } else {
+                    log.err("Connection error: {}", .{err});
+                }
             };
         }
 
@@ -502,7 +528,17 @@ pub fn Server(comptime Ctx: type) type {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
+                    error.ReadFailed => {
+                        const e = connection.getReadError() orelse error.ReadFailed;
+                        // Nothing is in flight between requests, so a peer
+                        // that went away here has cost us nothing. The socket
+                        // is already gone, so skip the shutdown syscall too.
+                        if (Connection.isPeerGone(e)) {
+                            needs_shutdown.* = false;
+                            return;
+                        }
+                        return e;
+                    },
                 };
             }
         }
@@ -511,4 +547,58 @@ pub fn Server(comptime Ctx: type) type {
 
 test {
     _ = RequestParser;
+}
+
+/// A Connection with no real transport, in TLS mode, so the error accessors
+/// can be driven directly. Only the `err` fields are read.
+fn testTlsConnection() Connection {
+    var conn: Connection = undefined;
+    conn.initWriterForTesting(undefined);
+    conn.tls_conn = .{ .input = undefined, .output = undefined, .cipher = undefined };
+    conn.tls_reader.err = null;
+    conn.tls_writer.err = null;
+    return conn;
+}
+
+test "Connection: error accessors descend past the TLS layer's generic error" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+
+    { // a transport write failure: TLS records WriteFailed, TCP has the cause
+        var conn = testTlsConnection();
+        conn.tls_writer.err = error.WriteFailed;
+        conn.tcp_writer.err = error.ConnectionResetByPeer;
+        try std.testing.expectEqual(error.ConnectionResetByPeer, conn.getWriteError().?);
+    }
+    { // same on the read side
+        var conn = testTlsConnection();
+        conn.tls_reader.err = error.ReadFailed;
+        conn.tcp_reader.err = error.Canceled;
+        try std.testing.expectEqual(error.Canceled, conn.getReadError().?);
+    }
+}
+
+test "Connection: a TLS-level failure is reported as itself" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+
+    { // not a transport failure, so there is nothing below to descend to
+        var conn = testTlsConnection();
+        conn.tls_reader.err = error.TlsBadRecordMac;
+        conn.tcp_reader.err = error.ConnectionResetByPeer;
+        try std.testing.expectEqual(error.TlsBadRecordMac, conn.getReadError().?);
+    }
+    { // and with nothing recorded anywhere there is no error to report
+        var conn = testTlsConnection();
+        try std.testing.expectEqual(@as(?anyerror, null), conn.getWriteError());
+    }
+}
+
+test "Connection: isPeerGone separates a departed peer from a real failure" {
+    try std.testing.expect(Connection.isPeerGone(error.EndOfStream));
+    try std.testing.expect(Connection.isPeerGone(error.ConnectionResetByPeer));
+    // Closed between records: nothing was in flight, nothing was lost.
+    try std.testing.expect(Connection.isPeerGone(error.TlsUnexpectedEof));
+    // Closed mid-record: a record was cut, which is worth hearing about.
+    try std.testing.expect(!Connection.isPeerGone(error.TlsTruncated));
+    try std.testing.expect(!Connection.isPeerGone(error.TlsBadRecordMac));
+    try std.testing.expect(!Connection.isPeerGone(error.Canceled));
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -17,6 +17,107 @@ const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
 
 const log = std.log.scoped(.dusty);
 
+/// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
+/// layer) for one accepted connection. Initialized in place: `tls_conn`
+/// stores pointers into `tcp_reader`/`tcp_writer`, and `tls_reader`/
+/// `tls_writer` store a pointer back into `tls_conn`, so a `Connection` must
+/// never be moved after `initPlain`/`initTls` runs.
+pub const Connection = struct {
+    io: std.Io,
+    stream: std.Io.net.Stream,
+
+    tcp_reader: std.Io.net.Stream.Reader = undefined,
+    tcp_writer: std.Io.net.Stream.Writer = undefined,
+    write_buffer: [4096]u8 = undefined,
+
+    // TLS layer: tcp_reader/tcp_writer above carry ciphertext; tls_conn wraps
+    // them, and tls_reader/tls_writer expose the cleartext Reader/Writer used
+    // for HTTP I/O.
+    tls_conn: ?tls.Connection = null,
+    tls_rng: std.Random.IoSource = undefined,
+    tls_cleartext_write_buffer: [4096]u8 = undefined,
+    tls_reader: tls.Connection.Reader = undefined,
+    tls_writer: tls.Connection.Writer = undefined,
+
+    // Active reader/writer, whichever path is in use.
+    reader: *std.Io.Reader = undefined,
+    writer: *std.Io.Writer = undefined,
+
+    pub fn initPlain(self: *Connection, io: std.Io, stream: std.Io.net.Stream) void {
+        self.* = .{ .io = io, .stream = stream };
+        self.tcp_reader = stream.reader(io, &.{});
+        self.tcp_writer = stream.writer(io, &self.write_buffer);
+        self.reader = &self.tcp_reader.interface;
+        self.writer = &self.tcp_writer.interface;
+    }
+
+    pub fn initTls(
+        self: *Connection,
+        io: std.Io,
+        stream: std.Io.net.Stream,
+        tcp_read_buffer: []u8,
+        tcp_write_buffer: []u8,
+        auth: *tls.config.CertKeyPair,
+    ) !void {
+        self.* = .{ .io = io, .stream = stream };
+        self.tcp_reader = stream.reader(io, tcp_read_buffer);
+        self.tcp_writer = stream.writer(io, tcp_write_buffer);
+        self.tls_rng = .{ .io = io };
+        self.tls_conn = try tls.server(&self.tcp_reader.interface, &self.tcp_writer.interface, .{
+            .auth = auth,
+            .now = std.Io.Clock.real.now(io),
+            .rng = self.tls_rng.interface(),
+        });
+        self.tls_reader = self.tls_conn.?.reader(&.{});
+        self.tls_writer = self.tls_conn.?.writer(&self.tls_cleartext_write_buffer);
+        self.reader = &self.tls_reader.interface;
+        self.writer = &self.tls_writer.interface;
+    }
+
+    /// For tests: wraps a bare writer with no real TLS/TCP layer behind it.
+    /// `tcp_writer.err` is left settable so a test can simulate the real
+    /// error a write failure should surface.
+    pub fn initWriterForTesting(self: *Connection, w: *std.Io.Writer) void {
+        self.* = .{ .io = undefined, .stream = undefined, .reader = undefined, .writer = w };
+        self.tcp_writer.err = null;
+    }
+
+    /// If `err` is the generic `error.ReadFailed`, returns the real error
+    /// behind it (falling back to `err` itself if none was recorded);
+    /// otherwise returns `err` unchanged.
+    pub fn checkReadError(self: *Connection, err: anytype) !void {
+        if (err != error.ReadFailed) return err;
+        if (build_options.use_tls) {
+            if (self.tls_conn != null) {
+                if (self.tls_reader.err) |e| return e;
+                return err;
+            }
+        }
+        if (self.tcp_reader.err) |e| return e;
+        return err;
+    }
+
+    /// If `err` is the generic `error.WriteFailed`, returns the real error
+    /// behind it (falling back to `err` itself if none was recorded);
+    /// otherwise returns `err` unchanged. For TLS, a write can fail because
+    /// the TLS layer needed to read internally, so both the TLS reader and
+    /// writer (and the raw TCP pair underneath) are scanned.
+    pub fn checkWriteError(self: *Connection, err: anytype) !void {
+        if (err != error.WriteFailed) return err;
+        if (build_options.use_tls) {
+            if (self.tls_conn != null) {
+                if (self.tls_writer.err) |e| return e;
+                if (self.tcp_writer.err) |e| return e;
+                if (self.tls_reader.err) |e| return e;
+                if (self.tcp_reader.err) |e| return e;
+                return err;
+            }
+        }
+        if (self.tcp_writer.err) |e| return e;
+        return err;
+    }
+};
+
 pub const Address = union(enum) {
     ip: std.Io.net.IpAddress,
     unix: std.Io.net.UnixAddress,
@@ -203,6 +304,8 @@ pub fn Server(comptime Ctx: type) type {
             var conn_arena = std.heap.ArenaAllocator.init(self.allocator);
             defer conn_arena.deinit();
 
+            var connection: Connection = undefined;
+
             // When TLS is configured, upgrade the accepted stream and run the
             // request loop over the cleartext reader/writer. Otherwise run it
             // directly over the raw stream.
@@ -224,54 +327,34 @@ pub fn Server(comptime Ctx: type) type {
                     const tcp_read_buffer = try conn_arena.allocator().alloc(u8, tls.input_buffer_len);
                     const tcp_write_buffer = try conn_arena.allocator().alloc(u8, tls.output_buffer_len);
 
-                    var tcp_reader = stream.reader(self.io, tcp_read_buffer);
-                    var tcp_writer = stream.writer(self.io, tcp_write_buffer);
-
-                    var rng_source: std.Random.IoSource = .{ .io = self.io };
-                    var conn = tls.server(&tcp_reader.interface, &tcp_writer.interface, .{
-                        .auth = auth,
-                        .now = std.Io.Clock.real.now(self.io),
-                        .rng = rng_source.interface(),
-                    }) catch |err| {
+                    connection.initTls(self.io, stream, tcp_read_buffer, tcp_write_buffer, auth) catch |err| {
                         log.err("TLS handshake failed: {}", .{err});
                         return;
                     };
-
-                    // Cleartext response buffer; same role and size as the plain
-                    // path's write_buffer, so it lives on the stack too.
-                    var cleartext_write_buffer: [4096]u8 = undefined;
-                    var reader = conn.reader(&.{});
-                    var writer = conn.writer(&cleartext_write_buffer);
 
                     // Per-request arena nested on the connection arena: resetting it
                     // between keepalive requests reuses the connection's memory
                     // without touching the TLS buffers carved above.
                     var request_arena = std.heap.ArenaAllocator.init(conn_arena.allocator());
-                    return self.handleRequests(&reader, &writer, &request_arena, &needs_shutdown);
+                    return self.handleRequests(&connection, &request_arena, &needs_shutdown);
                 }
             }
 
-            var reader = stream.reader(self.io, &.{});
-            var write_buffer: [4096]u8 = undefined;
-            var writer = stream.writer(self.io, &write_buffer);
-            return self.handleRequests(&reader, &writer, &conn_arena, &needs_shutdown);
+            connection.initPlain(self.io, stream);
+            return self.handleRequests(&connection, &conn_arena, &needs_shutdown);
         }
 
-        /// Runs the HTTP request/keepalive loop over a reader/writer pair.
-        /// `reader`/`writer` are pointers to either the raw stream's
-        /// Reader/Writer or a tls.Connection's — both expose `.interface` and
-        /// `.err`.
+        /// Runs the HTTP request/keepalive loop over a connection.
         fn handleRequests(
             self: *Self,
-            reader: anytype,
-            writer: anytype,
+            connection: *Connection,
             arena: *std.heap.ArenaAllocator,
             needs_shutdown: *bool,
         ) !void {
             var request: Request = .{
                 .arena = arena.allocator(),
                 .io = self.io,
-                .conn = &reader.interface,
+                .conn = connection.reader,
                 .parser = undefined,
                 .config = self.config.request,
             };
@@ -288,7 +371,7 @@ pub fn Server(comptime Ctx: type) type {
             defer timeout.clear();
 
             // Allocate initial buffer from arena
-            reader.interface.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
+            connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
                 return err;
             };
@@ -300,18 +383,18 @@ pub fn Server(comptime Ctx: type) type {
                     timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
                 }
 
-                parseHeaders(&reader.interface, &parser) catch |err| switch (err) {
+                parseHeaders(connection.reader, &parser) catch |err| switch (err) {
                     error.EndOfStream => {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return reader.err orelse error.ReadFailed,
+                    error.ReadFailed => return connection.checkReadError(err),
                     else => |e| return e,
                 };
 
                 log.debug("Received: {f} {s}", .{ request.method, request.url });
 
-                var response = try Response.init(arena.allocator(), &writer.interface, self.config.request.max_header_count);
+                var response = try Response.init(arena.allocator(), connection, self.config.request.max_header_count);
                 request.response = &response;
 
                 // Handle Expect header (100-continue)
@@ -348,8 +431,8 @@ pub fn Server(comptime Ctx: type) type {
                     .middlewares = if (found) |r| r.middlewares else self.router.middlewares,
                 };
                 executor.run() catch |err| switch (err) {
-                    error.ReadFailed => return reader.err orelse error.ReadFailed,
-                    error.WriteFailed => return writer.err orelse error.WriteFailed,
+                    error.ReadFailed => return connection.checkReadError(err),
+                    error.WriteFailed => return connection.checkWriteError(err),
                     else => |e| return e,
                 };
 
@@ -362,11 +445,11 @@ pub fn Server(comptime Ctx: type) type {
                     };
                     if (drainable) {
                         var scratch: [4096]u8 = undefined;
-                        var body_reader = RequestBodyReader.init(&parser, &reader.interface, &scratch);
+                        var body_reader = RequestBodyReader.init(&parser, connection.reader, &scratch);
                         if (body_reader.interface.discardShort(max + 1)) |consumed| {
                             if (consumed > max) response.keepalive = false;
-                        } else |_| {
-                            if (reader.err) |e| if (e == error.Canceled) return error.Canceled;
+                        } else |drain_err| {
+                            connection.checkReadError(drain_err) catch |e| if (e == error.Canceled) return error.Canceled;
                             response.keepalive = false;
                         }
                     } else {
@@ -388,31 +471,31 @@ pub fn Server(comptime Ctx: type) type {
                 request.reset();
 
                 // If there's buffered data (pipelining), close connection - we don't support it
-                if (reader.interface.end > reader.interface.seek) {
+                if (connection.reader.end > connection.reader.seek) {
                     break;
                 }
 
                 _ = arena.reset(.retain_capacity);
 
                 // Allocate fresh buffer for keepalive wait (previous buffer was freed by arena reset)
-                reader.interface.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
+                connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
                     log.err("Failed to allocate read buffer: {}", .{err});
                     return err;
                 };
-                reader.interface.seek = 0;
-                reader.interface.end = 0;
+                connection.reader.seek = 0;
+                connection.reader.end = 0;
 
                 if (self.config.timeout.keepalive) |duration| {
                     timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
                 }
 
                 // Fill some data here, under the keepalive timeout
-                reader.interface.fillMore() catch |err| switch (err) {
+                connection.reader.fillMore() catch |err| switch (err) {
                     error.EndOfStream => {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return reader.err orelse error.ReadFailed,
+                    error.ReadFailed => return connection.checkReadError(err),
                 };
             }
         }

--- a/src/tls_stub.zig
+++ b/src/tls_stub.zig
@@ -48,8 +48,8 @@ pub const config = struct {
 };
 
 pub const Connection = struct {
-    pub const Reader = struct { interface: std.Io.Reader };
-    pub const Writer = struct { interface: std.Io.Writer };
+    pub const Reader = struct { interface: std.Io.Reader, err: ?anyerror = null };
+    pub const Writer = struct { interface: std.Io.Writer, err: ?anyerror = null };
 
     pub fn reader(self: *Connection, buffer: []u8) Reader {
         _ = self;


### PR DESCRIPTION
## Summary
- Introduce `server.Connection`, which owns the reader/writer for one accepted connection (plain TCP, or the whole TLS + underlying TCP layer), initialized in place since `tls.Connection` and its cleartext reader/writer hold pointers into their siblings.
- `Response.conn` is now `*Connection` instead of a bare `*std.Io.Writer`, so it can reach past the generic `error.WriteFailed`/`error.ReadFailed` to the real underlying error (e.g. `ConnectionResetByPeer`) when one was recorded.
- `Connection.checkReadError`/`checkWriteError` do the translation: `anytype` error param (so the caller's real error type flows through instead of widening to `anyerror`) and an inferred `!void` return; the TLS-specific scan is gated behind `build_options.use_tls` so it compiles away entirely when TLS support isn't built in.
- `Response.chunk()` now routes its writes through `checkWriteError`, so a chunked body write surfaces the real error instead of the generic `WriteFailed`.
- `tls_stub.zig` gained the `err` field on its `Connection.Reader`/`Writer` stubs to match the real `tls.zig` shape.

## Test plan
- [x] `./check.sh` (default, TLS on) — 222/222 passing
- [x] `zig build test -Duse_tls=false` — 222/222 passing
- [x] New tests: `chunk()` surfaces an injected real error, and falls back to `error.WriteFailed` when none was recorded