### PR TITLE
Survive an accept() that fails for a reason that will pass

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -26,6 +26,11 @@ pub const ServerConfig = struct {
         keepalive: ?std.Io.Duration = null,
         /// Maximum number of requests per keepalive connection
         request_count: ?usize = null,
+        /// Maximum time a graceful shutdown waits for the connections still
+        /// in flight. Null waits for all of them, however long they take --
+        /// which for a connection that never closes on its own, such as a
+        /// WebSocket or an event stream, is forever.
+        shutdown: ?std.Io.Duration = .fromSeconds(30),
     };
 
     pub const Request = struct {

--- a/src/server.zig
+++ b/src/server.zig
@@ -380,23 +380,36 @@ pub fn Server(comptime Ctx: type) type {
 
             log.info("Graceful shutdown requested", .{});
             self.shutting_down.store(true, .release);
-            while (true) { // TODO: add graceful shutdown timeout
+
+            // Turned into a deadline once, so the budget covers the drain as
+            // a whole. A per-wait duration would restart it every time a
+            // connection closed, and a steady trickle would then hold the
+            // shutdown open indefinitely.
+            const timeout: std.Io.Timeout = if (self.config.timeout.shutdown) |duration|
+                std.Io.Timeout.toDeadline(.{ .duration = .{ .raw = duration, .clock = .awake } }, self.io)
+            else
+                .none;
+
+            while (true) {
                 const remaining = self.active_connections.load(.acquire);
                 if (remaining == 0) return;
+
+                if (timeout.toTimestamp(self.io)) |deadline| {
+                    if (std.Io.Clock.Timestamp.now(self.io, .awake).compare(.gte, deadline)) {
+                        log.warn("Shutdown timed out with {d} connection(s) still open", .{remaining});
+                        return;
+                    }
+                }
+
                 log.info("Waiting for {} remaining connections to close", .{remaining});
-                // Returns immediately if the count already changed, otherwise
-                // blocks until a close wakes it or the timeout expires.
-                self.io.futexWaitTimeout(u32, &self.active_connections.raw, remaining, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } }) catch |err| switch (err) {
+                // Wakes when a connection closes, or when the deadline
+                // arrives; the loop above decides which happened. Spurious
+                // wakeups just re-read the count.
+                self.io.futexWaitTimeout(u32, &self.active_connections.raw, remaining, timeout) catch |err| switch (err) {
                     // Cannot happen: protection is blocked for this whole
                     // function, so no Io call here is a cancelation point.
                     error.Canceled => unreachable,
                 };
-                if (self.active_connections.load(.acquire) == remaining) {
-                    // Nothing closed while we waited. Stop holding the
-                    // shutdown open for connections that are not finishing.
-                    log.warn("Giving up on {d} connection(s) that did not close", .{remaining});
-                    return;
-                }
             }
         }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -311,7 +311,7 @@ pub fn Server(comptime Ctx: type) type {
             while (true) {
                 const stream = server.accept(self.io) catch |err| switch (err) {
                     error.Canceled => {
-                        try self.drainConnections();
+                        self.drainConnections();
                         return err;
                     },
                     // One connection went away between its SYN and our
@@ -331,14 +331,17 @@ pub fn Server(comptime Ctx: type) type {
                         backoff_ms = if (backoff_ms == 0) min_accept_backoff_ms else @min(backoff_ms * 2, max_accept_backoff_ms);
                         log.warn("Accept failed: {}; retrying in {d}ms", .{ err, backoff_ms });
                         self.io.sleep(.fromMilliseconds(@intCast(backoff_ms)), .awake) catch |sleep_err| {
-                            // Acted on here, not deferred with `recancel` to
-                            // the accept above: that accept is failing
-                            // without suspending -- that is why we are in
-                            // the backoff -- so it is not a cancelation
-                            // point and would never report it. Deferring
-                            // livelocks, ping-ponging the cancellation
-                            // between here and the re-arm.
-                            try self.drainConnections();
+                            // Acted on here, not deferred to the accept
+                            // above with `recancel`. That accept keeps
+                            // failing for its own reason -- the fd table is
+                            // full, which is why we are in the backoff --
+                            // and an operation that completes with a result
+                            // of its own has the cancellation re-armed
+                            // rather than reported, so the caller gets its
+                            // result. Deferring therefore livelocks: the
+                            // cancellation is re-armed by turns here and in
+                            // the runtime, and never delivered.
+                            self.drainConnections();
                             return sleep_err;
                         };
                         continue;
@@ -366,7 +369,12 @@ pub fn Server(comptime Ctx: type) type {
         /// cancel arriving mid-drain would abandon connections rather than
         /// finish with them. What bounds it is its own policy below, not
         /// whoever asked it to stop.
-        fn drainConnections(self: *Self) error{Timeout}!void {
+        ///
+        /// Infallible, so that `listen` reports the cancellation that stopped
+        /// it rather than a detail of how the drain went. Connections that
+        /// outlast the wait are logged and left to the caller's deferred
+        /// `group.cancel`, which tears them down either way.
+        fn drainConnections(self: *Self) void {
             const protection = self.io.swapCancelProtection(.blocked);
             defer _ = self.io.swapCancelProtection(protection);
 
@@ -383,9 +391,12 @@ pub fn Server(comptime Ctx: type) type {
                     // function, so no Io call here is a cancelation point.
                     error.Canceled => unreachable,
                 };
-                // No connection closed within the timeout. Let the deferred
-                // group.cancel tear down the remaining handlers.
-                if (self.active_connections.load(.acquire) == remaining) return error.Timeout;
+                if (self.active_connections.load(.acquire) == remaining) {
+                    // Nothing closed while we waited. Stop holding the
+                    // shutdown open for connections that are not finishing.
+                    log.warn("Giving up on {d} connection(s) that did not close", .{remaining});
+                    return;
+                }
             }
         }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -17,6 +17,13 @@ const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
 
 const log = std.log.scoped(.dusty);
 
+/// How long the accept loop waits after failing for want of a file
+/// descriptor or memory, doubling up to the cap. Short enough that a brief
+/// shortage costs a little latency, capped so a sustained one settles into
+/// one attempt a second rather than a spin.
+const min_accept_backoff_ms = 5;
+const max_accept_backoff_ms = 1000;
+
 /// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
 /// layer), plus the arena backing their buffers, for one accepted
 /// connection. Initialized in place: `tls_conn` stores pointers into
@@ -297,26 +304,48 @@ pub fn Server(comptime Ctx: type) type {
                 group.cancel(self.io);
             }
 
+            // Grows while accepting keeps failing for want of resources, and
+            // is reset by the first connection that gets through.
+            var backoff_ms: u64 = 0;
+
             while (true) {
-                const stream = server.accept(self.io) catch |err| {
-                    if (err == error.Canceled) {
-                        log.info("Graceful shutdown requested", .{});
-                        self.shutting_down.store(true, .release);
-                        while (true) { // TODO: add graceful shutdown timeout
-                            const remaining = self.active_connections.load(.acquire);
-                            if (remaining == 0) break;
-                            log.info("Waiting for {} remaining connections to close", .{remaining});
-                            // Returns immediately if the count already changed, otherwise
-                            // blocks until a close wakes it or the timeout expires.
-                            try self.io.futexWaitTimeout(u32, &self.active_connections.raw, remaining, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } });
-                            // No connection closed within the timeout. Let the deferred
-                            // group.cancel tear down the remaining handlers.
-                            if (self.active_connections.load(.acquire) == remaining) return error.Timeout;
-                        }
+                const stream = server.accept(self.io) catch |err| switch (err) {
+                    error.Canceled => {
+                        try self.drainConnections();
                         return err;
-                    }
-                    return err;
+                    },
+                    // One connection went away between its SYN and our
+                    // accept, which says nothing about the listener. Routine
+                    // on a public address, where clients reset and scanners
+                    // probe, so it is not worth a log line or a pause.
+                    error.ConnectionAborted => continue,
+                    // The machine is out of something, for now. Sleeping and
+                    // trying again turns that into latency; returning would
+                    // turn a condition that clears on its own into an outage
+                    // that needs a restart.
+                    error.ProcessFdQuotaExceeded,
+                    error.SystemFdQuotaExceeded,
+                    error.SystemResources,
+                    error.WouldBlock,
+                    => {
+                        backoff_ms = if (backoff_ms == 0) min_accept_backoff_ms else @min(backoff_ms * 2, max_accept_backoff_ms);
+                        log.warn("Accept failed: {}; retrying in {d}ms", .{ err, backoff_ms });
+                        self.io.sleep(.fromMilliseconds(@intCast(backoff_ms)), .awake) catch |sleep_err| {
+                            // Acted on here, not deferred with `recancel` to
+                            // the accept above: that accept is failing
+                            // without suspending -- that is why we are in
+                            // the backoff -- so it is not a cancelation
+                            // point and would never report it. Deferring
+                            // livelocks, ping-ponging the cancellation
+                            // between here and the re-arm.
+                            try self.drainConnections();
+                            return sleep_err;
+                        };
+                        continue;
+                    },
+                    else => return err,
                 };
+                backoff_ms = 0;
 
                 _ = self.active_connections.fetchAdd(1, .acq_rel);
                 group.concurrent(self.io, handleConnectionWrapper, .{ self, stream }) catch |err| {
@@ -325,6 +354,38 @@ pub fn Server(comptime Ctx: type) type {
                     stream.close(self.io);
                     continue;
                 };
+            }
+        }
+
+        /// Stops accepting and waits for the connections already in flight.
+        /// Reached from every way the accept loop can learn it was canceled,
+        /// so a shutdown drains whether the cancel landed on the accept or
+        /// on a backoff wait.
+        ///
+        /// Runs under cancel protection: this is the shutdown, and a further
+        /// cancel arriving mid-drain would abandon connections rather than
+        /// finish with them. What bounds it is its own policy below, not
+        /// whoever asked it to stop.
+        fn drainConnections(self: *Self) error{Timeout}!void {
+            const protection = self.io.swapCancelProtection(.blocked);
+            defer _ = self.io.swapCancelProtection(protection);
+
+            log.info("Graceful shutdown requested", .{});
+            self.shutting_down.store(true, .release);
+            while (true) { // TODO: add graceful shutdown timeout
+                const remaining = self.active_connections.load(.acquire);
+                if (remaining == 0) return;
+                log.info("Waiting for {} remaining connections to close", .{remaining});
+                // Returns immediately if the count already changed, otherwise
+                // blocks until a close wakes it or the timeout expires.
+                self.io.futexWaitTimeout(u32, &self.active_connections.raw, remaining, .{ .duration = .{ .raw = std.Io.Duration.fromMilliseconds(100), .clock = .awake } }) catch |err| switch (err) {
+                    // Cannot happen: protection is blocked for this whole
+                    // function, so no Io call here is a cancelation point.
+                    error.Canceled => unreachable,
+                };
+                // No connection closed within the timeout. Let the deferred
+                // group.cancel tear down the remaining handlers.
+                if (self.active_connections.load(.acquire) == remaining) return error.Timeout;
             }
         }
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -452,7 +452,11 @@ test "Server: graceful shutdown drain still blocks after an earlier connection c
     };
     sync.slow_started = .unset;
 
-    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    // Short enough to expire long before the 2s handler finishes, so the
+    // drain has to give up rather than wait it out.
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .timeout = .{ .shutdown = .fromMilliseconds(100) },
+    }, {});
     defer server.deinit();
 
     server.router.get("/fast", struct {
@@ -516,11 +520,11 @@ test "Server: graceful shutdown drain still blocks after an earlier connection c
 
     try sync.slow_started.wait(io);
 
-    // Graceful shutdown: the drain must block, and give up on the connection
-    // rather than wait out the 2s handler. The elapsed time is what shows
-    // that -- before the fix the drain spun hot until the handler finished,
-    // which took the full two seconds. `listen` reports the cancellation
-    // either way; the drain no longer reports how it went.
+    // Graceful shutdown: the drain must block, and give up when its budget
+    // runs out rather than wait out the 2s handler. The elapsed time is what
+    // shows that -- before the fix the drain spun hot until the handler
+    // finished, which took the full two seconds. `listen` reports the
+    // cancellation either way; the drain no longer reports how it went.
     const start = std.Io.Timestamp.now(io, .awake);
     try std.testing.expectError(error.Canceled, server_future.cancel(io));
     const elapsed_ns = std.Io.Timestamp.now(io, .awake).nanoseconds - start.nanoseconds;
@@ -969,4 +973,62 @@ test "Server: HEAD is answered by the GET route with no body" {
     }.run, .{ &server, io });
 
     try client_future.await(io);
+}
+
+test "Server: graceful shutdown waits for a connection that finishes in time" {
+    const io = std.testing.io;
+
+    const sync = struct {
+        var started: std.Io.Event = .unset;
+        var finished: bool = false;
+    };
+    sync.started = .unset;
+    sync.finished = false;
+
+    // Comfortably longer than the handler, so the drain has no reason to
+    // give up on it.
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .timeout = .{ .shutdown = .fromMilliseconds(5000) },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/slow", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            sync.started.set(req.io);
+            try req.io.sleep(.fromMilliseconds(200), .awake);
+            sync.finished = true;
+            res.body = "slow";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const stream = try server.address.ip.connect(io, .{ .mode = .stream });
+    defer stream.close(io);
+    defer stream.shutdown(io, .both) catch {};
+
+    var write_buf: [1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buf);
+    try writer.interface.writeAll("GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    try writer.interface.flush();
+
+    try sync.started.wait(io);
+
+    const start = std.Io.Timestamp.now(io, .awake);
+    try std.testing.expectError(error.Canceled, server_future.cancel(io));
+    const elapsed_ns = std.Io.Timestamp.now(io, .awake).nanoseconds - start.nanoseconds;
+
+    // Waited for the handler rather than abandoning it, and stopped as soon
+    // as it was done rather than sitting out the rest of the budget.
+    try std.testing.expect(sync.finished);
+    try std.testing.expect(elapsed_ns >= 100 * std.time.ns_per_ms);
+    try std.testing.expect(elapsed_ns < 2000 * std.time.ns_per_ms);
 }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -516,11 +516,13 @@ test "Server: graceful shutdown drain still blocks after an earlier connection c
 
     try sync.slow_started.wait(io);
 
-    // Graceful shutdown: the drain must block and hit its 100ms timeout long
-    // before the 2s handler completes. Before the fix the drain spun hot until
-    // the handler finished and returned error.Canceled instead.
+    // Graceful shutdown: the drain must block, and give up on the connection
+    // rather than wait out the 2s handler. The elapsed time is what shows
+    // that -- before the fix the drain spun hot until the handler finished,
+    // which took the full two seconds. `listen` reports the cancellation
+    // either way; the drain no longer reports how it went.
     const start = std.Io.Timestamp.now(io, .awake);
-    try std.testing.expectError(error.Timeout, server_future.cancel(io));
+    try std.testing.expectError(error.Canceled, server_future.cancel(io));
     const elapsed_ns = std.Io.Timestamp.now(io, .awake).nanoseconds - start.nanoseconds;
     try std.testing.expect(elapsed_ns < 1500 * std.time.ns_per_ms);
 }


### PR DESCRIPTION
Closes #134.

## The problem

The accept loop treated every error except `error.Canceled` as fatal — `return err` leaves `listen()` and the server stops accepting for good. Most of `AcceptError` is transient, and one member of it is not even a problem:

- **`ConnectionAborted`** — a socket in the accept queue whose peer went away before we got to it. Says nothing about the listener, and happens continuously on a public address.
- **`ProcessFdQuotaExceeded` / `SystemFdQuotaExceeded` / `SystemResources`** — the machine is out of something, for now. Exactly what a connection flood produces.

So a flood did not degrade the server, it ended it: a condition that clears on its own became an outage needing a restart.

## What it does now

Aborted connections retry immediately — nothing is wrong, and pausing would only give the next one time to abort too. Resource failures back off from 5ms, doubling to a 1s cap, reset by the first connection that gets through. Same shape as Go's `net/http` (`server.go:3439`).

Two deliberate departures from Go, both noted in the code:

- **`SystemResources` backs off rather than being fatal.** Go treats ENOBUFS as fatal — it is absent from `Errno.Temporary()`. `std.Io` describes it as socket buffer limits rather than system memory, which reads transient, and the cost of guessing wrong is one retry.
- **`ConnectionAborted` is handled here, not below.** Go retries it inside the accept syscall wrapper so it never surfaces. dusty is `std.Io`-generic and cannot assume its `Io` does that, so it copes regardless. lalinsky/zio#658 proposes the lower-level retry for zio's own users.

## Cancellation

A cancel arriving during the backoff wait is a shutdown, and is acted on where it lands rather than deferred to the accept above with `std.Io.recancel`.

Deferring is what the std docs suggest for "I saw it, not my job" — and it livelocks here. The accept is failing *without suspending*, which is the whole reason we are in the backoff; it is therefore not a cancelation point and never reports the re-armed cancellation. The cancel ping-pongs between the sleep and the re-arm forever. Confirmed by test: the server hung, logging one backoff line a second indefinitely after the cancel.

Acting on it is also mandatory rather than merely tidy, since delivery is once only — `AnyTask.checkCancel` decrements `pending_errors` as it reports. Swallowing would not delay the shutdown, it would lose it, and the next `accept()` would block as if nothing had happened.

The graceful drain moved out of the accept error path into `drainConnections()` so both ways of learning about a cancel reach it, and it runs under `swapCancelProtection(.blocked)` using the idiom from the `swapCancelProtection` docs. It is the shutdown: a further cancel arriving mid-drain would abandon connections rather than finish with them, and what bounds it is its own policy, not whoever asked it to stop.

## Verification

Not testable in the suite — nothing can provoke an accept failure through `std.testing.io`.

Verified against a server built with the real zio, run under `RLIMIT_NOFILE=64` with 200 sockets held open against it:

| | before | after |
|---|---|---|
| sockets accepted before the listener died | 65 | all 200 held, none refused |
| request once the sockets close | `ECONNREFUSED` | `200` |
| cancel arriving during the backoff | n/a | drains and exits cleanly |

The log shows the backoff climbing 5ms, 10ms, 20ms and stopping once connections free up. Graceful shutdown on SIGTERM still drains.
