### PR TITLE
Response: write bodies through std.Io.Writer

### DIFF
--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -65,19 +65,15 @@ fn handleChunked(ctx: *AppContext, req: *const http.Request, res: *http.Response
     try res.header("X-Demo", "Chunked-Response");
     res.status = .ok;
 
-    // The body is written through a buffer the handler owns. It is sent
-    // with a Content-Length if it all fits, and switches to chunked
-    // transfer encoding as soon as it does not, or as soon as we flush.
+    // Streamed: the headers go out now and each flush puts a chunk on
+    // the wire, so the client sees the response as it is produced.
     var buf: [256]u8 = undefined;
-    var body = res.writer(&buf);
+    var body = try res.stream(&buf);
     const w = &body.interface;
 
     try w.writeAll("First chunk of data\n");
     try w.writeAll("Second chunk of data\n");
     try w.writeAll("Third chunk of data\n");
-
-    // Force it out now rather than waiting for the buffer to fill; this is
-    // what commits the response to chunked encoding.
     try w.flush();
 
     try w.print("Chunk with timestamp: {d}\n", .{std.Io.Timestamp.now(req.io, .real).toSeconds()});

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -65,17 +65,25 @@ fn handleChunked(ctx: *AppContext, req: *const http.Request, res: *http.Response
     try res.header("X-Demo", "Chunked-Response");
     res.status = .ok;
 
-    // Send chunks of data
-    try res.chunk("First chunk of data\n");
-    try res.chunk("Second chunk of data\n");
-    try res.chunk("Third chunk of data\n");
+    // The body is written through a buffer the handler owns. It is sent
+    // with a Content-Length if it all fits, and switches to chunked
+    // transfer encoding as soon as it does not, or as soon as we flush.
+    var buf: [256]u8 = undefined;
+    var body = res.writer(&buf);
+    const w = &body.interface;
 
-    // Dynamic content in chunk
-    const dynamic = try std.fmt.allocPrint(res.arena, "Chunk with timestamp: {d}\n", .{std.Io.Timestamp.now(req.io, .real).toSeconds()});
-    try res.chunk(dynamic);
+    try w.writeAll("First chunk of data\n");
+    try w.writeAll("Second chunk of data\n");
+    try w.writeAll("Third chunk of data\n");
 
-    try res.chunk("Final chunk!\n");
-    // res.write() will be called automatically by the server to add terminator
+    // Force it out now rather than waiting for the buffer to fill; this is
+    // what commits the response to chunked encoding.
+    try w.flush();
+
+    try w.print("Chunk with timestamp: {d}\n", .{std.Io.Timestamp.now(req.io, .real).toSeconds()});
+    try w.writeAll("Final chunk!\n");
+
+    try body.end();
 }
 
 fn handleJson(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -81,8 +81,10 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
 
     // Stream response body
     const body_reader = upstream_res.reader();
-    const res_writer = res.writer();
-    const bytes_written = try body_reader.streamRemaining(res_writer);
+    var buf: [4096]u8 = undefined;
+    var body_writer = res.writer(&buf);
+    const bytes_written = try body_reader.streamRemaining(&body_writer.interface);
+    try body_writer.end();
 
     std.log.info("Proxied response: {d} bytes", .{bytes_written});
 }

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -28,6 +28,9 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
         if (std.ascii.eqlIgnoreCase(key, "connection") or
             std.ascii.eqlIgnoreCase(key, "keep-alive") or
             std.ascii.eqlIgnoreCase(key, "transfer-encoding") or
+            // The client decompresses transparently, so the upstream
+            // length does not describe what we are about to send.
+            std.ascii.eqlIgnoreCase(key, "content-length") or
             std.ascii.eqlIgnoreCase(key, "upgrade") or
             std.ascii.eqlIgnoreCase(key, "proxy-connection") or
             std.ascii.eqlIgnoreCase(key, "host"))
@@ -70,6 +73,9 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
         if (std.ascii.eqlIgnoreCase(key, "connection") or
             std.ascii.eqlIgnoreCase(key, "keep-alive") or
             std.ascii.eqlIgnoreCase(key, "transfer-encoding") or
+            // The client decompresses transparently, so the upstream
+            // length does not describe what we are about to send.
+            std.ascii.eqlIgnoreCase(key, "content-length") or
             std.ascii.eqlIgnoreCase(key, "upgrade") or
             std.ascii.eqlIgnoreCase(key, "proxy-connection"))
         {
@@ -82,7 +88,7 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     // Stream response body
     const body_reader = upstream_res.reader();
     var buf: [4096]u8 = undefined;
-    var body_writer = res.writer(&buf);
+    var body_writer = try res.stream(&buf);
     const bytes_written = try body_reader.streamRemaining(&body_writer.interface);
     try body_writer.end();
 

--- a/src/middleware/Session.zig
+++ b/src/middleware/Session.zig
@@ -98,19 +98,26 @@ pub fn execute(self: *const Session, req: *Request, res: *Response, executor: an
     const should_set = req.session.modified or (self.config.max_age != null and req.session.len > 0);
 
     if (should_set) {
-        if (req.session.len == 0) {
+        const result = if (req.session.len == 0) blk: {
             // Session was cleared — delete the cookie
             var delete_opts = self.config.cookie_opts;
             delete_opts.max_age = .zero;
-            try res.setCookie(self.config.cookie_name, "", delete_opts);
-        } else {
+            break :blk res.setCookie(self.config.cookie_name, "", delete_opts);
+        } else blk: {
             const signed = try self.signSession(req.arena, &req.session, .now(req.io, .real));
             var opts = self.config.cookie_opts;
             if (self.config.max_age) |ma| {
                 opts.max_age = ma;
             }
-            try res.setCookie(self.config.cookie_name, signed, opts);
-        }
+            break :blk res.setCookie(self.config.cookie_name, signed, opts);
+        };
+        result catch |err| switch (err) {
+            // The handler streamed its response, so the headers left before
+            // we got here and the cookie cannot be refreshed. That is the
+            // handler's choice to make, not a failure of the request.
+            error.HeadersAlreadySent => log.debug("session cookie not set: response already started", .{}),
+            else => |e| return e,
+        };
     }
 }
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -240,6 +240,7 @@ pub const Response = struct {
     }
 
     pub fn header(self: *Response, name: []const u8, value: []const u8) !void {
+        std.debug.assert(!self.headers_written); // headers are already on the wire
         try http.validateHeaderName(name);
         try http.validateHeaderValue(value);
         try self.headers.put(name, value);
@@ -267,6 +268,7 @@ pub const Response = struct {
     }
 
     pub fn setCookie(self: *Response, name: []const u8, value: []const u8, opts: CookieOpts) !void {
+        std.debug.assert(!self.headers_written); // headers are already on the wire
         const serialized = try serializeCookie(self.arena, name, value, opts);
         try http.validateHeaderValue(serialized);
         try self.headers.add("Set-Cookie", serialized);
@@ -319,15 +321,16 @@ pub const Response = struct {
         if (self.headers_written) {
             return;
         }
+
+        // Set the Content-Type header. Before the flag, so it goes through
+        // the same door as every other header rather than around it.
+        if (self.content_type) |content_type| {
+            try self.header("Content-Type", content_type.toContentType());
+        }
         self.headers_written = true;
 
         // Write status line
         try self.conn.writer.print("HTTP/1.1 {d} {f}\r\n", .{ @intFromEnum(self.status), self.status });
-
-        // Set the Content-Type header
-        if (self.content_type) |content_type| {
-            try self.header("Content-Type", content_type.toContentType());
-        }
 
         // Write headers
         var iter = self.headers.iterator();

--- a/src/response.zig
+++ b/src/response.zig
@@ -155,7 +155,9 @@ pub const BodyWriter = struct {
     /// Marks the body complete. It is sent with the rest of the response,
     /// once the headers have settled.
     pub fn end(self: *BodyWriter) !void {
-        std.debug.assert(self.res.body_writer_open); // end called twice
+        // Idempotent, so `defer body.end() catch {}` alongside an explicit
+        // `end` on the success path is harmless rather than a second body.
+        if (!self.res.body_writer_open) return;
         self.res.body_writer_open = false;
         try self.interface.flush();
     }
@@ -179,11 +181,6 @@ pub const StreamingBodyWriter = struct {
     /// fails, so a handler that catches one can find out what happened
     /// instead of being told only that it did.
     err: ?Error = null,
-    /// Length the handler declared, if any.
-    content_length: ?usize = null,
-    /// Body bytes handed to the connection, checked against `content_length`.
-    sent: usize = 0,
-
     /// Everything `writeHeader` can fail with, plus the real transport
     /// errors hiding behind `WriteFailed`.
     pub const Error = Connection.WriteError || HeaderError;
@@ -222,7 +219,7 @@ pub const StreamingBodyWriter = struct {
             self.writeChunk(pending, data, splat, total)
         else
             self.writeBody(pending, data, splat));
-        self.sent += total;
+        self.res.body_sent += total;
         return w.consume(total);
     }
 
@@ -272,7 +269,9 @@ pub const StreamingBodyWriter = struct {
     /// writes the terminator. Must be called before the handler returns.
     pub fn end(self: *StreamingBodyWriter) !void {
         const res = self.res;
-        std.debug.assert(res.body_writer_open); // end called twice
+        // Idempotent: a second `end` must not write a second terminator,
+        // which the peer would read as the start of the next message.
+        if (!res.body_writer_open) return;
         res.body_writer_open = false;
 
         try self.record(self.interface.flush());
@@ -280,8 +279,8 @@ pub const StreamingBodyWriter = struct {
         try self.record(res.conn.writer.flush());
         // Sending the wrong number of bytes for a declared length leaves
         // the connection out of sync and the client waiting.
-        if (self.content_length) |declared| {
-            if (self.sent != declared) return error.ContentLengthMismatch;
+        if (res.content_length) |declared| {
+            if (res.body_sent != declared) return error.ContentLengthMismatch;
         }
         res.written = true;
     }
@@ -300,8 +299,14 @@ pub const Response = struct {
     keepalive: bool = true,
     chunked: bool = false,
     streaming: bool = false,
-    /// A `BodyWriter` was handed out and has not been ended yet.
+    /// A body writer was handed out and has not been ended yet.
     body_writer_open: bool = false,
+    /// Length declared before streaming, if any. On the response rather
+    /// than the writer so that `write` can still tell whether the body
+    /// that went out matched it, even if the writer was abandoned.
+    content_length: ?usize = null,
+    /// Body bytes handed to the connection by a streaming writer.
+    body_sent: usize = 0,
 
     pub fn init(arena: std.mem.Allocator, conn: *Connection, max_headers: usize) !Response {
         return .{
@@ -339,14 +344,13 @@ pub const Response = struct {
     /// them afterwards. Call `end` on the result before returning.
     pub fn stream(self: *Response, buf: []u8) !StreamingBodyWriter {
         self.startBody();
-        var body: StreamingBodyWriter = .init(self, buf);
         if (self.headers.get("Content-Length")) |v| {
-            body.content_length = std.fmt.parseInt(usize, v, 10) catch return error.InvalidContentLength;
+            self.content_length = std.fmt.parseInt(usize, v, 10) catch return error.InvalidContentLength;
         } else {
             self.chunked = true;
         }
         try self.writeHeader();
-        return body;
+        return .init(self, buf);
     }
 
     fn startBody(self: *Response) void {
@@ -472,13 +476,25 @@ pub const Response = struct {
         if (self.body_writer_open) {
             self.body_writer_open = false;
             if (self.headers_written) {
-                if (self.chunked) try self.conn.writer.writeAll("0\r\n\r\n");
+                // Streaming was under way. Whatever the writer still held
+                // is gone with the handler's buffer, so the body is short.
+                if (self.chunked) {
+                    // Framing survives: terminate and let the peer see a
+                    // truncated but well formed body.
+                    try self.conn.writer.writeAll("0\r\n\r\n");
+                } else if (self.content_length) |declared| {
+                    // Nothing can make the body match the length we
+                    // promised, so the connection must not be reused: the
+                    // peer would read the next response as this body.
+                    if (self.body_sent != declared) self.keepalive = false;
+                }
                 try self.conn.writer.flush();
                 self.written = true;
                 return;
             }
-            // Nothing was sent, so the caller's own body (a 500, say) wins.
-            _ = self.buffer.writer.consumeAll();
+            // Nothing was sent yet. A buffered body lives in the arena and
+            // is still good, so leave it be: an error handler that built a
+            // replacement has already cleared it.
         }
         self.written = true;
 
@@ -921,6 +937,126 @@ test "StreamingBodyWriter: records the real error behind error.WriteFailed" {
     var body_buf: [64]u8 = undefined;
     try std.testing.expectError(error.WriteFailed, response.stream(&body_buf));
     try std.testing.expectEqual(error.ConnectionResetByPeer, connection.getWriteError().?);
+}
+
+test "BodyWriter: end is idempotent" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body = response.writer();
+    try body.interface.writeAll("hello");
+    try body.end();
+    // The `defer body.end() catch {}` that pairs with the line above.
+    try body.end();
+    try response.write();
+
+    try std.testing.expect(std.mem.endsWith(u8, conn_writer.buffered(), "\r\n\r\nhello"));
+}
+
+test "StreamingBodyWriter: end does not write a second terminator" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("hello");
+    try body.end();
+    try body.end();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.endsWith(u8, written, "5\r\nhello\r\n0\r\n\r\n"));
+    // Exactly one terminator.
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        std.mem.indexOfPos(u8, written, std.mem.indexOf(u8, written, "0\r\n\r\n").? + 1, "0\r\n\r\n"),
+    );
+}
+
+test "Response: an abandoned buffered body is still sent" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body = response.writer();
+    try body.interface.writeAll("hello");
+    // Handler returns without calling end.
+    try response.write();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 5") != null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "hello"));
+}
+
+test "Response: an abandoned short body closes the connection" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    try response.header("Content-Length", "11");
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("hello world");
+    // Handler returns without end, so the body never leaves its buffer.
+    try response.write();
+
+    try std.testing.expectEqual(@as(usize, 0), response.body_sent);
+    // The peer would read the next response as this body, so the
+    // connection must not be reused.
+    try std.testing.expect(!response.keepalive);
+}
+
+test "Response: an abandoned chunked body is still terminated" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("hello");
+    try body.interface.flush();
+    // Handler returns without end.
+    try response.write();
+
+    // Truncated, but framed: the peer knows where the body ended.
+    try std.testing.expect(std.mem.endsWith(u8, conn_writer.buffered(), "0\r\n\r\n"));
+    try std.testing.expect(response.keepalive);
 }
 
 test "Response: json() with simple object" {

--- a/src/response.zig
+++ b/src/response.zig
@@ -273,6 +273,14 @@ pub const StreamingBodyWriter = struct {
         // which the peer would read as the start of the next message.
         if (!res.body_writer_open) return;
         res.body_writer_open = false;
+        // From here the bytes already sent are the response, whatever
+        // happens next, so `write` must not add a terminator or a body to
+        // them.
+        res.written = true;
+        // If this does not finish cleanly the body is not framed the way
+        // its headers promised, and the connection cannot carry another
+        // response.
+        errdefer res.keepalive = false;
 
         try self.record(self.interface.flush());
         if (res.chunked) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
@@ -282,7 +290,6 @@ pub const StreamingBodyWriter = struct {
         if (res.content_length) |declared| {
             if (res.body_sent != declared) return error.ContentLengthMismatch;
         }
-        res.written = true;
     }
 };
 
@@ -499,8 +506,8 @@ pub const Response = struct {
         self.written = true;
 
         if (self.chunked) {
-            // For chunked responses, headers are already written by chunk()
-            // We just need to write the final zero-length chunk terminator
+            // A streaming writer sent the headers; all that is left is the
+            // terminator.
             try self.conn.writer.writeAll("0\r\n\r\n");
             try self.conn.writer.flush();
             return;
@@ -1057,6 +1064,57 @@ test "Response: an abandoned chunked body is still terminated" {
     // Truncated, but framed: the peer knows where the body ended.
     try std.testing.expect(std.mem.endsWith(u8, conn_writer.buffered(), "0\r\n\r\n"));
     try std.testing.expect(response.keepalive);
+}
+
+test "StreamingBodyWriter: a failed end does not let write add to the body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    try response.header("Content-Length", "11");
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    // What an error handler would leave behind after the body started.
+    response.body = "error body";
+    try body.interface.writeAll("short");
+    try std.testing.expectError(error.ContentLengthMismatch, body.end());
+
+    const after_end = conn_writer.end;
+    // The `catch {}` half of `defer body.end() catch {}`: the response is
+    // finished either way, so this must add nothing.
+    try response.write();
+    try std.testing.expectEqual(after_end, conn_writer.end);
+    try std.testing.expect(!response.keepalive);
+}
+
+test "StreamingBodyWriter: a failed end does not leave a second terminator" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("hello");
+    try body.end();
+
+    const written = conn_writer.buffered();
+    try response.write();
+    // Already finished, so nothing more goes out.
+    try std.testing.expectEqualStrings(written, conn_writer.buffered());
 }
 
 test "Response: json() with simple object" {

--- a/src/response.zig
+++ b/src/response.zig
@@ -98,17 +98,80 @@ pub const EventStream = struct {
     }
 };
 
-/// Writes a response body, picking the framing from how much gets written.
+/// Collects a response body without touching the connection.
 ///
-/// Nothing is sent while the body still fits in the caller's buffer, so
-/// `end` can send it with an exact `Content-Length`. The first drain --
-/// the buffer overflowing, or the handler calling `flush` to start
-/// streaming -- commits to chunked transfer encoding, because from then on
-/// the length is not known in advance.
+/// The headers are not sent until the whole response is, so middleware
+/// running after the handler can still change them, and the body is sent
+/// with a `Content-Length`. Storage comes from the response's arena, so
+/// there is no size to pick and nothing for the caller to own.
 ///
-/// The buffer only has to outlive the handler if `end` is not called, and
-/// `end` must be called, so a stack buffer is fine.
+/// This exists as a wrapper rather than a bare `std.Io.Writer` so that a
+/// failure has somewhere to say what it was: the interface can only
+/// report `WriteFailed`.
+///
+/// Use `StreamingBodyWriter` when the body should go out as it is
+/// produced. Either way, `end` must be called before the handler returns.
 pub const BodyWriter = struct {
+    res: *Response,
+    interface: std.Io.Writer,
+    /// The real cause behind the generic `error.WriteFailed`. Nothing here
+    /// talks to the connection, so this only ever holds an allocation
+    /// failure.
+    err: ?Error = null,
+
+    pub const Error = std.mem.Allocator.Error;
+
+    fn init(res: *Response) BodyWriter {
+        return .{
+            .res = res,
+            // Unbuffered: the response's own storage is the buffer, so
+            // holding bytes here would only copy them twice.
+            .interface = .{ .buffer = &no_buf, .vtable = &.{ .drain = BodyWriter.drain } },
+        };
+    }
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *BodyWriter = @alignCast(@fieldParentPtr("interface", w));
+        const out = &self.res.buffer.writer;
+        var total: usize = 0;
+        // Allocating's writer only fails by running out of memory.
+        for (data[0 .. data.len - 1]) |bytes| {
+            out.writeAll(bytes) catch return self.fail();
+            total += bytes.len;
+        }
+        const pattern = data[data.len - 1];
+        for (0..splat) |_| {
+            out.writeAll(pattern) catch return self.fail();
+            total += pattern.len;
+        }
+        return w.consume(total);
+    }
+
+    fn fail(self: *BodyWriter) std.Io.Writer.Error {
+        self.err = error.OutOfMemory;
+        return error.WriteFailed;
+    }
+
+    /// Marks the body complete. It is sent with the rest of the response,
+    /// once the headers have settled.
+    pub fn end(self: *BodyWriter) !void {
+        std.debug.assert(self.res.body_writer_open); // end called twice
+        self.res.body_writer_open = false;
+        try self.interface.flush();
+    }
+};
+
+/// Writes a response body straight to the connection as it is produced.
+///
+/// The headers are sent when this is created, so nothing can change them
+/// afterwards -- `Response.header` and `Response.setCookie` will report
+/// `error.HeadersAlreadySent`. Use `BodyWriter` unless the body really
+/// should go out incrementally.
+///
+/// Framing is decided once, at construction: chunked, unless a
+/// `Content-Length` header already says how long the body will be, in
+/// which case it is streamed as-is.
+pub const StreamingBodyWriter = struct {
     res: *Response,
     interface: std.Io.Writer,
     /// The real cause behind the generic `error.WriteFailed` that the
@@ -116,11 +179,9 @@ pub const BodyWriter = struct {
     /// fails, so a handler that catches one can find out what happened
     /// instead of being told only that it did.
     err: ?Error = null,
-    /// Length the handler declared up front, if any. With one, the body is
-    /// streamed as-is: the length is already known, so chunk framing would
-    /// only add overhead.
+    /// Length the handler declared, if any.
     content_length: ?usize = null,
-    /// Body bytes handed to the transport, checked against `content_length`.
+    /// Body bytes handed to the connection, checked against `content_length`.
     sent: usize = 0,
 
     /// Everything `writeHeader` can fail with, plus the real transport
@@ -129,25 +190,17 @@ pub const BodyWriter = struct {
 
     const HeaderError = @typeInfo(@typeInfo(@TypeOf(Response.writeHeader)).@"fn".return_type.?).error_union.error_set;
 
-    fn init(res: *Response, buf: []u8) BodyWriter {
-        const declared: ?usize = if (res.headers.get("Content-Length")) |v|
-            std.fmt.parseInt(usize, v, 10) catch |e| std.debug.panic("bad Content-Length {s}: {}", .{ v, e })
-        else
-            null;
+    fn init(res: *Response, buf: []u8) StreamingBodyWriter {
         return .{
             .res = res,
-            .content_length = declared,
-            .interface = .{
-                .buffer = buf,
-                .vtable = &.{ .drain = BodyWriter.drain },
-            },
+            .interface = .{ .buffer = buf, .vtable = &.{ .drain = StreamingBodyWriter.drain } },
         };
     }
 
     /// Runs `result`, recording what actually went wrong. The interface
     /// still reports the generic `WriteFailed`, as its contract requires;
     /// `err` is where the answer lives.
-    fn record(self: *BodyWriter, result: HeaderError!void) std.Io.Writer.Error!void {
+    fn record(self: *StreamingBodyWriter, result: HeaderError!void) std.Io.Writer.Error!void {
         result catch |e| {
             self.err = if (e == error.WriteFailed)
                 self.res.conn.getWriteError() orelse e
@@ -158,25 +211,14 @@ pub const BodyWriter = struct {
     }
 
     fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
-        const self: *BodyWriter = @alignCast(@fieldParentPtr("interface", w));
-        const res = self.res;
-
-        // Getting here means the body outgrew the buffer, or the handler
-        // asked to start streaming. Either way it is going out now, so the
-        // framing has to be decided: chunked, unless the handler already
-        // told us how long the body is.
-        if (!res.headers_written) {
-            if (self.content_length == null) res.chunked = true;
-            try self.record(res.writeHeader());
-        }
-
+        const self: *StreamingBodyWriter = @alignCast(@fieldParentPtr("interface", w));
         const pending = w.buffered();
         const total = pending.len + std.Io.Writer.countSplat(data, splat);
-        // A zero length chunk is the terminator, so an empty flush has to
-        // send nothing at all rather than ending the body early.
+        // A zero length chunk is the terminator, so an empty drain must
+        // send nothing rather than ending the body early.
         if (total == 0) return 0;
 
-        try self.record(if (res.chunked)
+        try self.record(if (self.res.chunked)
             self.writeChunk(pending, data, splat, total)
         else
             self.writeBody(pending, data, splat));
@@ -184,23 +226,32 @@ pub const BodyWriter = struct {
         return w.consume(total);
     }
 
+    fn writeParts(
+        out: *std.Io.Writer,
+        pending: []const u8,
+        data: []const []const u8,
+        splat: usize,
+    ) std.Io.Writer.Error!void {
+        try out.writeAll(pending);
+        for (data[0 .. data.len - 1]) |bytes| try out.writeAll(bytes);
+        const pattern = data[data.len - 1];
+        for (0..splat) |_| try out.writeAll(pattern);
+    }
+
     /// Streams the body as-is, for a declared Content-Length.
     fn writeBody(
-        self: *BodyWriter,
+        self: *StreamingBodyWriter,
         pending: []const u8,
         data: []const []const u8,
         splat: usize,
     ) std.Io.Writer.Error!void {
         const out = self.res.conn.writer;
-        try out.writeAll(pending);
-        for (data[0 .. data.len - 1]) |bytes| try out.writeAll(bytes);
-        const pattern = data[data.len - 1];
-        for (0..splat) |_| try out.writeAll(pattern);
+        try writeParts(out, pending, data, splat);
         try out.flush();
     }
 
     fn writeChunk(
-        self: *BodyWriter,
+        self: *StreamingBodyWriter,
         pending: []const u8,
         data: []const []const u8,
         splat: usize,
@@ -212,40 +263,26 @@ pub const BodyWriter = struct {
 
         const out = self.res.conn.writer;
         try out.writeAll(size);
-        try out.writeAll(pending);
-        for (data[0 .. data.len - 1]) |bytes| try out.writeAll(bytes);
-        const pattern = data[data.len - 1];
-        for (0..splat) |_| try out.writeAll(pattern);
+        try writeParts(out, pending, data, splat);
         try out.writeAll("\r\n");
         try out.flush();
     }
 
-    /// Finishes the body. Must be called before the handler returns: until
-    /// it does, a buffered body has not been sent and a chunked one has no
-    /// terminator.
-    pub fn end(self: *BodyWriter) !void {
+    /// Finishes the body: flushes what is left and, for a chunked body,
+    /// writes the terminator. Must be called before the handler returns.
+    pub fn end(self: *StreamingBodyWriter) !void {
         const res = self.res;
-        std.debug.assert(res.body_writer_open);
+        std.debug.assert(res.body_writer_open); // end called twice
         res.body_writer_open = false;
 
-        if (res.headers_written) {
-            // Already streaming; drain whatever is left.
-            try self.record(self.interface.flush());
-            if (res.chunked) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
-        } else {
-            // Never drained, so the whole body is still in the buffer and
-            // its length is known without the handler saying so.
-            const body = self.interface.buffered();
-            res.body = body;
-            defer res.body = "";
-            try self.record(res.writeHeader());
-            try self.record(res.conn.writer.writeAll(body));
-            self.sent += body.len;
-        }
+        try self.record(self.interface.flush());
+        if (res.chunked) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
         try self.record(res.conn.writer.flush());
-        // Sending the wrong number of bytes for a declared length leaves the
-        // connection out of sync, and the client waiting.
-        if (self.content_length) |declared| std.debug.assert(self.sent == declared);
+        // Sending the wrong number of bytes for a declared length leaves
+        // the connection out of sync and the client waiting.
+        if (self.content_length) |declared| {
+            if (self.sent != declared) return error.ContentLengthMismatch;
+        }
         res.written = true;
     }
 };
@@ -276,21 +313,47 @@ pub const Response = struct {
     }
 
     pub fn header(self: *Response, name: []const u8, value: []const u8) !void {
-        std.debug.assert(!self.headers_written); // headers are already on the wire
+        // Not a programmer error: middleware that runs after the handler
+        // cannot know whether the handler chose to stream.
+        if (self.headers_written) return error.HeadersAlreadySent;
         try http.validateHeaderName(name);
         try http.validateHeaderValue(value);
         try self.headers.put(name, value);
     }
 
-    /// A writer for the response body. `buf` holds the body until it
-    /// overflows or is flushed; see `BodyWriter`. Call `end` on the result
-    /// before returning from the handler.
-    pub fn writer(self: *Response, buf: []u8) BodyWriter {
+    /// A writer that collects the body without touching the connection.
+    /// The headers are not sent until the whole response is, so anything
+    /// running after the handler can still change them.
+    ///
+    /// Call `end` on the result before returning from the handler.
+    pub fn writer(self: *Response) BodyWriter {
+        self.startBody();
+        return .init(self);
+    }
+
+    /// A writer that sends the headers now and streams the body as it is
+    /// written. Chunked, unless a `Content-Length` header says how long the
+    /// body will be, in which case it is streamed as-is.
+    ///
+    /// The headers are on the wire when this returns, so nothing can change
+    /// them afterwards. Call `end` on the result before returning.
+    pub fn stream(self: *Response, buf: []u8) !StreamingBodyWriter {
+        self.startBody();
+        var body: StreamingBodyWriter = .init(self, buf);
+        if (self.headers.get("Content-Length")) |v| {
+            body.content_length = std.fmt.parseInt(usize, v, 10) catch return error.InvalidContentLength;
+        } else {
+            self.chunked = true;
+        }
+        try self.writeHeader();
+        return body;
+    }
+
+    fn startBody(self: *Response) void {
         std.debug.assert(!self.body_writer_open); // one body writer per response
         std.debug.assert(!self.headers_written); // body cannot start after the headers
         std.debug.assert(self.body.len == 0 and self.buffer.writer.end == 0); // body already set
         self.body_writer_open = true;
-        return .init(self, buf);
     }
 
     pub fn clearWriter(self: *Response) void {
@@ -304,7 +367,7 @@ pub const Response = struct {
     }
 
     pub fn setCookie(self: *Response, name: []const u8, value: []const u8, opts: CookieOpts) !void {
-        std.debug.assert(!self.headers_written); // headers are already on the wire
+        if (self.headers_written) return error.HeadersAlreadySent;
         const serialized = try serializeCookie(self.arena, name, value, opts);
         try http.validateHeaderValue(serialized);
         try self.headers.add("Set-Cookie", serialized);
@@ -402,9 +465,21 @@ pub const Response = struct {
         if (self.written) {
             return;
         }
-        // The body writer's buffer belongs to the handler and is gone by
-        // now, so there is nothing left that could finish the response.
-        std.debug.assert(!self.body_writer_open); // handler returned without calling end()
+        // A handler that failed part way through may never have called
+        // `end`. Its buffer is gone, so whatever it held is lost either
+        // way; recover rather than take the process down, and make sure a
+        // started body is still framed correctly.
+        if (self.body_writer_open) {
+            self.body_writer_open = false;
+            if (self.headers_written) {
+                if (self.chunked) try self.conn.writer.writeAll("0\r\n\r\n");
+                try self.conn.writer.flush();
+                self.written = true;
+                return;
+            }
+            // Nothing was sent, so the caller's own body (a 500, say) wins.
+            _ = self.buffer.writer.consumeAll();
+        }
         self.written = true;
 
         if (self.chunked) {
@@ -427,89 +502,6 @@ pub const Response = struct {
     }
 };
 
-test "BodyWriter: a body that fits is sent with a Content-Length" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    var body_buf: [64]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("Hello, ");
-    try body.interface.writeAll("World!");
-    try body.end();
-
-    try std.testing.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\n" ++
-            "Content-Length: 13\r\n" ++
-            "\r\n" ++
-            "Hello, World!",
-        conn_writer.buffered(),
-    );
-    try std.testing.expect(!response.chunked);
-}
-test "BodyWriter: overflowing the buffer switches to chunked" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    // Too small for the body, so the first write has to drain.
-    var body_buf: [8]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.print("Hello, {s}! You are {d}.", .{ "Alice", 30 });
-    try body.end();
-
-    const written = conn_writer.buffered();
-    try std.testing.expect(response.chunked);
-    try std.testing.expect(std.mem.indexOf(u8, written, "Transfer-Encoding: chunked") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length") == null);
-    try std.testing.expect(std.mem.endsWith(u8, written, "0\r\n\r\n"));
-}
-test "BodyWriter: flush starts streaming before the buffer is full" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    var body_buf: [1024]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("first");
-    // Plenty of room left, but the handler wants it on the wire now.
-    try body.interface.flush();
-    try std.testing.expect(response.chunked);
-
-    try body.interface.writeAll("second");
-    try body.end();
-
-    try std.testing.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\n" ++
-            "Transfer-Encoding: chunked\r\n" ++
-            "\r\n" ++
-            "5\r\nfirst\r\n" ++
-            "6\r\nsecond\r\n" ++
-            "0\r\n\r\n",
-        conn_writer.buffered(),
-    );
-}
 test "Response: body used when buffer is empty" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -553,36 +545,6 @@ test "Response: write() with body" {
     try std.testing.expect(std.mem.indexOf(u8, written, "Hello World") != null);
 }
 
-test "BodyWriter: writes between flushes are framed as one chunk" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    var body_buf: [1024]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("aaa");
-    try body.interface.writeAll("bbb");
-    try body.interface.print("{d}", .{42});
-    try body.interface.flush();
-    try body.end();
-
-    // One chunk for all three writes, not three.
-    try std.testing.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\n" ++
-            "Transfer-Encoding: chunked\r\n" ++
-            "\r\n" ++
-            "8\r\naaabbb42\r\n" ++
-            "0\r\n\r\n",
-        conn_writer.buffered(),
-    );
-}
 test "Response: write() only writes once" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -686,37 +648,6 @@ test "Response: write() after writeHeader() doesn't duplicate headers" {
     try std.testing.expectEqual(header_len + "Body content".len, full_len);
 }
 
-test "BodyWriter: an empty flush does not terminate the body" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    var body_buf: [1024]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("first");
-    try body.interface.flush();
-    // Nothing buffered: a zero length chunk here would end the body early.
-    try body.interface.flush();
-    try body.interface.writeAll("second");
-    try body.end();
-
-    try std.testing.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\n" ++
-            "Transfer-Encoding: chunked\r\n" ++
-            "\r\n" ++
-            "5\r\nfirst\r\n" ++
-            "6\r\nsecond\r\n" ++
-            "0\r\n\r\n",
-        conn_writer.buffered(),
-    );
-}
 test "Response: keepalive defaults to true" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -758,29 +689,6 @@ test "Response: Connection close header when keepalive is false" {
     try std.testing.expect(std.mem.indexOf(u8, written, "Connection: close") != null);
 }
 
-test "BodyWriter: headers set before the body are sent with it" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-    response.status = .created;
-    try response.header("X-Custom", "value");
-
-    var body_buf: [8]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("Data that does not fit");
-    try body.end();
-
-    const written = conn_writer.buffered();
-    try std.testing.expect(std.mem.startsWith(u8, written, "HTTP/1.1 201 CREATED\r\n"));
-    try std.testing.expect(std.mem.indexOf(u8, written, "X-Custom: value") != null);
-}
 test "Response: chunked flag defaults to false" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -794,7 +702,144 @@ test "Response: chunked flag defaults to false" {
     try std.testing.expectEqual(false, response.chunked);
 }
 
-test "BodyWriter: a declared Content-Length streams without chunk framing" {
+test "BodyWriter: sends nothing until the response is written" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body = response.writer();
+    try body.interface.writeAll("Hello, ");
+    try body.interface.writeAll("World!");
+    try body.end();
+
+    // The headers are still open: nothing has gone out yet.
+    try std.testing.expectEqual(@as(usize, 0), conn_writer.end);
+    try std.testing.expect(!response.headers_written);
+    try response.header("X-Late", "still allowed");
+
+    try response.write();
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 13") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "X-Late: still allowed") != null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "Hello, World!"));
+    try std.testing.expect(!response.chunked);
+}
+
+test "BodyWriter: a body larger than one write still arrives whole" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body = response.writer();
+    for (0..100) |i| try body.interface.print("{d},", .{i});
+    try body.end();
+    try response.write();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.endsWith(u8, written, "97,98,99,"));
+    try std.testing.expect(!response.chunked);
+}
+
+test "StreamingBodyWriter: sends the headers immediately and chunks the body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [1024]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try std.testing.expect(response.headers_written);
+    // Too late for anyone to change them now.
+    try std.testing.expectError(error.HeadersAlreadySent, response.header("X-Late", "no"));
+
+    try body.interface.writeAll("first");
+    try body.interface.flush();
+    try body.interface.writeAll("second");
+    try body.end();
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Transfer-Encoding: chunked\r\n" ++
+            "\r\n" ++
+            "5\r\nfirst\r\n" ++
+            "6\r\nsecond\r\n" ++
+            "0\r\n\r\n",
+        conn_writer.buffered(),
+    );
+}
+
+test "StreamingBodyWriter: writes between flushes are framed as one chunk" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [1024]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("aaa");
+    try body.interface.writeAll("bbb");
+    try body.interface.print("{d}", .{42});
+    try body.end();
+
+    // One chunk for all three writes, not three.
+    try std.testing.expect(std.mem.endsWith(u8, conn_writer.buffered(), "8\r\naaabbb42\r\n0\r\n\r\n"));
+}
+
+test "StreamingBodyWriter: an empty flush does not terminate the body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+
+    var body_buf: [1024]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("first");
+    try body.interface.flush();
+    // Nothing buffered: a zero length chunk here would end the body early.
+    try body.interface.flush();
+    try body.interface.writeAll("second");
+    try body.end();
+
+    try std.testing.expect(std.mem.endsWith(
+        u8,
+        conn_writer.buffered(),
+        "5\r\nfirst\r\n6\r\nsecond\r\n0\r\n\r\n",
+    ));
+}
+
+test "StreamingBodyWriter: a declared Content-Length streams without chunk framing" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -807,10 +852,8 @@ test "BodyWriter: a declared Content-Length streams without chunk framing" {
     var response = try Response.init(arena.allocator(), &connection, 32);
     try response.header("Content-Length", "11");
 
-    // Buffer too small for the body, so it has to stream; with a declared
-    // length that must not turn into chunked.
     var body_buf: [4]u8 = undefined;
-    var body = response.writer(&body_buf);
+    var body = try response.stream(&body_buf);
     try body.interface.writeAll("hello ");
     try body.interface.writeAll("world");
     try body.end();
@@ -825,7 +868,7 @@ test "BodyWriter: a declared Content-Length streams without chunk framing" {
     );
 }
 
-test "BodyWriter: a declared Content-Length is not written twice" {
+test "StreamingBodyWriter: reports a body that does not match the declared length" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -836,27 +879,37 @@ test "BodyWriter: a declared Content-Length is not written twice" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    try response.header("Content-Length", "5");
+    try response.header("Content-Length", "11");
 
-    // Fits, so it never drains and takes the buffered path instead.
     var body_buf: [64]u8 = undefined;
-    var body = response.writer(&body_buf);
-    try body.interface.writeAll("hello");
-    try body.end();
-
-    const written = conn_writer.buffered();
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        std.mem.indexOfPos(u8, written, std.mem.indexOf(u8, written, "Content-Length").? + 1, "Content-Length"),
-    );
-    try std.testing.expect(std.mem.endsWith(u8, written, "\r\n\r\nhello"));
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("short");
+    try std.testing.expectError(error.ContentLengthMismatch, body.end());
 }
 
-test "BodyWriter: records the real error behind error.WriteFailed" {
+test "StreamingBodyWriter: rejects a Content-Length it cannot parse" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    // Too small to hold the headers, so the first drain fails.
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    // A proxy can forward whatever an upstream sent.
+    try response.header("Content-Length", "99999999999999999999999999");
+
+    var body_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.InvalidContentLength, response.stream(&body_buf));
+}
+
+test "StreamingBodyWriter: records the real error behind error.WriteFailed" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Too small to hold the headers, so streaming fails at the start.
     var buf: [4]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
@@ -865,31 +918,11 @@ test "BodyWriter: records the real error behind error.WriteFailed" {
     connection.tcp_writer.err = error.ConnectionResetByPeer;
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    var body_buf: [2]u8 = undefined;
-    var body = response.writer(&body_buf);
-
-    // The interface reports the generic error, as it must.
-    try std.testing.expectError(error.WriteFailed, body.interface.writeAll("too long for the buffer"));
-    // The answer is on the writer.
-    try std.testing.expectEqual(error.ConnectionResetByPeer, body.err.?);
+    var body_buf: [64]u8 = undefined;
+    try std.testing.expectError(error.WriteFailed, response.stream(&body_buf));
+    try std.testing.expectEqual(error.ConnectionResetByPeer, connection.getWriteError().?);
 }
-test "BodyWriter: falls back to WriteFailed when nothing was recorded" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
 
-    var buf: [4]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-    var body_buf: [2]u8 = undefined;
-    var body = response.writer(&body_buf);
-
-    try std.testing.expectError(error.WriteFailed, body.interface.writeAll("too long for the buffer"));
-    try std.testing.expectEqual(error.WriteFailed, body.err.?);
-}
 test "Response: json() with simple object" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/src/response.zig
+++ b/src/response.zig
@@ -116,6 +116,12 @@ pub const BodyWriter = struct {
     /// fails, so a handler that catches one can find out what happened
     /// instead of being told only that it did.
     err: ?Error = null,
+    /// Length the handler declared up front, if any. With one, the body is
+    /// streamed as-is: the length is already known, so chunk framing would
+    /// only add overhead.
+    content_length: ?usize = null,
+    /// Body bytes handed to the transport, checked against `content_length`.
+    sent: usize = 0,
 
     /// Everything `writeHeader` can fail with, plus the real transport
     /// errors hiding behind `WriteFailed`.
@@ -124,8 +130,13 @@ pub const BodyWriter = struct {
     const HeaderError = @typeInfo(@typeInfo(@TypeOf(Response.writeHeader)).@"fn".return_type.?).error_union.error_set;
 
     fn init(res: *Response, buf: []u8) BodyWriter {
+        const declared: ?usize = if (res.headers.get("Content-Length")) |v|
+            std.fmt.parseInt(usize, v, 10) catch |e| std.debug.panic("bad Content-Length {s}: {}", .{ v, e })
+        else
+            null;
         return .{
             .res = res,
+            .content_length = declared,
             .interface = .{
                 .buffer = buf,
                 .vtable = &.{ .drain = BodyWriter.drain },
@@ -150,11 +161,12 @@ pub const BodyWriter = struct {
         const self: *BodyWriter = @alignCast(@fieldParentPtr("interface", w));
         const res = self.res;
 
-        // Getting here at all means the body outgrew the buffer, or the
-        // handler asked to start streaming. Either way the length can no
-        // longer be stated up front.
-        if (!res.chunked) {
-            res.chunked = true;
+        // Getting here means the body outgrew the buffer, or the handler
+        // asked to start streaming. Either way it is going out now, so the
+        // framing has to be decided: chunked, unless the handler already
+        // told us how long the body is.
+        if (!res.headers_written) {
+            if (self.content_length == null) res.chunked = true;
             try self.record(res.writeHeader());
         }
 
@@ -164,8 +176,27 @@ pub const BodyWriter = struct {
         // send nothing at all rather than ending the body early.
         if (total == 0) return 0;
 
-        try self.record(self.writeChunk(pending, data, splat, total));
+        try self.record(if (res.chunked)
+            self.writeChunk(pending, data, splat, total)
+        else
+            self.writeBody(pending, data, splat));
+        self.sent += total;
         return w.consume(total);
+    }
+
+    /// Streams the body as-is, for a declared Content-Length.
+    fn writeBody(
+        self: *BodyWriter,
+        pending: []const u8,
+        data: []const []const u8,
+        splat: usize,
+    ) std.Io.Writer.Error!void {
+        const out = self.res.conn.writer;
+        try out.writeAll(pending);
+        for (data[0 .. data.len - 1]) |bytes| try out.writeAll(bytes);
+        const pattern = data[data.len - 1];
+        for (0..splat) |_| try out.writeAll(pattern);
+        try out.flush();
     }
 
     fn writeChunk(
@@ -197,19 +228,24 @@ pub const BodyWriter = struct {
         std.debug.assert(res.body_writer_open);
         res.body_writer_open = false;
 
-        if (res.chunked) {
+        if (res.headers_written) {
+            // Already streaming; drain whatever is left.
             try self.record(self.interface.flush());
-            try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
+            if (res.chunked) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
         } else {
             // Never drained, so the whole body is still in the buffer and
-            // its length is known.
+            // its length is known without the handler saying so.
             const body = self.interface.buffered();
             res.body = body;
             defer res.body = "";
             try self.record(res.writeHeader());
             try self.record(res.conn.writer.writeAll(body));
+            self.sent += body.len;
         }
         try self.record(res.conn.writer.flush());
+        // Sending the wrong number of bytes for a declared length leaves the
+        // connection out of sync, and the client waiting.
+        if (self.content_length) |declared| std.debug.assert(self.sent == declared);
         res.written = true;
     }
 };
@@ -756,6 +792,64 @@ test "Response: chunked flag defaults to false" {
 
     const response = try Response.init(arena.allocator(), &connection, 32);
     try std.testing.expectEqual(false, response.chunked);
+}
+
+test "BodyWriter: a declared Content-Length streams without chunk framing" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    try response.header("Content-Length", "11");
+
+    // Buffer too small for the body, so it has to stream; with a declared
+    // length that must not turn into chunked.
+    var body_buf: [4]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("hello ");
+    try body.interface.writeAll("world");
+    try body.end();
+
+    try std.testing.expect(!response.chunked);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Content-Length: 11\r\n" ++
+            "\r\n" ++
+            "hello world",
+        conn_writer.buffered(),
+    );
+}
+
+test "BodyWriter: a declared Content-Length is not written twice" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    try response.header("Content-Length", "5");
+
+    // Fits, so it never drains and takes the buffered path instead.
+    var body_buf: [64]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("hello");
+    try body.end();
+
+    const written = conn_writer.buffered();
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        std.mem.indexOfPos(u8, written, std.mem.indexOf(u8, written, "Content-Length").? + 1, "Content-Length"),
+    );
+    try std.testing.expect(std.mem.endsWith(u8, written, "\r\n\r\nhello"));
 }
 
 test "BodyWriter: records the real error behind error.WriteFailed" {

--- a/src/response.zig
+++ b/src/response.zig
@@ -98,6 +98,122 @@ pub const EventStream = struct {
     }
 };
 
+/// Writes a response body, picking the framing from how much gets written.
+///
+/// Nothing is sent while the body still fits in the caller's buffer, so
+/// `end` can send it with an exact `Content-Length`. The first drain --
+/// the buffer overflowing, or the handler calling `flush` to start
+/// streaming -- commits to chunked transfer encoding, because from then on
+/// the length is not known in advance.
+///
+/// The buffer only has to outlive the handler if `end` is not called, and
+/// `end` must be called, so a stack buffer is fine.
+pub const BodyWriter = struct {
+    res: *Response,
+    interface: std.Io.Writer,
+    /// The real cause behind the generic `error.WriteFailed` that the
+    /// `std.Io.Writer` interface has to return. Recorded when a write
+    /// fails, so a handler that catches one can find out what happened
+    /// instead of being told only that it did.
+    err: ?Error = null,
+
+    /// Everything `writeHeader` can fail with, plus the real transport
+    /// errors hiding behind `WriteFailed`.
+    pub const Error = Connection.WriteError || HeaderError;
+
+    const HeaderError = @typeInfo(@typeInfo(@TypeOf(Response.writeHeader)).@"fn".return_type.?).error_union.error_set;
+
+    fn init(res: *Response, buf: []u8) BodyWriter {
+        return .{
+            .res = res,
+            .interface = .{
+                .buffer = buf,
+                .vtable = &.{ .drain = BodyWriter.drain },
+            },
+        };
+    }
+
+    /// Runs `result`, recording what actually went wrong. The interface
+    /// still reports the generic `WriteFailed`, as its contract requires;
+    /// `err` is where the answer lives.
+    fn record(self: *BodyWriter, result: HeaderError!void) std.Io.Writer.Error!void {
+        result catch |e| {
+            self.err = if (e == error.WriteFailed)
+                self.res.conn.getWriteError() orelse e
+            else
+                e;
+            return error.WriteFailed;
+        };
+    }
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *BodyWriter = @alignCast(@fieldParentPtr("interface", w));
+        const res = self.res;
+
+        // Getting here at all means the body outgrew the buffer, or the
+        // handler asked to start streaming. Either way the length can no
+        // longer be stated up front.
+        if (!res.chunked) {
+            res.chunked = true;
+            try self.record(res.writeHeader());
+        }
+
+        const pending = w.buffered();
+        const total = pending.len + std.Io.Writer.countSplat(data, splat);
+        // A zero length chunk is the terminator, so an empty flush has to
+        // send nothing at all rather than ending the body early.
+        if (total == 0) return 0;
+
+        try self.record(self.writeChunk(pending, data, splat, total));
+        return w.consume(total);
+    }
+
+    fn writeChunk(
+        self: *BodyWriter,
+        pending: []const u8,
+        data: []const []const u8,
+        splat: usize,
+        total: usize,
+    ) std.Io.Writer.Error!void {
+        // 16 hex digits covers any usize, plus the CRLF.
+        var size_buf: [18]u8 = undefined;
+        const size = std.fmt.bufPrint(&size_buf, "{x}\r\n", .{total}) catch unreachable;
+
+        const out = self.res.conn.writer;
+        try out.writeAll(size);
+        try out.writeAll(pending);
+        for (data[0 .. data.len - 1]) |bytes| try out.writeAll(bytes);
+        const pattern = data[data.len - 1];
+        for (0..splat) |_| try out.writeAll(pattern);
+        try out.writeAll("\r\n");
+        try out.flush();
+    }
+
+    /// Finishes the body. Must be called before the handler returns: until
+    /// it does, a buffered body has not been sent and a chunked one has no
+    /// terminator.
+    pub fn end(self: *BodyWriter) !void {
+        const res = self.res;
+        std.debug.assert(res.body_writer_open);
+        res.body_writer_open = false;
+
+        if (res.chunked) {
+            try self.record(self.interface.flush());
+            try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
+        } else {
+            // Never drained, so the whole body is still in the buffer and
+            // its length is known.
+            const body = self.interface.buffered();
+            res.body = body;
+            defer res.body = "";
+            try self.record(res.writeHeader());
+            try self.record(res.conn.writer.writeAll(body));
+        }
+        try self.record(res.conn.writer.flush());
+        res.written = true;
+    }
+};
+
 pub const Response = struct {
     status: http.Status = .ok,
     body: []const u8 = "",
@@ -111,6 +227,8 @@ pub const Response = struct {
     keepalive: bool = true,
     chunked: bool = false,
     streaming: bool = false,
+    /// A `BodyWriter` was handed out and has not been ended yet.
+    body_writer_open: bool = false,
 
     pub fn init(arena: std.mem.Allocator, conn: *Connection, max_headers: usize) !Response {
         return .{
@@ -127,8 +245,15 @@ pub const Response = struct {
         try self.headers.put(name, value);
     }
 
-    pub fn writer(self: *Response) *std.Io.Writer {
-        return &self.buffer.writer;
+    /// A writer for the response body. `buf` holds the body until it
+    /// overflows or is flushed; see `BodyWriter`. Call `end` on the result
+    /// before returning from the handler.
+    pub fn writer(self: *Response, buf: []u8) BodyWriter {
+        std.debug.assert(!self.body_writer_open); // one body writer per response
+        std.debug.assert(!self.headers_written); // body cannot start after the headers
+        std.debug.assert(self.body.len == 0 and self.buffer.writer.end == 0); // body already set
+        self.body_writer_open = true;
+        return .init(self, buf);
     }
 
     pub fn clearWriter(self: *Response) void {
@@ -145,36 +270,6 @@ pub const Response = struct {
         const serialized = try serializeCookie(self.arena, name, value, opts);
         try http.validateHeaderValue(serialized);
         try self.headers.add("Set-Cookie", serialized);
-    }
-
-    pub fn chunk(self: *Response, data: []const u8) !void {
-        if (!self.chunked) {
-            self.chunked = true;
-            self.writeHeader() catch |err| switch (err) {
-                error.WriteFailed => return self.conn.getWriteError() orelse err,
-                else => |e| return e,
-            };
-        }
-
-        // A zero-length chunk is the chunked-encoding terminator; skip it so
-        // an accidental empty write doesn't end the response early (and let
-        // subsequent chunks land after the terminator on the wire).
-        if (data.len == 0) return;
-
-        // Format: {size_hex}\r\n{data}\r\n
-        // Buffer size: enough for a 1TB chunk (40 bits = 10 hex digits) + formatting
-        var buf: [16]u8 = undefined;
-        const chunk_header = try std.fmt.bufPrint(&buf, "{x}\r\n", .{data.len});
-
-        self.writeChunkBytes(chunk_header, data) catch |err| return self.conn.getWriteError() orelse err;
-    }
-
-    fn writeChunkBytes(self: *Response, chunk_header: []const u8, data: []const u8) !void {
-        // Write chunk size header, data, and trailing CRLF
-        try self.conn.writer.writeAll(chunk_header);
-        try self.conn.writer.writeAll(data);
-        try self.conn.writer.writeAll("\r\n");
-        try self.conn.writer.flush();
     }
 
     pub fn startEventStream(self: *Response) !EventStream {
@@ -268,6 +363,9 @@ pub const Response = struct {
         if (self.written) {
             return;
         }
+        // The body writer's buffer belongs to the handler and is gone by
+        // now, so there is nothing left that could finish the response.
+        std.debug.assert(!self.body_writer_open); // handler returned without calling end()
         self.written = true;
 
         if (self.chunked) {
@@ -290,7 +388,7 @@ pub const Response = struct {
     }
 };
 
-test "Response: basic writer usage" {
+test "BodyWriter: a body that fits is sent with a Content-Length" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -301,16 +399,23 @@ test "Response: basic writer usage" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    const w = response.writer();
 
-    try w.writeAll("Hello, ");
-    try w.writeAll("World!");
+    var body_buf: [64]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("Hello, ");
+    try body.interface.writeAll("World!");
+    try body.end();
 
-    const buffered = response.buffer.writer.buffered();
-    try std.testing.expectEqualStrings("Hello, World!", buffered);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Content-Length: 13\r\n" ++
+            "\r\n" ++
+            "Hello, World!",
+        conn_writer.buffered(),
+    );
+    try std.testing.expect(!response.chunked);
 }
-
-test "Response: writer with formatted output" {
+test "BodyWriter: overflowing the buffer switches to chunked" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -321,15 +426,20 @@ test "Response: writer with formatted output" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    const w = response.writer();
 
-    try w.print("Hello, {s}! You are {d} years old.", .{ "Alice", 30 });
+    // Too small for the body, so the first write has to drain.
+    var body_buf: [8]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.print("Hello, {s}! You are {d}.", .{ "Alice", 30 });
+    try body.end();
 
-    const buffered = response.buffer.writer.buffered();
-    try std.testing.expectEqualStrings("Hello, Alice! You are 30 years old.", buffered);
+    const written = conn_writer.buffered();
+    try std.testing.expect(response.chunked);
+    try std.testing.expect(std.mem.indexOf(u8, written, "Transfer-Encoding: chunked") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length") == null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "0\r\n\r\n"));
 }
-
-test "Response: buffer takes precedence over body" {
+test "BodyWriter: flush starts streaming before the buffer is full" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -340,20 +450,27 @@ test "Response: buffer takes precedence over body" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    response.body = "body content";
 
-    const w = response.writer();
-    try w.writeAll("writer content");
+    var body_buf: [1024]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("first");
+    // Plenty of room left, but the handler wants it on the wire now.
+    try body.interface.flush();
+    try std.testing.expect(response.chunked);
 
-    // Buffer should have content
-    const buffered = response.buffer.writer.buffered();
-    try std.testing.expectEqualStrings("writer content", buffered);
-    try std.testing.expect(buffered.len > 0);
+    try body.interface.writeAll("second");
+    try body.end();
 
-    // Body is still there but shouldn't be used
-    try std.testing.expectEqualStrings("body content", response.body);
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Transfer-Encoding: chunked\r\n" ++
+            "\r\n" ++
+            "5\r\nfirst\r\n" ++
+            "6\r\nsecond\r\n" ++
+            "0\r\n\r\n",
+        conn_writer.buffered(),
+    );
 }
-
 test "Response: body used when buffer is empty" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -397,7 +514,7 @@ test "Response: write() with body" {
     try std.testing.expect(std.mem.indexOf(u8, written, "Hello World") != null);
 }
 
-test "Response: write() with writer buffer" {
+test "BodyWriter: writes between flushes are framed as one chunk" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -408,17 +525,25 @@ test "Response: write() with writer buffer" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    const w = response.writer();
-    try w.print("Count: {d}", .{42});
 
-    try response.write();
+    var body_buf: [1024]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("aaa");
+    try body.interface.writeAll("bbb");
+    try body.interface.print("{d}", .{42});
+    try body.interface.flush();
+    try body.end();
 
-    const written = conn_writer.buffered();
-    try std.testing.expect(std.mem.indexOf(u8, written, "HTTP/1.1 200") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 9") != null);
-    try std.testing.expect(std.mem.indexOf(u8, written, "Count: 42") != null);
+    // One chunk for all three writes, not three.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Transfer-Encoding: chunked\r\n" ++
+            "\r\n" ++
+            "8\r\naaabbb42\r\n" ++
+            "0\r\n\r\n",
+        conn_writer.buffered(),
+    );
 }
-
 test "Response: write() only writes once" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -522,7 +647,7 @@ test "Response: write() after writeHeader() doesn't duplicate headers" {
     try std.testing.expectEqual(header_len + "Body content".len, full_len);
 }
 
-test "Response: clearWriter()" {
+test "BodyWriter: an empty flush does not terminate the body" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -533,18 +658,26 @@ test "Response: clearWriter()" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    const w = response.writer();
 
-    try w.writeAll("First content");
-    try std.testing.expectEqualStrings("First content", response.buffer.writer.buffered());
+    var body_buf: [1024]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("first");
+    try body.interface.flush();
+    // Nothing buffered: a zero length chunk here would end the body early.
+    try body.interface.flush();
+    try body.interface.writeAll("second");
+    try body.end();
 
-    response.clearWriter();
-    try std.testing.expectEqualStrings("", response.buffer.writer.buffered());
-
-    try w.writeAll("Second content");
-    try std.testing.expectEqualStrings("Second content", response.buffer.writer.buffered());
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\n" ++
+            "Transfer-Encoding: chunked\r\n" ++
+            "\r\n" ++
+            "5\r\nfirst\r\n" ++
+            "6\r\nsecond\r\n" ++
+            "0\r\n\r\n",
+        conn_writer.buffered(),
+    );
 }
-
 test "Response: keepalive defaults to true" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -586,69 +719,7 @@ test "Response: Connection close header when keepalive is false" {
     try std.testing.expect(std.mem.indexOf(u8, written, "Connection: close") != null);
 }
 
-test "Response: chunked with single chunk" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-    response.status = .ok;
-
-    try response.chunk("Hello");
-    try response.write();
-
-    const written = conn_writer.buffered();
-
-    // Validate exact chunked encoding format
-    const expected =
-        "HTTP/1.1 200 OK\r\n" ++
-        "Transfer-Encoding: chunked\r\n" ++
-        "\r\n" ++ // End of headers
-        "5\r\n" ++ // Chunk size
-        "Hello\r\n" ++ // Chunk data + trailing CRLF
-        "0\r\n\r\n"; // Final terminator
-
-    try std.testing.expectEqualStrings(expected, written);
-}
-
-test "Response: chunked with multiple chunks" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    try response.chunk("First");
-    try response.chunk("Second chunk");
-    try response.write();
-
-    const written = conn_writer.buffered();
-
-    // Validate exact chunked encoding format
-    const expected =
-        "HTTP/1.1 200 OK\r\n" ++
-        "Transfer-Encoding: chunked\r\n" ++
-        "\r\n" ++ // End of headers
-        "5\r\n" ++ // First chunk size
-        "First\r\n" ++ // First chunk data + trailing CRLF
-        "c\r\n" ++ // Second chunk size (12 in hex)
-        "Second chunk\r\n" ++ // Second chunk data + trailing CRLF
-        "0\r\n\r\n"; // Final terminator
-
-    try std.testing.expectEqualStrings(expected, written);
-}
-
-test "Response: chunked with custom headers" {
+test "BodyWriter: headers set before the body are sent with it" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -662,24 +733,15 @@ test "Response: chunked with custom headers" {
     response.status = .created;
     try response.header("X-Custom", "value");
 
-    try response.chunk("Data");
-    try response.write();
+    var body_buf: [8]u8 = undefined;
+    var body = response.writer(&body_buf);
+    try body.interface.writeAll("Data that does not fit");
+    try body.end();
 
     const written = conn_writer.buffered();
-
-    // Validate exact chunked encoding format with custom headers
-    const expected =
-        "HTTP/1.1 201 CREATED\r\n" ++
-        "X-Custom: value\r\n" ++
-        "Transfer-Encoding: chunked\r\n" ++
-        "\r\n" ++ // End of headers
-        "4\r\n" ++ // Chunk size (4 bytes)
-        "Data\r\n" ++ // Chunk data + trailing CRLF
-        "0\r\n\r\n"; // Final terminator
-
-    try std.testing.expectEqualStrings(expected, written);
+    try std.testing.expect(std.mem.startsWith(u8, written, "HTTP/1.1 201 CREATED\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, written, "X-Custom: value") != null);
 }
-
 test "Response: chunked flag defaults to false" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -693,39 +755,11 @@ test "Response: chunked flag defaults to false" {
     try std.testing.expectEqual(false, response.chunked);
 }
 
-test "Response: chunk() skips empty data so it doesn't terminate the stream" {
+test "BodyWriter: records the real error behind error.WriteFailed" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    try response.chunk("first");
-    try response.chunk(""); // would be the chunked terminator if written; must be skipped
-    try response.chunk("second");
-    try response.write();
-
-    const written = conn_writer.buffered();
-    const expected =
-        "HTTP/1.1 200 OK\r\n" ++
-        "Transfer-Encoding: chunked\r\n" ++
-        "\r\n" ++
-        "5\r\nfirst\r\n" ++
-        "6\r\nsecond\r\n" ++
-        "0\r\n\r\n";
-    try std.testing.expectEqualStrings(expected, written);
-}
-
-test "Response: chunk() surfaces the real error behind error.WriteFailed" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    // Buffer too small to hold the headers, so the very first write fails.
+    // Too small to hold the headers, so the first drain fails.
     var buf: [4]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
@@ -734,11 +768,15 @@ test "Response: chunk() surfaces the real error behind error.WriteFailed" {
     connection.tcp_writer.err = error.ConnectionResetByPeer;
 
     var response = try Response.init(arena.allocator(), &connection, 32);
+    var body_buf: [2]u8 = undefined;
+    var body = response.writer(&body_buf);
 
-    try std.testing.expectError(error.ConnectionResetByPeer, response.chunk("first"));
+    // The interface reports the generic error, as it must.
+    try std.testing.expectError(error.WriteFailed, body.interface.writeAll("too long for the buffer"));
+    // The answer is on the writer.
+    try std.testing.expectEqual(error.ConnectionResetByPeer, body.err.?);
 }
-
-test "Response: chunk() falls back to error.WriteFailed when no real error was recorded" {
+test "BodyWriter: falls back to WriteFailed when nothing was recorded" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
@@ -749,34 +787,12 @@ test "Response: chunk() falls back to error.WriteFailed when no real error was r
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
+    var body_buf: [2]u8 = undefined;
+    var body = response.writer(&body_buf);
 
-    try std.testing.expectError(error.WriteFailed, response.chunk("first"));
+    try std.testing.expectError(error.WriteFailed, body.interface.writeAll("too long for the buffer"));
+    try std.testing.expectEqual(error.WriteFailed, body.err.?);
 }
-
-test "Response: chunked mode doesn't write Content-Length" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    var buf: [1024]u8 = undefined;
-    var conn_writer: std.Io.Writer = .fixed(&buf);
-
-    var connection: Connection = undefined;
-    connection.initWriterForTesting(&conn_writer);
-
-    var response = try Response.init(arena.allocator(), &connection, 32);
-
-    try response.chunk("test");
-    try response.write();
-
-    const written = conn_writer.buffered();
-
-    // Should NOT have Content-Length header
-    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length") == null);
-
-    // Should have Transfer-Encoding instead
-    try std.testing.expect(std.mem.indexOf(u8, written, "Transfer-Encoding: chunked") != null);
-}
-
 test "Response: json() with simple object" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/src/server.zig
+++ b/src/server.zig
@@ -136,6 +136,9 @@ pub const Connection = struct {
         if (self.tcp_writer.err) |e| return e;
     }
 
+    /// The error type `getWriteError` yields.
+    pub const WriteError = @typeInfo(@TypeOf(checkWriteError(undefined))).error_union.error_set;
+
     /// The real error behind a generic `error.WriteFailed`, if any was
     /// recorded.
     pub fn getWriteError(self: *Connection) ?@typeInfo(@TypeOf(checkWriteError(self))).error_union.error_set {

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -751,7 +751,7 @@ test "Server: handler error after streaming started aborts the connection" {
             // Start streaming, then fail - the headers and first chunk are
             // already on the wire, so the error can't be turned into a 500.
             var body_buf: [64]u8 = undefined;
-            var body = res.writer(&body_buf);
+            var body = try res.stream(&body_buf);
             try body.interface.writeAll("partial");
             try body.interface.flush();
             return error.Boom;

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -748,9 +748,12 @@ test "Server: handler error after streaming started aborts the connection" {
     server.router.get("/bad-stream", struct {
         fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             _ = req;
-            // Start a chunked response, then fail - headers/first chunk are
+            // Start streaming, then fail - the headers and first chunk are
             // already on the wire, so the error can't be turned into a 500.
-            try res.chunk("partial");
+            var body_buf: [64]u8 = undefined;
+            var body = res.writer(&body_buf);
+            try body.interface.writeAll("partial");
+            try body.interface.flush();
             return error.Boom;
         }
     }.handle);


### PR DESCRIPTION
Closes #6.

Response bodies are now written through `std.Io.Writer`, replacing `res.chunk()` and the old `res.writer()`. Which framing goes on the wire — `Content-Length`, chunked, or a declared length streamed as-is — is decided by the library, not spelled out by the handler.

```zig
// Collects the body. Nothing reaches the connection, so the headers stay
// open until the whole response is sent and middleware after next() can
// still change them. Sent with a Content-Length.
var body = res.writer();
try body.interface.print("hello {s}", .{name});
try body.end();

// Sends the headers now and writes the body as it is produced. Chunked,
// or as-is when a Content-Length already says how long it will be.
var body = try res.stream(&buf);
try body.interface.writeAll(part);
try body.end();
```

Both are real `std.Io.Writer` implementations, so `print`, `writeAll`, `streamRemaining` and everything else work, and both carry an `err` field holding the real cause behind the generic `error.WriteFailed`.

There are two constructors rather than one because the choice that actually matters to a handler is not how the body is framed — that is a transport detail — but *when the headers leave*, since everything a handler or its middleware can still change depends on it. Making that visible at the call site is the difference between the two.

## Why

`res.chunk()` wrote straight to the connection while `res.writer()` accumulated into an arena buffer, and `write()` returned early in chunked mode. A handler that used both silently lost whatever the writer had buffered, and nothing in the types prevented it.

`chunk()` also flushed per call, so a run of small writes cost a syscall each. The streaming writer frames everything pending as one chunk instead.

## Behaviour worth knowing

- A handler that never calls `end()` no longer takes the process down. A buffered body is still sent; a chunked one is terminated and truncated; an identity-framed one that came up short closes the connection, because nothing can make it match the length already promised and the peer would otherwise read the next response as this body.
- `end()` is idempotent, so `defer body.end() catch {}` beside an explicit `end()` is safe rather than a second terminator.
- `header()` and `setCookie()` return `error.HeadersAlreadySent` once the headers are out. `Session` treats that as "too late" and carries on, since whether to stream is the handler's decision.
- `stream()` reports `error.InvalidContentLength` for a value it cannot parse, and `end()` reports `error.ContentLengthMismatch` when the body does not match one that was declared. Both are reachable from headers forwarded by an upstream, so neither asserts.
- `proxy.zig` no longer forwards `Content-Length`: the client decompresses transparently, so an upstream length does not describe what we send.

## Breaking

- `res.chunk()` is gone.
- `res.writer()` returns a `BodyWriter` rather than a `*std.Io.Writer`; use `&body.interface`, and call `body.end()`.

## Known and not addressed

- A manually set `Content-Length` that disagrees with a buffered body is still emitted as-is. Pre-existing in `writeHeader`.
- `keepalive` decided after the handler returns cannot reach the headers of a `stream()` response. Inherent: they are already on the wire.

## Reviewing

The commits are kept as worked, so the middle of the branch contains a single writer that switched framing on its own and the later commits replace it. The end state is what matters; reviewing the diff as a whole will be easier than commit by commit.

228/228 tests pass. Fourteen new tests cover the framing choices, chunk coalescing, empty-flush safety, both `err` paths, idempotent `end`, and each abandonment case.
