### PR TITLE
Cover the TLS handshake with the request timeout

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -377,7 +377,27 @@ pub fn Server(comptime Ctx: type) type {
                         }
 
                         connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth) catch |err| {
-                            log.err("TLS handshake failed: {}", .{err});
+                            // tls.zig only saw the ciphertext reader or
+                            // writer fail generically, so the cause is a
+                            // layer down -- and when the handshake ran out
+                            // of time, that cause is the cancel.
+                            const cause = switch (err) {
+                                error.TransportReadFailed => connection.getReadError() orelse err,
+                                error.TransportWriteFailed => connection.getWriteError() orelse err,
+                                else => err,
+                            };
+                            // Nothing was negotiated, so there is no TLS
+                            // session to shut down politely either way.
+                            needs_shutdown = false;
+                            if (cause == error.Canceled) {
+                                log.debug("TLS handshake canceled", .{});
+                                return error.Canceled;
+                            }
+                            if (Connection.isPeerGone(cause)) {
+                                log.debug("TLS handshake abandoned by peer: {}", .{cause});
+                            } else {
+                                log.err("TLS handshake failed: {}", .{cause});
+                            }
                             return;
                         };
                     }

--- a/src/server.zig
+++ b/src/server.zig
@@ -362,10 +362,25 @@ pub fn Server(comptime Ctx: type) type {
             // directly over the raw stream.
             if (build_options.use_tls) {
                 if (self.tls_auth) |*auth| {
-                    connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth) catch |err| {
-                        log.err("TLS handshake failed: {}", .{err});
-                        return;
-                    };
+                    // The handshake is the one part of a connection's life
+                    // the request loop's timeout cannot cover, since that
+                    // loop does not exist yet. A peer that opens a socket
+                    // and then stalls mid-handshake would otherwise hold a
+                    // task and the connection's whole buffer reservation
+                    // for as long as it likes -- cheaper for it than a
+                    // slow request, which is bounded.
+                    {
+                        var handshake: zio.AutoCancel = .init;
+                        defer handshake.clear();
+                        if (self.config.timeout.request) |duration| {
+                            handshake.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                        }
+
+                        connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth) catch |err| {
+                            log.err("TLS handshake failed: {}", .{err});
+                            return;
+                        };
+                    }
 
                     // Per-request arena nested on the connection arena: resetting it
                     // between keepalive requests reuses the connection's memory


### PR DESCRIPTION
## The gap

Every part of a connection's life is bounded by a timeout except the one that happens first.

`handleRequests` creates the `AutoCancel` at `server.zig:406` and arms it at `:417`, before reading a request, and keeps it armed through the handler, the response write, the body drain, and the keepalive wait. But the TLS handshake runs in `handleConnection` at `:365` — before that loop exists.

So a peer can complete the TCP handshake, send a record header promising bytes that never arrive, and hold a connection task indefinitely. It also holds the whole per-connection reservation, which on the TLS path is both record buffers plus two request buffers, allocated eagerly at `:73`:

```zig
const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + 1024);
```

That makes a stalled handshake *cheaper* for an attacker than a slow request, which was already bounded, and more expensive for the server.

## The fix

Arm an `AutoCancel` around `initTls` using `config.timeout.request`, on the grounds that the handshake is part of receiving the first request rather than something a caller would want to budget separately. If you'd rather it were its own knob, say so — it's a one-line change to `Timeout`.

## Verification

Not testable in this repo: `zig build test` links `src/zio_stub.zig`, whose `AutoCancel.set` panics, so no test here can configure a timeout at all. That's why the timeout paths have no coverage in general.

Verified instead against a server built with the real zio module and a self-signed cert. A client that opens a socket, writes a TLS record header claiming 80 bytes, and then sends nothing:

| | result |
|---|---|
| before | still connected when the test gave up at 20s |
| after | dropped at the 2s configured timeout |

A normal TLS request over the same server returns 200 in both cases, so the timeout isn't firing on healthy handshakes.

## Context

Came out of a threat-modelling pass on running dusty publicly without a proxy. The other two findings there are not addressed here: there is still no cap on concurrent connections (`active_connections` is a shutdown counter, not a limit), and the TLS cert is read once at `listen()` with no reload path.
