### PR TITLE
WebSocket: serialize frame writes

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -118,33 +118,23 @@ pub const WebSocketClient = struct {
     ws: WebSocket,
     conn: *Connection,
 
+    // No flushing here: `WebSocket` flushes each frame while holding its write
+    // mutex, and a flush from out here would touch the same writer unguarded.
+
     pub fn send(self: *WebSocketClient, msg_type: WebSocket.MessageType, data: []const u8) !void {
-        try self.ws.send(msg_type, data);
-        try self.conn.flush();
+        return self.ws.send(msg_type, data);
     }
 
     pub fn receive(self: *WebSocketClient) !WebSocket.Message {
-        const msg = self.ws.receive() catch |err| {
-            if (self.ws.auto_responded) {
-                // Best effort: flush queued control-frame reply before bubbling error.
-                self.conn.flush() catch {};
-            }
-            return err;
-        };
-        if (self.ws.auto_responded) {
-            try self.conn.flush();
-        }
-        return msg;
+        return self.ws.receive();
     }
 
     pub fn ping(self: *WebSocketClient, data: []const u8) !void {
-        try self.ws.ping(data);
-        try self.conn.flush();
+        return self.ws.ping(data);
     }
 
     pub fn close(self: *WebSocketClient, code: WebSocket.CloseCode, reason: []const u8) !void {
-        try self.ws.close(code, reason);
-        try self.conn.flush();
+        return self.ws.close(code, reason);
     }
 
     pub fn deinit(self: *WebSocketClient) void {

--- a/src/client.zig
+++ b/src/client.zig
@@ -895,7 +895,7 @@ pub const Client = struct {
 
         var seed: u64 = undefined;
         self.io.random(std.mem.asBytes(&seed));
-        var ws = WebSocket.init(conn.writer, conn.reader, conn.allocator, seed);
+        var ws = WebSocket.init(self.io, conn.writer, conn.reader, conn.allocator, seed);
         ws.is_client = true;
         return .{ .ws = ws, .conn = conn };
     }

--- a/src/response.zig
+++ b/src/response.zig
@@ -209,7 +209,7 @@ pub const Response = struct {
 
         var seed: u64 = undefined;
         req.io.random(std.mem.asBytes(&seed));
-        return WebSocket.init(self.conn, req.conn, self.arena, seed);
+        return WebSocket.init(req.io, self.conn, req.conn, self.arena, seed);
     }
 
     pub fn writeHeader(self: *Response) !void {

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -1,6 +1,12 @@
 const std = @import("std");
 
+/// An established WebSocket connection (RFC 6455). Obtained from
+/// `Response.upgradeWebSocket` on the server side and `Client.connectWebSocket`
+/// on the client side; call `deinit` when done.
+///
+/// One task may call `receive`; any number of tasks may send concurrently.
 pub const WebSocket = struct {
+    io: std.Io,
     conn: *std.Io.Writer,
     reader: *std.Io.Reader,
     msg_arena: std.heap.ArenaAllocator,
@@ -11,6 +17,7 @@ pub const WebSocket = struct {
     auto_responded: bool = false,
     fragmented_type: ?MessageType = null,
     fragmented_data: std.ArrayListUnmanaged(u8) = .empty,
+    write_mutex: std.Io.Mutex = .init,
 
     pub const default_max_message_size: usize = 16 * 1024 * 1024; // 16MB
 
@@ -59,8 +66,9 @@ pub const WebSocket = struct {
 
     const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-    pub fn init(conn: *std.Io.Writer, reader: *std.Io.Reader, gpa: std.mem.Allocator, seed: u64) WebSocket {
+    pub fn init(io: std.Io, conn: *std.Io.Writer, reader: *std.Io.Reader, gpa: std.mem.Allocator, seed: u64) WebSocket {
         return .{
+            .io = io,
             .conn = conn,
             .reader = reader,
             .msg_arena = std.heap.ArenaAllocator.init(gpa),
@@ -248,6 +256,13 @@ pub const WebSocket = struct {
     }
 
     fn writeFrame(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) !void {
+        try self.write_mutex.lock(self.io);
+        defer self.write_mutex.unlock(self.io);
+
+        // A half-written frame leaves the peer unable to find the next frame
+        // boundary.
+        errdefer self.closed = true;
+
         // First byte: FIN + opcode
         const byte0: u8 = (@as(u8, if (fin) 0x80 else 0x00)) | @intFromEnum(opcode);
         try self.conn.writeByte(byte0);
@@ -315,7 +330,7 @@ test "WebSocket: writeFrame text" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeFrame(.text, "Hello", true);
 
@@ -333,7 +348,7 @@ test "WebSocket: writeFrame binary with medium length" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
 
     const payload = "x" ** 200;
@@ -353,7 +368,7 @@ test "WebSocket: writeCloseFrame" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeCloseFrame(.normal, "goodbye");
 
@@ -382,7 +397,7 @@ test "WebSocket: readFrame unmasked (client mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     const frame = try ws.readFrame();
@@ -398,7 +413,7 @@ test "WebSocket: readFrame rejects unmasked client frame (server mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     // is_client = false (default) — must reject unmasked input per RFC 6455 §5.1.
     try std.testing.expectError(WebSocket.Error.UnmaskedClientFrame, ws.readFrame());
@@ -414,7 +429,7 @@ test "WebSocket: readFrame rejects masked server frame (client mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try std.testing.expectError(WebSocket.Error.MaskedServerFrame, ws.readFrame());
@@ -436,7 +451,7 @@ test "WebSocket: readFrame masked" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     const frame = try ws.readFrame();
 
@@ -461,7 +476,7 @@ test "WebSocket: receive handles ping automatically" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     const msg = try ws.receive();
 
@@ -490,7 +505,7 @@ test "WebSocket: readFrame rejects RSV bits" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     try std.testing.expectError(WebSocket.Error.ReservedFlags, ws.readFrame());
 }
@@ -510,7 +525,7 @@ test "WebSocket: readFrame rejects large control frame" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try std.testing.expectError(WebSocket.Error.LargeControlFrame, ws.readFrame());
@@ -521,7 +536,7 @@ test "WebSocket: writeFrame masked (client mode)" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(&conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try ws.writeFrame(.text, "Hello", true);
@@ -543,4 +558,81 @@ test "WebSocket: writeFrame masked (client mode)" {
     try std.testing.expectEqualStrings("Hello", &unmasked);
     // Total length: 1 (header) + 1 (len) + 4 (mask) + 5 (payload) = 11
     try std.testing.expectEqual(11, written.len);
+}
+
+/// Collects everything written, suspending on each drain so another task gets
+/// a chance to write into the middle of a frame.
+const InterleaveProbe = struct {
+    interface: std.Io.Writer,
+    io: std.Io,
+    out: std.ArrayListUnmanaged(u8) = .empty,
+    gpa: std.mem.Allocator,
+    buf: [8]u8 = undefined,
+
+    fn init(gpa: std.mem.Allocator, io: std.Io) InterleaveProbe {
+        return .{
+            .interface = .{
+                .vtable = &.{ .drain = drain },
+                .buffer = &.{},
+            },
+            .io = io,
+            .gpa = gpa,
+        };
+    }
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *InterleaveProbe = @alignCast(@fieldParentPtr("interface", w));
+        self.io.sleep(.fromNanoseconds(1), .awake) catch {};
+        var n: usize = 0;
+        for (data[0 .. data.len - 1]) |bytes| {
+            self.out.appendSlice(self.gpa, bytes) catch return error.WriteFailed;
+            n += bytes.len;
+        }
+        const pattern = data[data.len - 1];
+        for (0..splat) |_| {
+            self.out.appendSlice(self.gpa, pattern) catch return error.WriteFailed;
+            n += pattern.len;
+        }
+        return n;
+    }
+};
+
+test "WebSocket: concurrent sends do not interleave within a frame" {
+    const gpa = std.testing.allocator;
+    const io = std.testing.io;
+
+    var probe = InterleaveProbe.init(gpa, io);
+    defer probe.out.deinit(gpa);
+    var reader: std.Io.Reader = .fixed("");
+
+    var ws = WebSocket.init(io, &probe.interface, &reader, gpa, 0);
+    defer ws.deinit();
+
+    const a = "a" ** 300;
+    const b = "b" ** 300;
+
+    var fa = try io.concurrent(struct {
+        fn run(s: *WebSocket, payload: []const u8) !void {
+            try s.send(.text, payload);
+        }
+    }.run, .{ &ws, a });
+    var fb = try io.concurrent(struct {
+        fn run(s: *WebSocket, payload: []const u8) !void {
+            try s.send(.text, payload);
+        }
+    }.run, .{ &ws, b });
+    try fa.await(io);
+    try fb.await(io);
+
+    // Each payload goes out in one write, so it stays contiguous even when
+    // interleaved; only the header gets separated from it. Compare whole frames.
+    const header = [_]u8{ 0x80 | @as(u8, @intFromEnum(WebSocket.MessageType.text)), 126, 0x01, 0x2C };
+    const frame_a = header ++ a.*;
+    const frame_b = header ++ b.*;
+    const written = probe.out.items;
+    const ab = frame_a ++ frame_b;
+    const ba = frame_b ++ frame_a;
+    if (!std.mem.eql(u8, written, &ab) and !std.mem.eql(u8, written, &ba)) {
+        return error.FrameInterleaved;
+    }
 }

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -105,7 +105,6 @@ pub const WebSocket = struct {
                     continue;
                 },
                 .close => {
-                    self.closed = true;
                     var close_code: ?CloseCode = null;
                     var reason: []const u8 = "";
                     if (frame.payload.len >= 2) {
@@ -114,7 +113,7 @@ pub const WebSocket = struct {
                         reason = frame.payload[2..];
                     }
                     // Echo close frame back
-                    try self.writeCloseFrame(close_code orelse .normal, reason);
+                    try self.writeClose(close_code orelse .normal, reason);
                     self.auto_responded = true;
                     return .{ .type = .close, .data = reason, .close_code = close_code };
                 },
@@ -163,23 +162,20 @@ pub const WebSocket = struct {
 
     /// Send a text or binary message
     pub fn send(self: *WebSocket, msg_type: MessageType, data: []const u8) !void {
-        if (self.closed) return error.EndOfStream;
         if (msg_type != .text and msg_type != .binary) return Error.InvalidOpcode;
         try self.writeFrame(msg_type, data, true);
     }
 
     /// Send a ping frame
     pub fn ping(self: *WebSocket, data: []const u8) !void {
-        if (self.closed) return error.EndOfStream;
         if (data.len > 125) return Error.LargeControlFrame;
         try self.writeFrame(.ping, data, true);
     }
 
-    /// Send close frame and mark connection as closed
+    /// Send close frame and mark connection as closed. Does nothing if a close
+    /// frame has already been sent.
     pub fn close(self: *WebSocket, code: CloseCode, reason: []const u8) !void {
-        if (self.closed) return;
-        self.closed = true;
-        try self.writeCloseFrame(code, reason);
+        return self.writeClose(code, reason);
     }
 
     const Frame = struct {
@@ -258,7 +254,11 @@ pub const WebSocket = struct {
     fn writeFrame(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) !void {
         try self.write_mutex.lock(self.io);
         defer self.write_mutex.unlock(self.io);
+        if (self.closed) return error.EndOfStream;
+        return self.writeFrameLocked(opcode, data, fin);
+    }
 
+    fn writeFrameLocked(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) !void {
         // A half-written frame leaves the peer unable to find the next frame
         // boundary.
         errdefer self.closed = true;
@@ -299,12 +299,17 @@ pub const WebSocket = struct {
         try self.conn.flush();
     }
 
-    fn writeCloseFrame(self: *WebSocket, code: CloseCode, reason: []const u8) !void {
+    fn writeClose(self: *WebSocket, code: CloseCode, reason: []const u8) !void {
+        try self.write_mutex.lock(self.io);
+        defer self.write_mutex.unlock(self.io);
+        if (self.closed) return;
+        self.closed = true;
+
         var buf: [127]u8 = undefined;
         std.mem.writeInt(u16, buf[0..2], @intFromEnum(code), .big);
         const reason_len = @min(reason.len, 123);
         @memcpy(buf[2..][0..reason_len], reason[0..reason_len]);
-        try self.writeFrame(.close, buf[0 .. 2 + reason_len], true);
+        try self.writeFrameLocked(.close, buf[0 .. 2 + reason_len], true);
     }
 
     /// Compute Sec-WebSocket-Accept value from client key
@@ -363,14 +368,14 @@ test "WebSocket: writeFrame binary with medium length" {
     try std.testing.expectEqual(200, std.mem.readInt(u16, written[2..4], .big));
 }
 
-test "WebSocket: writeCloseFrame" {
+test "WebSocket: writeClose" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
     var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
     defer ws.deinit();
-    try ws.writeCloseFrame(.normal, "goodbye");
+    try ws.writeClose(.normal, "goodbye");
 
     const written = conn_writer.buffered();
     // FIN + close opcode


### PR DESCRIPTION
Fixes the shared-writer race reported in #120.

## The defect

`receive` answers a ping by writing a pong to the same socket. An application that sends from one task and receives in another therefore has two writers on one connection *even if every one of its own sends goes through a single task* — the library injects the second one. A single-writer discipline is not reachable through the current API.

A frame is several writes into a buffered writer. Small frames are pure memcpy and happen to be atomic, but `writeAll` on a payload larger than the writer's free space drains part way through, and a drain suspends. The other task resumes and writes into the middle of the frame; the peer sees a malformed frame and drops the connection.

## The fix

Guard `writeFrame` with an `Io.Mutex`, so `send`, `ping`, `close` and the automatic pong are atomic with respect to each other. This needs no API change beyond an `Io` in `WebSocket.init`, and no cooperation from the application.

A failed write now also sets `closed`, since a half-written frame leaves the peer unable to find the next frame boundary.

## Relation to the patch in #120

#120 adds a `no_auto_pong` flag so the ping surfaces to the application, which then queues the pong through its own writer task. That is the right fix for the architecture it was written for: one task owns the socket, everything to be sent goes through its queue, and no locking is needed because nothing else ever writes. The automatic pong was the single write that could not be routed through that queue, and the flag restores the invariant.

This PR takes the other route because a framework has to be correct for applications that did not adopt that pattern — with a mutex, sending from several tasks is safe too, and no application has to implement ping handling to be correct. The two are complementary rather than opposed; `no_auto_pong` would still make sense later for applications that want the library to stay off the wire entirely.

## Test

`WebSocket: concurrent sends do not interleave within a frame` drives two concurrent `send` calls through a writer that suspends on every drain, then asserts the output is exactly one frame followed by the other.

Verified it catches the bug: with the lock removed the test fails with `FrameInterleaved`.

Note the assertion compares whole frames rather than searching for the payloads. Each payload goes out in a single write so it stays contiguous even when interleaved — only the header gets separated from it. An earlier version of the test searched for payloads and passed without the lock.

## Not addressed

Concurrent `receive` from multiple tasks is still unsafe. The type doc now states the contract: one reader, any number of senders.