### PR TITLE
Answer HEAD from the GET route, without the body

### DIFF
--- a/src/response.zig
+++ b/src/response.zig
@@ -319,6 +319,10 @@ pub const Response = struct {
     /// server; a handler writes its body either way and does not have to
     /// know.
     head: bool = false,
+    /// Where a HEAD event stream writes. Per response rather than shared,
+    /// because two executors would otherwise be counting into the same
+    /// one.
+    discard: std.Io.Writer.Discarding = .init(&.{}),
     /// A body writer was handed out and has not been ended yet.
     body_writer_open: bool = false,
     /// Length declared before streaming, if any. On the response rather
@@ -428,7 +432,10 @@ pub const Response = struct {
         self.streaming = true;
         try self.writeHeader();
         try self.conn.writer.flush();
-        return .{ .conn = self.conn.writer };
+        // A HEAD gets the headers an event stream would have opened with
+        // and none of the events, so the whole stream writes into a sink
+        // rather than every send having to ask.
+        return .{ .conn = if (self.head) &self.discard.writer else self.conn.writer };
     }
 
     /// Upgrade HTTP connection to WebSocket.
@@ -1690,4 +1697,32 @@ test "Response: a streamed HEAD still checks a declared length" {
         "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n",
         conn_writer.buffered(),
     );
+}
+
+test "Response: a HEAD event stream sends the headers and no events" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.head = true;
+
+    const stream = try response.startEventStream();
+    try stream.send("hello", .{});
+    var w = try stream.startSend(.{ .event = "tick" });
+    try w.interface.writeAll("more");
+    try w.end();
+
+    // The headers a GET would have opened the stream with, and nothing
+    // after them.
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "text/event-stream") != null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "\r\n\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, written, "hello") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "tick") == null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "data:") == null);
 }

