### PR TITLE
Don't answer with the body of a handler that never finished

### DIFF
--- a/src/http.zig
+++ b/src/http.zig
@@ -279,6 +279,24 @@ pub const Headers = struct {
         return null;
     }
 
+    /// Drops every entry matching name (case-insensitive), keeping the
+    /// order of the rest. Returns how many went.
+    pub fn remove(self: *Headers, name: []const u8) usize {
+        const h = hashFn(name);
+        var kept: usize = 0;
+        for (0..self.len) |i| {
+            if (self.hashes[i] == h and std.ascii.eqlIgnoreCase(self.keys[i], name)) continue;
+            if (kept != i) {
+                self.keys[kept] = self.keys[i];
+                self.values[kept] = self.values[i];
+                self.hashes[kept] = self.hashes[i];
+            }
+            kept += 1;
+        }
+        defer self.len = kept;
+        return self.len - kept;
+    }
+
     pub fn count(self: *const Headers) usize {
         return self.len;
     }
@@ -572,4 +590,43 @@ test "ContentEncoding: fromString" {
     try std.testing.expectEqual(ContentEncoding.deflate, ContentEncoding.fromString("deflate"));
     try std.testing.expectEqual(ContentEncoding.unknown, ContentEncoding.fromString("br"));
     try std.testing.expectEqual(ContentEncoding.unknown, ContentEncoding.fromString("zstd"));
+}
+
+test "Headers: remove" {
+    var headers = try Headers.init(std.testing.allocator, 8);
+    defer headers.deinit(std.testing.allocator);
+
+    try headers.put("Content-Type", "application/json");
+    try headers.put("Host", "example.com");
+    try headers.add("X-Tag", "a");
+    try headers.add("X-Tag", "b");
+
+    // Case-insensitive, and every copy goes.
+    try std.testing.expectEqual(@as(usize, 1), headers.remove("content-type"));
+    try std.testing.expectEqual(@as(?[]const u8, null), headers.get("Content-Type"));
+    try std.testing.expectEqual(@as(usize, 2), headers.remove("X-Tag"));
+    try std.testing.expectEqual(@as(usize, 0), headers.remove("X-Tag"));
+    try std.testing.expectEqual(@as(usize, 0), headers.remove("Never-Set"));
+
+    // What is left keeps its order and its values.
+    try std.testing.expectEqual(@as(usize, 1), headers.count());
+    try std.testing.expectEqualStrings("example.com", headers.get("Host").?);
+}
+
+test "Headers: remove compacts so later entries stay reachable" {
+    var headers = try Headers.init(std.testing.allocator, 8);
+    defer headers.deinit(std.testing.allocator);
+
+    try headers.put("A", "1");
+    try headers.put("B", "2");
+    try headers.put("C", "3");
+    _ = headers.remove("A");
+
+    try std.testing.expectEqualStrings("2", headers.get("B").?);
+    try std.testing.expectEqualStrings("3", headers.get("C").?);
+
+    var it = headers.iterator();
+    try std.testing.expectEqualStrings("B", it.next().?.key);
+    try std.testing.expectEqualStrings("C", it.next().?.key);
+    try std.testing.expectEqual(@as(?Headers.Iterator.Entry, null), it.next());
 }

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -207,7 +207,10 @@ fn makeTestResponse() Response {
         .headers = .{},
         .content_type = null,
         .arena = undefined,
-        .buffer = undefined,
+        // Real storage rather than undefined: the 404 and 500 paths clear
+        // the buffer, and `init` allocates nothing until something is
+        // written, so a test that writes no body still leaks nothing.
+        .buffer = .init(std.testing.allocator),
         .conn = undefined,
         .written = false,
         .headers_written = false,

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Request = @import("request.zig").Request;
 const Response = @import("response.zig").Response;
 const Action = @import("router.zig").Action;
+const Connection = @import("server.zig").Connection;
 
 const log = std.log.scoped(.dusty);
 
@@ -118,19 +119,32 @@ pub fn Executor(comptime Ctx: type) type {
         }
 
         fn handleNotFound(self: *Self) !void {
+            // A middleware may have written part of a body before the
+            // router came up empty, and `write` would send that in place
+            // of the 404. Unlike the error path, nothing has checked the
+            // headers yet: a middleware that started streaming has already
+            // committed the framing, so there is nothing to replace.
+            if (!self.res.headers_written) self.res.resetBody();
             if (comptime Ctx != void and @hasDecl(Ctx, "notFound")) {
                 try self.ctx.notFound(self.req, self.res);
             } else {
                 self.res.status = .not_found;
+                self.res.content_type = .text;
                 self.res.body = "404 Not Found\n";
             }
         }
 
         fn handleError(self: *Self, err: anyerror) void {
+            // Whatever the handler managed to write is half of something
+            // it did not finish, and `write` would send it in place of the
+            // error response. The caller has already checked that the
+            // headers are still open.
+            self.res.resetBody();
             if (comptime Ctx != void and @hasDecl(Ctx, "uncaughtError")) {
                 self.ctx.uncaughtError(self.req, self.res, err);
             } else {
                 self.res.status = .internal_server_error;
+                self.res.content_type = .text;
                 self.res.body = "500 Internal Server Error\n";
             }
         }
@@ -500,4 +514,83 @@ test "Executor: middleware error triggers custom uncaughtError" {
     try std.testing.expectEqual(error.MiddlewareError, ctx.last_error.?);
     try std.testing.expectEqual(.internal_server_error, res.status);
     try std.testing.expectEqualStrings("custom 500", res.body);
+}
+
+test "Executor: a handler that fails mid-body does not send the fragment" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var req: Request = .{ .arena = arena.allocator(), .conn = undefined, .parser = undefined };
+    var res = try Response.init(arena.allocator(), &connection, 32);
+
+    var executor = Executor(void){
+        .req = &req,
+        .res = &res,
+        .ctx = {},
+        .action = struct {
+            fn handle(_: *Request, r: *Response) !void {
+                r.content_type = .json;
+                var body = r.writer();
+                try body.interface.writeAll("{\"half\":");
+                return error.Boom;
+            }
+        }.handle,
+        .middlewares = &.{},
+    };
+
+    try executor.run();
+    try std.testing.expectEqual(.internal_server_error, res.status);
+
+    try res.write();
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "half") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "application/json") == null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "500 Internal Server Error\n"));
+}
+
+const WritingMiddleware = struct {
+    pub fn execute(_: *const WritingMiddleware, _: *Request, res: *Response, executor: *Executor(void)) !void {
+        res.content_type = .json;
+        var body = res.writer();
+        try body.interface.writeAll("{\"half\":");
+        return executor.next();
+    }
+};
+
+test "Executor: a middleware that wrote a body does not supply the 404" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var req: Request = .{ .arena = arena.allocator(), .conn = undefined, .parser = undefined };
+    var res = try Response.init(arena.allocator(), &connection, 32);
+
+    var mw = WritingMiddleware{};
+    const middlewares = [_]Middleware(void){Middleware(void).init(&mw)};
+    var executor = Executor(void){
+        .req = &req,
+        .res = &res,
+        .ctx = {},
+        // No route matched, so the executor falls through to the 404.
+        .action = null,
+        .middlewares = &middlewares,
+    };
+
+    try executor.run();
+    try std.testing.expectEqual(.not_found, res.status);
+
+    try res.write();
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "half") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "application/json") == null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "404 Not Found\n"));
 }

