### PR TITLE
Release the connection timeout before arming it again (workaround for a zio regression)

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -415,6 +415,12 @@ pub fn Server(comptime Ctx: type) type {
                 request_count += 1;
 
                 if (self.config.timeout.request) |duration| {
+                    // TODO(zio): drop once we require a zio with
+                    // lalinsky/zio#657. `set` is meant to handle a re-arm
+                    // itself, and stopped: it arms on the executor the task
+                    // is on now, so re-arming after a migration asks one
+                    // loop for a timer live in another's heap.
+                    timeout.clear();
                     timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
                 }
 
@@ -522,6 +528,8 @@ pub fn Server(comptime Ctx: type) type {
                 connection.reader.end = 0;
 
                 if (self.config.timeout.keepalive) |duration| {
+                    // TODO(zio): drop with the one above, same reason.
+                    timeout.clear();
                     timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
                 }
 


### PR DESCRIPTION
**This is a workaround, and probably should not be merged.** The fix belongs in zio: https://github.com/lalinsky/zio/pull/657

## What happens

```
thread panic: reached unreachable code
  ev/loop.zig:621:  assert(st.phase != .running or timer.c.getLoop() == self)
  autocancel.zig:76: executor.loop.setTimer(&self.timer, timeout)
  server.zig:526:    timeout.set(...)
```

`handleRequests` arms an `AutoCancel` for the request and again for the keepalive wait. `AutoCancel.set` arms on whichever executor the task is running on at the time, so a connection task that migrated between those two arms asked one loop to re-arm a timer still live in another's heap.

## Whose bug it is

dusty's usage is correct — re-arming an `AutoCancel` is what the API is for, and it worked until a zio refactoring stopped handling it. `set()` should retire the previous arm itself, which is what zio#657 does; that also closes a second problem in the same lines, where `set()`'s resets of `triggered` and `fired` race a callback still in flight regardless of which loop owns the timer.

So this branch changes the caller to work around something the callee should handle, and would leave a `clear()` in dusty that reads as load-bearing once zio no longer needs it.

## Why it is still here

dusty doesn't depend on zio — the httpbin example does, pinned at `v0.17.0` — so #125's CI stays red until zio#657 ships in a release and the example's `build.zig.zon` moves to it. This unblocks that in the meantime if the wait is inconvenient.

Measured against the integration suite in #125: 2 of 15 runs crashed before, 15 of 15 pass after. Same result from zio#657 alone.

## Worth keeping separately?

There is an argument for dusty releasing the timeout explicitly regardless of zio: a keepalive timeout still armed when the request arrives, and a request timeout still armed while waiting for the next one, both describe a deadline that no longer applies. That is a readability question rather than a correctness one, and it should not be settled under the pressure of a crash.