--- a/src/response.zig
+++ b/src/response.zig
@@ -215,6 +215,14 @@ pub const StreamingBodyWriter = struct {
         // send nothing rather than ending the body early.
         if (total == 0) return 0;
 
+        // A HEAD reports the length its GET would have and sends none of
+        // it. The handler still writes, and is still charged for what it
+        // wrote, so a declared Content-Length is checked the same way.
+        if (self.res.head) {
+            self.res.body_sent += total;
+            return w.consume(total);
+        }
+
         try self.record(if (self.res.chunked)
             self.writeChunk(pending, data, splat, total)
         else
@@ -283,7 +291,7 @@ pub const StreamingBodyWriter = struct {
         errdefer res.keepalive = false;
 
         try self.record(self.interface.flush());
-        if (res.chunked) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
+        if (res.chunked and !res.head) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
         try self.record(res.conn.writer.flush());
         // Sending the wrong number of bytes for a declared length leaves
         // the connection out of sync and the client waiting.
@@ -306,6 +314,11 @@ pub const Response = struct {
     keepalive: bool = true,
     chunked: bool = false,
     streaming: bool = false,
+    /// The request was a HEAD, so the headers go out describing the body
+    /// a GET would have sent, and the body itself does not. Set by the
+    /// server; a handler writes its body either way and does not have to
+    /// know.
+    head: bool = false,
     /// A body writer was handed out and has not been ended yet.
     body_writer_open: bool = false,
     /// Length declared before streaming, if any. On the response rather
@@ -512,7 +525,7 @@ pub const Response = struct {
                 if (self.chunked) {
                     // Framing survives: terminate and let the peer see a
                     // truncated but well formed body.
-                    try self.conn.writer.writeAll("0\r\n\r\n");
+                    if (!self.head) try self.conn.writer.writeAll("0\r\n\r\n");
                 } else if (self.content_length) |declared| {
                     // Nothing can make the body match the length we
                     // promised, so the connection must not be reused: the
@@ -531,8 +544,9 @@ pub const Response = struct {
 
         if (self.chunked) {
             // A streaming writer sent the headers; all that is left is the
-            // terminator.
-            try self.conn.writer.writeAll("0\r\n\r\n");
+            // terminator, which is body framing and so is not sent for a
+            // HEAD either.
+            if (!self.head) try self.conn.writer.writeAll("0\r\n\r\n");
             try self.conn.writer.flush();
             return;
         }
@@ -540,10 +554,13 @@ pub const Response = struct {
         // Write headers if not already written
         try self.writeHeader();
 
-        // Write body (either from buffer or body field)
-        const buffered = self.buffer.writer.buffered();
-        const body = if (buffered.len > 0) buffered else self.body;
-        try self.conn.writer.writeAll(body);
+        // Write body (either from buffer or body field). A HEAD response
+        // has already reported its length and must stop here.
+        if (!self.head) {
+            const buffered = self.buffer.writer.buffered();
+            const body = if (buffered.len > 0) buffered else self.body;
+            try self.conn.writer.writeAll(body);
+        }
 
         try self.conn.writer.flush();
     }
@@ -1574,4 +1591,103 @@ test "Response: resetBody drops the headers that described the old body" {
     // Headers that say nothing about the body are left alone.
     try std.testing.expect(std.mem.indexOf(u8, written, "X-Request-Id: abc") != null);
     try std.testing.expect(std.mem.endsWith(u8, written, "oops\n"));
+}
+
+test "Response: a HEAD reports the length but sends no body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.head = true;
+    response.content_type = .text;
+    response.body = "hello";
+    try response.write();
+
+    const written = conn_writer.buffered();
+    // The headers are the ones a GET would have got.
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "text/plain") != null);
+    // The body is not.
+    try std.testing.expect(std.mem.endsWith(u8, written, "\r\n\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, written, "hello") == null);
+}
+
+test "Response: a HEAD sends no body written through the writer" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.head = true;
+    var body = response.writer();
+    try body.interface.writeAll("hello");
+    try body.end();
+    try response.write();
+
+    const written = conn_writer.buffered();
+    try std.testing.expect(std.mem.indexOf(u8, written, "Content-Length: 5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, written, "hello") == null);
+    try std.testing.expect(std.mem.endsWith(u8, written, "\r\n\r\n"));
+}
+
+test "Response: a streamed HEAD sends the framing headers and nothing after" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.head = true;
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("first");
+    try body.interface.flush();
+    try body.interface.writeAll("second");
+    try body.end();
+
+    // Chunked is what a GET would have been, so it is still announced --
+    // but no chunk and no terminator follow it.
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
+        conn_writer.buffered(),
+    );
+}
+
+test "Response: a streamed HEAD still checks a declared length" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    response.head = true;
+    try response.header("Content-Length", "5");
+
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    // The handler wrote what a GET would have, and is held to the length
+    // it promised even though none of it went out.
+    try body.interface.writeAll("hello");
+    try body.end();
+
+    try std.testing.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n",
+        conn_writer.buffered(),
+    );
 }

--- a/src/router.zig
+++ b/src/router.zig
@@ -219,11 +219,6 @@ pub fn Router(comptime Ctx: type) type {
         }
 
         pub fn findHandler(self: *const Self, req: *Request) !?Route {
-            // Get the tree for this method
-            const method_idx = @intFromEnum(req.method);
-            std.debug.assert(method_idx < 256);
-            const root = self.trees[method_idx] orelse return null;
-
             // Strip query parameters from URL and parse them
             req.query.clearRetainingCapacity();
             const path = if (std.mem.indexOfScalar(u8, req.url, '?')) |query_start| blk: {
@@ -253,14 +248,31 @@ pub fn Router(comptime Ctx: type) type {
                 offset += segment.len + 1; // +1 for the '/'
             }
 
-            const node = try matchRecursive(root, req, path, segments.items, offsets.items, 0);
-            if (node) |n| {
-                if (n.route) |opaque_route| {
-                    const route: *const Route = @ptrCast(@alignCast(opaque_route));
-                    return route.*;
-                }
+            if (try self.matchIn(req.method, req, path, segments.items, offsets.items)) |route| {
+                return route;
+            }
+            // A HEAD response is the GET response without the body, so a
+            // HEAD with no route of its own is answered by the GET one.
+            // Second, so a route registered with `head` still wins.
+            if (req.method == .head) {
+                return self.matchIn(.get, req, path, segments.items, offsets.items);
             }
             return null;
+        }
+
+        fn matchIn(
+            self: *const Self,
+            method: Method,
+            req: *Request,
+            path: []const u8,
+            segments: []const []const u8,
+            offsets: []const usize,
+        ) !?Route {
+            const root = self.trees[@intFromEnum(method)] orelse return null;
+            const node = try matchRecursive(root, req, path, segments, offsets, 0) orelse return null;
+            const opaque_route = node.route orelse return null;
+            const route: *const Route = @ptrCast(@alignCast(opaque_route));
+            return route.*;
         }
 
         pub fn get(self: *Self, path: []const u8, handler: Handler) void {
@@ -1282,4 +1294,94 @@ test "Group: any method registers all methods" {
         const route = try router.findHandler(&req);
         try std.testing.expect(route != null);
     }
+}
+
+test "Router: a GET route answers HEAD" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var router = TestRouter.init(std.testing.allocator);
+    defer router.deinit();
+
+    router.get("/users", testHandler);
+
+    var req = Request{
+        .method = .head,
+        .url = "/users",
+        .arena = arena.allocator(),
+        .parser = undefined,
+        .conn = undefined,
+    };
+    try std.testing.expectEqual(&testHandler, (try router.findHandler(&req)).?.action);
+
+    // The fallback is HEAD's alone; nothing else borrows from GET.
+    req.method = .post;
+    try std.testing.expect(try router.findHandler(&req) == null);
+    req.url = "/nothing";
+    req.method = .head;
+    try std.testing.expect(try router.findHandler(&req) == null);
+}
+
+test "Router: an explicit HEAD route wins over the GET one" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var router = TestRouter.init(std.testing.allocator);
+    defer router.deinit();
+
+    router.get("/users", testHandler);
+    router.head("/users", testHandler2);
+
+    var req = Request{
+        .method = .head,
+        .url = "/users",
+        .arena = arena.allocator(),
+        .parser = undefined,
+        .conn = undefined,
+    };
+    try std.testing.expectEqual(&testHandler2, (try router.findHandler(&req)).?.action);
+
+    req.method = .get;
+    try std.testing.expectEqual(&testHandler, (try router.findHandler(&req)).?.action);
+}
+
+test "Router: HEAD falls back per path, not per tree" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var router = TestRouter.init(std.testing.allocator);
+    defer router.deinit();
+
+    // A HEAD tree exists because of /other, but /users is not in it.
+    router.head("/other", testHandler2);
+    router.get("/users", testHandler);
+
+    var req = Request{
+        .method = .head,
+        .url = "/users",
+        .arena = arena.allocator(),
+        .parser = undefined,
+        .conn = undefined,
+    };
+    try std.testing.expectEqual(&testHandler, (try router.findHandler(&req)).?.action);
+}
+
+test "Router: HEAD falling back to GET still captures path params" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var router = TestRouter.init(std.testing.allocator);
+    defer router.deinit();
+
+    router.get("/users/:id", testHandler);
+
+    var req = Request{
+        .method = .head,
+        .url = "/users/42",
+        .arena = arena.allocator(),
+        .parser = undefined,
+        .conn = undefined,
+    };
+    try std.testing.expect(try router.findHandler(&req) != null);
+    try std.testing.expectEqualStrings("42", req.params.get("id").?);
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -430,6 +430,7 @@ pub fn Server(comptime Ctx: type) type {
                 log.debug("Received: {f} {s}", .{ request.method, request.url });
 
                 var response = try Response.init(arena.allocator(), connection, self.config.request.max_header_count);
+                response.head = request.method == .head;
                 request.response = &response;
 
                 // Handle Expect header (100-continue)

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -916,3 +916,55 @@ test "Server: 417 Expectation Failed for unknown Expect value" {
 
     try client_future.await(io);
 }
+test "Server: HEAD is answered by the GET route with no body" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/thing", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.content_type = .text;
+            res.body = "0123456789";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+            defer stream.shutdown(_io, .both) catch {};
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+            var conn_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &conn_buf);
+
+            try writer.interface.writeAll("HEAD /thing HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+            try writer.interface.flush();
+
+            var rest: [2048]u8 = undefined;
+            var sink: std.Io.Writer = .fixed(&rest);
+            _ = reader.interface.streamRemaining(&sink) catch {};
+            const got = sink.buffered();
+
+            try std.testing.expect(std.mem.indexOf(u8, got, "HTTP/1.1 200") != null);
+            // The length a GET would have reported...
+            try std.testing.expect(std.mem.indexOf(u8, got, "Content-Length: 10") != null);
+            // ...and none of those bytes.
+            try std.testing.expect(std.mem.indexOf(u8, got, "0123456789") == null);
+            try std.testing.expect(std.mem.endsWith(u8, got, "\r\n\r\n"));
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}


### PR DESCRIPTION
Closes #124.

## The problem

`router.head(path, handler)` existed, but nothing between the router and the wire knew the request method — `grep -n "method" src/response.zig` returned nothing. So a HEAD request ran its handler, produced a body, and sent it behind headers that had already declared its length:

```
< Content-Length: 16
* Excess found: excess = 16 url = /bytes/16 (zero-length body)
```

The `Content-Length` is right — RFC 9110 wants HEAD to report what GET *would* have sent — but the payload follows it. The peer reads those bytes as the start of the next response, so a keepalive connection is desynced from there on. curl tolerates it; a stricter client won't.

Nothing had noticed because nothing registered HEAD routes.

## Routing

A HEAD with no route of its own is looked up a second time in the GET tree, rather than `get` registering both.

Registering both would have been simpler and wrong twice over:
- `router.head(p, h)` **before** the matching `router.get(p, h2)` would be silently replaced by `h2`.
- The fallback has to be per path, not per tree — a HEAD tree existing because of `/other` says nothing about `/users`.

An explicit `head` route still wins, because its own tree is consulted first.

## Body suppression

`Response.head` is set by the server from `request.method`. The body is dropped where it would be written, so a handler writes what it always wrote and doesn't have to know:

- the buffered body in `write`
- the streaming writer's chunks in `drain`
- the chunked terminator, which is framing for a body that isn't there

Headers are untouched, and a streaming writer is still held to a `Content-Length` it declared — the handler produced those bytes even though none of them left.

## Tests

Router: GET answers HEAD; explicit HEAD wins; fallback is per path not per tree; path params still captured through the fallback; no other method borrows from GET.

Response: buffered body, `res.writer()` body, streamed chunked, and streamed with a declared length.

Server: end-to-end over a real socket — `Content-Length: 10`, no payload, response ends at the blank line.

239 tests pass.