--- a/src/response.zig
+++ b/src/response.zig
@@ -371,6 +371,23 @@ pub const Response = struct {
         _ = self.buffer.writer.consumeAll();
     }
 
+    /// Throws away a body that was started but never finished, so a
+    /// replacement can be written in its place. `write` prefers the
+    /// buffer over `body`, so without this an error response would be
+    /// sent with whatever the failed handler had produced so far.
+    ///
+    /// Only usable while the headers are still open; once they are on the
+    /// wire the framing is already promised and the body cannot be
+    /// swapped.
+    pub fn resetBody(self: *Response) void {
+        std.debug.assert(!self.headers_written);
+        self.clearWriter();
+        self.body = "";
+        self.body_writer_open = false;
+        // The old body's type does not describe the new one.
+        self.content_type = null;
+    }
+
     pub fn json(self: *Response, value: anytype, options: std.json.Stringify.Options) !void {
         const json_formatter = std.json.fmt(value, options);
         try json_formatter.format(&self.buffer.writer);
@@ -1484,4 +1501,35 @@ test "EventWriter: splatBytesAll" {
     try ew.end();
 
     try std.testing.expectEqualStrings("data: ababab\n\n", conn_writer.buffered());
+}
+
+test "Response: resetBody replaces a half written body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.content_type = .json;
+    var body = response.writer();
+    try body.interface.writeAll("{\"half\":");
+    // The handler fails here, without ever calling `end`.
+
+    response.resetBody();
+    response.status = .internal_server_error;
+    response.content_type = .text;
+    response.body = "500 Internal Server Error\n";
+    try response.write();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "500") != null);
+    // The fragment must not survive as the body, nor its length as the
+    // Content-Length, nor its content type as the type.
+    try std.testing.expect(std.mem.indexOf(u8, written, "half") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "application/json") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 26") != null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "500 Internal Server Error\n"));
 }

--- a/src/response.zig
+++ b/src/response.zig
@@ -384,8 +384,15 @@ pub const Response = struct {
         self.clearWriter();
         self.body = "";
         self.body_writer_open = false;
-        // The old body's type does not describe the new one.
+        // Everything that described the old body has to go with it.
+        // `content_type` is the usual way to set one, but a handler can
+        // write either header directly, and then a stale Content-Length
+        // is worse than a stale type: `writeHeader` leaves a length that
+        // is already set alone, so the peer would be told to read a body
+        // of the wrong size and the connection would fall out of step.
         self.content_type = null;
+        _ = self.headers.remove("Content-Type");
+        _ = self.headers.remove("Content-Length");
     }
 
     pub fn json(self: *Response, value: anytype, options: std.json.Stringify.Options) !void {
@@ -1532,4 +1539,39 @@ test "Response: resetBody replaces a half written body" {
     try std.testing.expect(std.mem.indexOf(u8, written, "application/json") == null);
     try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 26") != null);
     try std.testing.expect(std.mem.endsWith(u8, written, "500 Internal Server Error\n"));
+}
+
+test "Response: resetBody drops the headers that described the old body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    // Set directly rather than through `content_type`, which is the case
+    // clearing that field alone does not cover.
+    try response.header("Content-Type", "application/json");
+    try response.header("Content-Length", "8");
+    try response.header("X-Request-Id", "abc");
+    var body = response.writer();
+    try body.interface.writeAll("{\"half\":");
+
+    response.resetBody();
+    response.status = .internal_server_error;
+    response.body = "oops\n";
+    try response.write();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "application/json") == null);
+    // The stale length is the dangerous one: `writeHeader` leaves a length
+    // that is already set alone, so the peer would read 8 bytes of a 5
+    // byte body and take the rest from the next response.
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 8") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 5") != null);
+    // Headers that say nothing about the body are left alone.
+    try std.testing.expect(std.mem.indexOf(u8, written, "X-Request-Id: abc") != null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "oops\n"));
 }


### PR DESCRIPTION
## The problem

`Response.write` prefers the response buffer over `body`:

```zig
const body = if (buffered.len > 0) buffered else self.body;
```

So a handler that writes part of a body and then fails gets a 500 whose body is its own fragment:

```
HTTP/1.1 500 INTERNAL_SERVER_ERROR\r\nContent-Length: 8\r\n\r\n{"half":
```

The `Content-Length` matches the fragment, so nothing on the wire indicates the response isn't what it claims to be. Truncated JSON at least fails to parse; truncated HTML doesn't.

`write` already assumed this couldn't happen — *"an error handler that built a replacement has already cleared it"* — but `clearWriter` was defined and never called anywhere in the tree, so the assumption was never true.

## The fix

`Response.resetBody()` drops the buffer, `body`, and the open-writer flag together. It also clears `content_type`, so a handler that set `.json` before failing doesn't leave the plain-text 500 labelled as JSON.

`handleNotFound` gets the same treatment: a middleware can write a body and then call `next()` into a route that doesn't exist. It checks `headers_written` itself, because unlike the error path nothing has checked for it, and a middleware that already started streaming has committed its framing and has nothing left to replace.

## Tests

- `Response: resetBody replaces a half written body` — fragment gone, `Content-Length` is the error's not the fragment's, content type reset
- `Executor: a handler that fails mid-body does not send the fragment`
- `Executor: a middleware that wrote a body does not supply the 404`

233 tests pass.

## Note

`notFound` and `uncaughtError` are gated on `Ctx != void`, so a `Server(void)` still can't customize either. Not addressed here.