### PR TITLE
Split the HTTP/1.x engine out of server.zig

### DIFF
--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Request = @import("request.zig").Request;
 const Response = @import("response.zig").Response;
 const Action = @import("router.zig").Action;
-const Connection = @import("server.zig").Connection;
+const Connection = @import("server/connection.zig").Connection;
 
 const log = std.log.scoped(.dusty);
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -4,7 +4,7 @@ const Request = @import("request.zig").Request;
 pub const WebSocket = @import("websocket.zig").WebSocket;
 pub const CookieOpts = @import("cookie.zig").CookieOpts;
 const serializeCookie = @import("cookie.zig").serializeCookie;
-const Connection = @import("server.zig").Connection;
+const Connection = @import("server/connection.zig").Connection;
 
 var no_buf: [0]u8 = .{};
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -5,15 +5,12 @@ const build_options = @import("build_options");
 
 const Router = @import("router.zig").Router;
 const Action = @import("router.zig").Action;
-const RequestParser = @import("parser.zig").RequestParser;
-const RequestBodyReader = @import("parser.zig").RequestBodyReader;
-const Request = @import("request.zig").Request;
-const parseHeaders = @import("request.zig").parseHeaders;
-const Response = @import("response.zig").Response;
 const ServerConfig = @import("config.zig").ServerConfig;
-const Executor = @import("middleware.zig").Executor;
 const Middleware = @import("middleware.zig").Middleware;
 const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
+const h1 = @import("server/h1.zig");
+
+pub const Connection = @import("server/connection.zig").Connection;
 
 const log = std.log.scoped(.dusty);
 
@@ -23,154 +20,6 @@ const log = std.log.scoped(.dusty);
 /// one attempt a second rather than a spin.
 const min_accept_backoff_ms = 5;
 const max_accept_backoff_ms = 1000;
-
-/// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
-/// layer), plus the arena backing their buffers, for one accepted
-/// connection. Initialized in place: `tls_conn` stores pointers into
-/// `tcp_reader`/`tcp_writer`, and `tls_reader`/`tls_writer` store a pointer
-/// back into `tls_conn`, so a `Connection` must never be moved after
-/// `initPlain`/`initTls` runs.
-pub const Connection = struct {
-    io: std.Io,
-    stream: std.Io.net.Stream,
-    arena: std.heap.ArenaAllocator = undefined,
-
-    tcp_reader: std.Io.net.Stream.Reader = undefined,
-    tcp_writer: std.Io.net.Stream.Writer = undefined,
-    write_buffer: [4096]u8 = undefined,
-
-    // TLS layer: tcp_reader/tcp_writer above carry ciphertext; tls_conn wraps
-    // them, and tls_reader/tls_writer expose the cleartext Reader/Writer used
-    // for HTTP I/O.
-    tls_conn: ?tls.Connection = null,
-    tls_rng: std.Random.IoSource = undefined,
-    tls_cleartext_write_buffer: [4096]u8 = undefined,
-    tls_reader: tls.Connection.Reader = undefined,
-    tls_writer: tls.Connection.Writer = undefined,
-
-    // Active reader/writer, whichever path is in use.
-    reader: *std.Io.Reader = undefined,
-    writer: *std.Io.Writer = undefined,
-
-    pub fn initPlain(self: *Connection, allocator: std.mem.Allocator, io: std.Io, stream: std.Io.net.Stream) void {
-        self.* = .{ .io = io, .stream = stream };
-        self.arena = .init(allocator);
-        self.tcp_reader = stream.reader(io, &.{});
-        self.tcp_writer = stream.writer(io, &self.write_buffer);
-        self.reader = &self.tcp_reader.interface;
-        self.writer = &self.tcp_writer.interface;
-    }
-
-    pub fn initTls(
-        self: *Connection,
-        allocator: std.mem.Allocator,
-        io: std.Io,
-        stream: std.Io.net.Stream,
-        request_buffer_size: usize,
-        auth: *tls.config.CertKeyPair,
-    ) !void {
-        self.* = .{ .io = io, .stream = stream };
-        self.arena = .init(allocator);
-
-        // Aim for a single backing allocation per connection: prime the
-        // arena with room for the two TLS record buffers plus a working
-        // budget, then recycle it (reset keeps the memory). The TLS buffers
-        // and the per-request arena are then carved from that one
-        // allocation; only unusually large requests grow it.
-        const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + 1024);
-        _ = try self.arena.allocator().alloc(u8, conn_reserve);
-        _ = self.arena.reset(.retain_capacity);
-
-        // The TLS record buffers live for the whole connection (the
-        // tls.Connection points into them) and must survive the per-request
-        // arena resets, so they come from the connection arena.
-        const tcp_read_buffer = try self.arena.allocator().alloc(u8, tls.input_buffer_len);
-        const tcp_write_buffer = try self.arena.allocator().alloc(u8, tls.output_buffer_len);
-
-        self.tcp_reader = stream.reader(io, tcp_read_buffer);
-        self.tcp_writer = stream.writer(io, tcp_write_buffer);
-        self.tls_rng = .{ .io = io };
-        self.tls_conn = try tls.server(&self.tcp_reader.interface, &self.tcp_writer.interface, .{
-            .auth = auth,
-            .now = std.Io.Clock.real.now(io),
-            .rng = self.tls_rng.interface(),
-        });
-        self.tls_reader = self.tls_conn.?.reader(&.{});
-        self.tls_writer = self.tls_conn.?.writer(&self.tls_cleartext_write_buffer);
-        self.reader = &self.tls_reader.interface;
-        self.writer = &self.tls_writer.interface;
-    }
-
-    /// For tests: wraps a bare writer with no real TLS/TCP layer behind it.
-    /// `tcp_writer.err` is left settable so a test can simulate the real
-    /// error a write failure should surface.
-    pub fn initWriterForTesting(self: *Connection, w: *std.Io.Writer) void {
-        self.* = .{ .io = undefined, .stream = undefined, .reader = undefined, .writer = w };
-        self.tcp_reader.err = null;
-        self.tcp_writer.err = null;
-    }
-
-    pub fn deinit(self: *Connection) void {
-        self.arena.deinit();
-    }
-
-    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
-    // layer below it failed, because all it saw was the ciphertext
-    // reader/writer's generic error; the real cause is on the TCP layer.
-    // So those two mean "keep descending". A TLS-level failure (bad record
-    // mac, bad version, ...) is recorded as itself and stops the search.
-
-    fn checkReadError(self: *Connection) !void {
-        if (build_options.use_tls) {
-            if (self.tls_conn != null) {
-                if (self.tls_reader.err) |e| if (e != error.TransportReadFailed) return e;
-            }
-        }
-        if (self.tcp_reader.err) |e| return e;
-    }
-
-    /// The real error behind a generic `error.ReadFailed`, if any was recorded.
-    pub fn getReadError(self: *Connection) ?@typeInfo(@TypeOf(checkReadError(self))).error_union.error_set {
-        if (checkReadError(self)) |_| return null else |e| return e;
-    }
-
-    fn checkWriteError(self: *Connection) !void {
-        if (build_options.use_tls) {
-            if (self.tls_conn != null) {
-                if (self.tls_writer.err) |e| if (e != error.TransportWriteFailed) return e;
-            }
-        }
-        if (self.tcp_writer.err) |e| return e;
-    }
-
-    /// The error type `getWriteError` yields.
-    pub const WriteError = @typeInfo(@TypeOf(checkWriteError(undefined))).error_union.error_set;
-
-    /// The real error behind a generic `error.WriteFailed`, if any was
-    /// recorded.
-    pub fn getWriteError(self: *Connection) ?@typeInfo(@TypeOf(checkWriteError(self))).error_union.error_set {
-        if (checkWriteError(self)) |_| return null else |e| return e;
-    }
-
-    /// True when `err` means the peer is gone rather than something being
-    /// wrong. Teardown is the same either way; this only decides whether the
-    /// connection is worth a log line and whether shutdown() is worth a
-    /// syscall.
-    pub fn isPeerGone(err: anyerror) bool {
-        return switch (err) {
-            error.EndOfStream,
-            // Peer closed the transport between TLS records without
-            // close_notify. Rude, but routine from clients that just close
-            // the socket. `TlsTruncated`, where a record was cut in half, is
-            // deliberately not here.
-            error.TlsUnexpectedEof,
-            error.ConnectionResetByPeer,
-            error.BrokenPipe,
-            => true,
-            else => false,
-        };
-    }
-};
 
 pub const Address = union(enum) {
     ip: std.Io.net.IpAddress,
@@ -442,8 +291,8 @@ pub fn Server(comptime Ctx: type) type {
             var connection: Connection = undefined;
             defer connection.deinit();
 
-            // When TLS is configured, upgrade the accepted stream and run the
-            // request loop over the cleartext reader/writer. Otherwise run it
+            // When TLS is configured, upgrade the accepted stream before
+            // handing the connection to the engine. Otherwise the engine runs
             // directly over the raw stream.
             if (build_options.use_tls) {
                 if (self.tls_auth) |*auth| {
@@ -487,250 +336,17 @@ pub fn Server(comptime Ctx: type) type {
                         };
                     }
 
-                    // Per-request arena nested on the connection arena: resetting it
-                    // between keepalive requests reuses the connection's memory
-                    // without touching the TLS buffers carved above.
-                    var request_arena = std.heap.ArenaAllocator.init(connection.arena.allocator());
-                    return self.handleRequests(&connection, &request_arena, &needs_shutdown);
+                    return h1.Engine(Ctx).serve(self, &connection, &needs_shutdown);
                 }
             }
 
             connection.initPlain(self.allocator, self.io, stream);
-            return self.handleRequests(&connection, &connection.arena, &needs_shutdown);
-        }
-
-        /// Runs the HTTP request/keepalive loop over a connection.
-        fn handleRequests(
-            self: *Self,
-            connection: *Connection,
-            arena: *std.heap.ArenaAllocator,
-            needs_shutdown: *bool,
-        ) !void {
-            var request: Request = .{
-                .arena = arena.allocator(),
-                .io = self.io,
-                .conn = connection.reader,
-                .parser = undefined,
-                .config = self.config.request,
-                .remote_address = connection.stream.socket.address,
-            };
-
-            var parser: RequestParser = undefined;
-            try parser.init(&request);
-            defer parser.deinit();
-
-            request.parser = &parser;
-
-            var request_count: usize = 0;
-
-            var timeout: zio.AutoCancel = .init;
-            defer timeout.clear();
-
-            // Allocate initial buffer from arena
-            connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
-                log.err("Failed to allocate read buffer: {}", .{err});
-                return err;
-            };
-
-            while (true) {
-                request_count += 1;
-
-                if (self.config.timeout.request) |duration| {
-                    // TODO(zio): drop once we require a zio with
-                    // lalinsky/zio#657. `set` is meant to handle a re-arm
-                    // itself, and stopped: it arms on the executor the task
-                    // is on now, so re-arming after a migration asks one
-                    // loop for a timer live in another's heap.
-                    timeout.clear();
-                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
-                }
-
-                parseHeaders(connection.reader, &parser) catch |err| switch (err) {
-                    error.EndOfStream => {
-                        needs_shutdown.* = false;
-                        return;
-                    },
-                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
-                    else => |e| return e,
-                };
-
-                log.debug("Received: {f} {s}", .{ request.method, request.url });
-
-                var response = try Response.init(arena.allocator(), connection, self.config.request.max_header_count);
-                response.head = request.method == .head;
-                request.response = &response;
-
-                // Handle Expect header (100-continue)
-                if (request.headers.get("Expect")) |expect| {
-                    if (std.ascii.eqlIgnoreCase(expect, "100-continue")) {
-                        request.expects_continue = true;
-                    } else {
-                        // Unknown Expect value - return 417
-                        response.status = .expectation_failed;
-                        response.keepalive = false;
-                        try response.write();
-                        return;
-                    }
-                }
-
-                // Check if the connection allows keepalive
-                if (!parser.shouldKeepAlive()) {
-                    response.keepalive = false;
-                }
-
-                // Check if we've reached the request count limit
-                if (self.config.timeout.request_count) |max_count| {
-                    if (request_count >= max_count) {
-                        response.keepalive = false;
-                    }
-                }
-
-                const found = try self.router.findHandler(&request);
-                var executor = Executor(Ctx){
-                    .req = &request,
-                    .res = &response,
-                    .ctx = self.ctx,
-                    .action = if (found) |r| r.action else null,
-                    .middlewares = if (found) |r| r.middlewares else self.router.middlewares,
-                };
-                executor.run() catch |err| switch (err) {
-                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
-                    error.WriteFailed => return connection.getWriteError() orelse error.WriteFailed,
-                    else => |e| return e,
-                };
-
-                if (!parser.isBodyComplete()) {
-                    const max = self.config.request.max_body_size;
-                    const drainable = blk: {
-                        const cl = request.headers.get("Content-Length") orelse break :blk false;
-                        const n = std.fmt.parseInt(usize, cl, 10) catch break :blk false;
-                        break :blk n <= max;
-                    };
-                    if (drainable) {
-                        var scratch: [4096]u8 = undefined;
-                        var body_reader = RequestBodyReader.init(&parser, connection.reader, &scratch);
-                        if (body_reader.interface.discardShort(max + 1)) |consumed| {
-                            if (consumed > max) response.keepalive = false;
-                        } else |_| {
-                            if (connection.getReadError()) |e| if (e == error.Canceled) return error.Canceled;
-                            response.keepalive = false;
-                        }
-                    } else {
-                        response.keepalive = false;
-                    }
-                }
-
-                if (self.shutting_down.load(.acquire)) {
-                    response.keepalive = false;
-                }
-
-                try response.write();
-
-                if (!response.keepalive) {
-                    break;
-                }
-
-                parser.reset();
-                request.reset();
-
-                // If there's buffered data (pipelining), close connection - we don't support it
-                if (connection.reader.end > connection.reader.seek) {
-                    break;
-                }
-
-                _ = arena.reset(.retain_capacity);
-
-                // Allocate fresh buffer for keepalive wait (previous buffer was freed by arena reset)
-                connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
-                    log.err("Failed to allocate read buffer: {}", .{err});
-                    return err;
-                };
-                connection.reader.seek = 0;
-                connection.reader.end = 0;
-
-                if (self.config.timeout.keepalive) |duration| {
-                    // TODO(zio): drop with the one above, same reason.
-                    timeout.clear();
-                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
-                }
-
-                // Fill some data here, under the keepalive timeout
-                connection.reader.fillMore() catch |err| switch (err) {
-                    error.EndOfStream => {
-                        needs_shutdown.* = false;
-                        return;
-                    },
-                    error.ReadFailed => {
-                        const e = connection.getReadError() orelse error.ReadFailed;
-                        // Nothing is in flight between requests, so a peer
-                        // that went away here has cost us nothing. The socket
-                        // is already gone, so skip the shutdown syscall too.
-                        if (Connection.isPeerGone(e)) {
-                            needs_shutdown.* = false;
-                            return;
-                        }
-                        return e;
-                    },
-                };
-            }
+            return h1.Engine(Ctx).serve(self, &connection, &needs_shutdown);
         }
     };
 }
 
 test {
-    _ = RequestParser;
-}
-
-/// A Connection with no real transport, in TLS mode, so the error accessors
-/// can be driven directly. Only the `err` fields are read.
-fn testTlsConnection() Connection {
-    var conn: Connection = undefined;
-    conn.initWriterForTesting(undefined);
-    conn.tls_conn = .{ .input = undefined, .output = undefined, .cipher = undefined };
-    conn.tls_reader.err = null;
-    conn.tls_writer.err = null;
-    return conn;
-}
-
-test "Connection: error accessors descend past the TLS layer's generic error" {
-    if (!build_options.use_tls) return error.SkipZigTest;
-
-    { // a transport write failure: TLS records WriteFailed, TCP has the cause
-        var conn = testTlsConnection();
-        conn.tls_writer.err = error.TransportWriteFailed;
-        conn.tcp_writer.err = error.ConnectionResetByPeer;
-        try std.testing.expectEqual(error.ConnectionResetByPeer, conn.getWriteError().?);
-    }
-    { // same on the read side
-        var conn = testTlsConnection();
-        conn.tls_reader.err = error.TransportReadFailed;
-        conn.tcp_reader.err = error.Canceled;
-        try std.testing.expectEqual(error.Canceled, conn.getReadError().?);
-    }
-}
-
-test "Connection: a TLS-level failure is reported as itself" {
-    if (!build_options.use_tls) return error.SkipZigTest;
-
-    { // not a transport failure, so there is nothing below to descend to
-        var conn = testTlsConnection();
-        conn.tls_reader.err = error.TlsBadRecordMac;
-        conn.tcp_reader.err = error.ConnectionResetByPeer;
-        try std.testing.expectEqual(error.TlsBadRecordMac, conn.getReadError().?);
-    }
-    { // and with nothing recorded anywhere there is no error to report
-        var conn = testTlsConnection();
-        try std.testing.expectEqual(@as(?anyerror, null), conn.getWriteError());
-    }
-}
-
-test "Connection: isPeerGone separates a departed peer from a real failure" {
-    try std.testing.expect(Connection.isPeerGone(error.EndOfStream));
-    try std.testing.expect(Connection.isPeerGone(error.ConnectionResetByPeer));
-    // Closed between records: nothing was in flight, nothing was lost.
-    try std.testing.expect(Connection.isPeerGone(error.TlsUnexpectedEof));
-    // Closed mid-record: a record was cut, which is worth hearing about.
-    try std.testing.expect(!Connection.isPeerGone(error.TlsTruncated));
-    try std.testing.expect(!Connection.isPeerGone(error.TlsBadRecordMac));
-    try std.testing.expect(!Connection.isPeerGone(error.Canceled));
+    _ = @import("server/connection.zig");
+    _ = @import("server/h1.zig");
 }

--- a/src/server/connection.zig
+++ b/src/server/connection.zig
@@ -1,0 +1,205 @@
+const std = @import("std");
+const tls = @import("tls");
+const build_options = @import("build_options");
+
+/// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
+/// layer), plus the arena backing their buffers, for one accepted
+/// connection. Initialized in place: `tls_conn` stores pointers into
+/// `tcp_reader`/`tcp_writer`, and `tls_reader`/`tls_writer` store a pointer
+/// back into `tls_conn`, so a `Connection` must never be moved after
+/// `initPlain`/`initTls` runs.
+pub const Connection = struct {
+    io: std.Io,
+    stream: std.Io.net.Stream,
+    arena: std.heap.ArenaAllocator = undefined,
+
+    tcp_reader: std.Io.net.Stream.Reader = undefined,
+    tcp_writer: std.Io.net.Stream.Writer = undefined,
+    write_buffer: [4096]u8 = undefined,
+
+    // TLS layer: tcp_reader/tcp_writer above carry ciphertext; tls_conn wraps
+    // them, and tls_reader/tls_writer expose the cleartext Reader/Writer used
+    // for HTTP I/O.
+    tls_conn: ?tls.Connection = null,
+    tls_rng: std.Random.IoSource = undefined,
+    tls_cleartext_write_buffer: [4096]u8 = undefined,
+    tls_reader: tls.Connection.Reader = undefined,
+    tls_writer: tls.Connection.Writer = undefined,
+
+    // Active reader/writer, whichever path is in use.
+    reader: *std.Io.Reader = undefined,
+    writer: *std.Io.Writer = undefined,
+
+    pub fn initPlain(self: *Connection, allocator: std.mem.Allocator, io: std.Io, stream: std.Io.net.Stream) void {
+        self.* = .{ .io = io, .stream = stream };
+        self.arena = .init(allocator);
+        self.tcp_reader = stream.reader(io, &.{});
+        self.tcp_writer = stream.writer(io, &self.write_buffer);
+        self.reader = &self.tcp_reader.interface;
+        self.writer = &self.tcp_writer.interface;
+    }
+
+    pub fn initTls(
+        self: *Connection,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        stream: std.Io.net.Stream,
+        request_buffer_size: usize,
+        auth: *tls.config.CertKeyPair,
+    ) !void {
+        self.* = .{ .io = io, .stream = stream };
+        self.arena = .init(allocator);
+
+        // Aim for a single backing allocation per connection: prime the
+        // arena with room for the two TLS record buffers plus a working
+        // budget, then recycle it (reset keeps the memory). The TLS buffers
+        // and the per-request arena are then carved from that one
+        // allocation; only unusually large requests grow it.
+        const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + 1024);
+        _ = try self.arena.allocator().alloc(u8, conn_reserve);
+        _ = self.arena.reset(.retain_capacity);
+
+        // The TLS record buffers live for the whole connection (the
+        // tls.Connection points into them) and must survive the per-request
+        // arena resets, so they come from the connection arena.
+        const tcp_read_buffer = try self.arena.allocator().alloc(u8, tls.input_buffer_len);
+        const tcp_write_buffer = try self.arena.allocator().alloc(u8, tls.output_buffer_len);
+
+        self.tcp_reader = stream.reader(io, tcp_read_buffer);
+        self.tcp_writer = stream.writer(io, tcp_write_buffer);
+        self.tls_rng = .{ .io = io };
+        self.tls_conn = try tls.server(&self.tcp_reader.interface, &self.tcp_writer.interface, .{
+            .auth = auth,
+            .now = std.Io.Clock.real.now(io),
+            .rng = self.tls_rng.interface(),
+        });
+        self.tls_reader = self.tls_conn.?.reader(&.{});
+        self.tls_writer = self.tls_conn.?.writer(&self.tls_cleartext_write_buffer);
+        self.reader = &self.tls_reader.interface;
+        self.writer = &self.tls_writer.interface;
+    }
+
+    /// For tests: wraps a bare writer with no real TLS/TCP layer behind it.
+    /// `tcp_writer.err` is left settable so a test can simulate the real
+    /// error a write failure should surface.
+    pub fn initWriterForTesting(self: *Connection, w: *std.Io.Writer) void {
+        self.* = .{ .io = undefined, .stream = undefined, .reader = undefined, .writer = w };
+        self.tcp_reader.err = null;
+        self.tcp_writer.err = null;
+    }
+
+    pub fn deinit(self: *Connection) void {
+        self.arena.deinit();
+    }
+
+    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
+    // layer below it failed, because all it saw was the ciphertext
+    // reader/writer's generic error; the real cause is on the TCP layer.
+    // So those two mean "keep descending". A TLS-level failure (bad record
+    // mac, bad version, ...) is recorded as itself and stops the search.
+
+    fn checkReadError(self: *Connection) !void {
+        if (build_options.use_tls) {
+            if (self.tls_conn != null) {
+                if (self.tls_reader.err) |e| if (e != error.TransportReadFailed) return e;
+            }
+        }
+        if (self.tcp_reader.err) |e| return e;
+    }
+
+    /// The real error behind a generic `error.ReadFailed`, if any was recorded.
+    pub fn getReadError(self: *Connection) ?@typeInfo(@TypeOf(checkReadError(self))).error_union.error_set {
+        if (checkReadError(self)) |_| return null else |e| return e;
+    }
+
+    fn checkWriteError(self: *Connection) !void {
+        if (build_options.use_tls) {
+            if (self.tls_conn != null) {
+                if (self.tls_writer.err) |e| if (e != error.TransportWriteFailed) return e;
+            }
+        }
+        if (self.tcp_writer.err) |e| return e;
+    }
+
+    /// The error type `getWriteError` yields.
+    pub const WriteError = @typeInfo(@TypeOf(checkWriteError(undefined))).error_union.error_set;
+
+    /// The real error behind a generic `error.WriteFailed`, if any was
+    /// recorded.
+    pub fn getWriteError(self: *Connection) ?@typeInfo(@TypeOf(checkWriteError(self))).error_union.error_set {
+        if (checkWriteError(self)) |_| return null else |e| return e;
+    }
+
+    /// True when `err` means the peer is gone rather than something being
+    /// wrong. Teardown is the same either way; this only decides whether the
+    /// connection is worth a log line and whether shutdown() is worth a
+    /// syscall.
+    pub fn isPeerGone(err: anyerror) bool {
+        return switch (err) {
+            error.EndOfStream,
+            // Peer closed the transport between TLS records without
+            // close_notify. Rude, but routine from clients that just close
+            // the socket. `TlsTruncated`, where a record was cut in half, is
+            // deliberately not here.
+            error.TlsUnexpectedEof,
+            error.ConnectionResetByPeer,
+            error.BrokenPipe,
+            => true,
+            else => false,
+        };
+    }
+};
+
+/// A Connection with no real transport, in TLS mode, so the error accessors
+/// can be driven directly. Only the `err` fields are read.
+fn testTlsConnection() Connection {
+    var conn: Connection = undefined;
+    conn.initWriterForTesting(undefined);
+    conn.tls_conn = .{ .input = undefined, .output = undefined, .cipher = undefined };
+    conn.tls_reader.err = null;
+    conn.tls_writer.err = null;
+    return conn;
+}
+
+test "Connection: error accessors descend past the TLS layer's generic error" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+
+    { // a transport write failure: TLS records WriteFailed, TCP has the cause
+        var conn = testTlsConnection();
+        conn.tls_writer.err = error.TransportWriteFailed;
+        conn.tcp_writer.err = error.ConnectionResetByPeer;
+        try std.testing.expectEqual(error.ConnectionResetByPeer, conn.getWriteError().?);
+    }
+    { // same on the read side
+        var conn = testTlsConnection();
+        conn.tls_reader.err = error.TransportReadFailed;
+        conn.tcp_reader.err = error.Canceled;
+        try std.testing.expectEqual(error.Canceled, conn.getReadError().?);
+    }
+}
+
+test "Connection: a TLS-level failure is reported as itself" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+
+    { // not a transport failure, so there is nothing below to descend to
+        var conn = testTlsConnection();
+        conn.tls_reader.err = error.TlsBadRecordMac;
+        conn.tcp_reader.err = error.ConnectionResetByPeer;
+        try std.testing.expectEqual(error.TlsBadRecordMac, conn.getReadError().?);
+    }
+    { // and with nothing recorded anywhere there is no error to report
+        var conn = testTlsConnection();
+        try std.testing.expectEqual(@as(?anyerror, null), conn.getWriteError());
+    }
+}
+
+test "Connection: isPeerGone separates a departed peer from a real failure" {
+    try std.testing.expect(Connection.isPeerGone(error.EndOfStream));
+    try std.testing.expect(Connection.isPeerGone(error.ConnectionResetByPeer));
+    // Closed between records: nothing was in flight, nothing was lost.
+    try std.testing.expect(Connection.isPeerGone(error.TlsUnexpectedEof));
+    // Closed mid-record: a record was cut, which is worth hearing about.
+    try std.testing.expect(!Connection.isPeerGone(error.TlsTruncated));
+    try std.testing.expect(!Connection.isPeerGone(error.TlsBadRecordMac));
+    try std.testing.expect(!Connection.isPeerGone(error.Canceled));
+}

--- a/src/server/h1.zig
+++ b/src/server/h1.zig
@@ -1,0 +1,213 @@
+//! The HTTP/1.x engine: one task per connection runs the sequential
+//! request/keepalive loop over the connection's blocking reader/writer.
+
+const std = @import("std");
+const zio = @import("zio");
+
+const Connection = @import("connection.zig").Connection;
+const RequestParser = @import("../parser.zig").RequestParser;
+const RequestBodyReader = @import("../parser.zig").RequestBodyReader;
+const Request = @import("../request.zig").Request;
+const parseHeaders = @import("../request.zig").parseHeaders;
+const Response = @import("../response.zig").Response;
+const Executor = @import("../middleware.zig").Executor;
+
+const log = std.log.scoped(.dusty);
+
+pub fn Engine(comptime Ctx: type) type {
+    return struct {
+        const Server = @import("../server.zig").Server(Ctx);
+
+        /// Runs the request loop over an initialized connection.
+        pub fn serve(server: *Server, connection: *Connection, needs_shutdown: *bool) !void {
+            if (connection.tls_conn != null) {
+                // Per-request arena nested on the connection arena: resetting it
+                // between keepalive requests reuses the connection's memory
+                // without touching the TLS buffers carved above.
+                var request_arena = std.heap.ArenaAllocator.init(connection.arena.allocator());
+                return handleRequests(server, connection, &request_arena, needs_shutdown);
+            }
+            return handleRequests(server, connection, &connection.arena, needs_shutdown);
+        }
+
+        /// Runs the HTTP request/keepalive loop over a connection.
+        fn handleRequests(
+            server: *Server,
+            connection: *Connection,
+            arena: *std.heap.ArenaAllocator,
+            needs_shutdown: *bool,
+        ) !void {
+            var request: Request = .{
+                .arena = arena.allocator(),
+                .io = server.io,
+                .conn = connection.reader,
+                .parser = undefined,
+                .config = server.config.request,
+                .remote_address = connection.stream.socket.address,
+            };
+
+            var parser: RequestParser = undefined;
+            try parser.init(&request);
+            defer parser.deinit();
+
+            request.parser = &parser;
+
+            var request_count: usize = 0;
+
+            var timeout: zio.AutoCancel = .init;
+            defer timeout.clear();
+
+            // Allocate initial buffer from arena
+            connection.reader.buffer = request.arena.alloc(u8, server.config.request.buffer_size + 1024) catch |err| {
+                log.err("Failed to allocate read buffer: {}", .{err});
+                return err;
+            };
+
+            while (true) {
+                request_count += 1;
+
+                if (server.config.timeout.request) |duration| {
+                    // TODO(zio): drop once we require a zio with
+                    // lalinsky/zio#657. `set` is meant to handle a re-arm
+                    // itself, and stopped: it arms on the executor the task
+                    // is on now, so re-arming after a migration asks one
+                    // loop for a timer live in another's heap.
+                    timeout.clear();
+                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                }
+
+                parseHeaders(connection.reader, &parser) catch |err| switch (err) {
+                    error.EndOfStream => {
+                        needs_shutdown.* = false;
+                        return;
+                    },
+                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
+                    else => |e| return e,
+                };
+
+                log.debug("Received: {f} {s}", .{ request.method, request.url });
+
+                var response = try Response.init(arena.allocator(), connection, server.config.request.max_header_count);
+                response.head = request.method == .head;
+                request.response = &response;
+
+                // Handle Expect header (100-continue)
+                if (request.headers.get("Expect")) |expect| {
+                    if (std.ascii.eqlIgnoreCase(expect, "100-continue")) {
+                        request.expects_continue = true;
+                    } else {
+                        // Unknown Expect value - return 417
+                        response.status = .expectation_failed;
+                        response.keepalive = false;
+                        try response.write();
+                        return;
+                    }
+                }
+
+                // Check if the connection allows keepalive
+                if (!parser.shouldKeepAlive()) {
+                    response.keepalive = false;
+                }
+
+                // Check if we've reached the request count limit
+                if (server.config.timeout.request_count) |max_count| {
+                    if (request_count >= max_count) {
+                        response.keepalive = false;
+                    }
+                }
+
+                const found = try server.router.findHandler(&request);
+                var executor = Executor(Ctx){
+                    .req = &request,
+                    .res = &response,
+                    .ctx = server.ctx,
+                    .action = if (found) |r| r.action else null,
+                    .middlewares = if (found) |r| r.middlewares else server.router.middlewares,
+                };
+                executor.run() catch |err| switch (err) {
+                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
+                    error.WriteFailed => return connection.getWriteError() orelse error.WriteFailed,
+                    else => |e| return e,
+                };
+
+                if (!parser.isBodyComplete()) {
+                    const max = server.config.request.max_body_size;
+                    const drainable = blk: {
+                        const cl = request.headers.get("Content-Length") orelse break :blk false;
+                        const n = std.fmt.parseInt(usize, cl, 10) catch break :blk false;
+                        break :blk n <= max;
+                    };
+                    if (drainable) {
+                        var scratch: [4096]u8 = undefined;
+                        var body_reader = RequestBodyReader.init(&parser, connection.reader, &scratch);
+                        if (body_reader.interface.discardShort(max + 1)) |consumed| {
+                            if (consumed > max) response.keepalive = false;
+                        } else |_| {
+                            if (connection.getReadError()) |e| if (e == error.Canceled) return error.Canceled;
+                            response.keepalive = false;
+                        }
+                    } else {
+                        response.keepalive = false;
+                    }
+                }
+
+                if (server.shutting_down.load(.acquire)) {
+                    response.keepalive = false;
+                }
+
+                try response.write();
+
+                if (!response.keepalive) {
+                    break;
+                }
+
+                parser.reset();
+                request.reset();
+
+                // If there's buffered data (pipelining), close connection - we don't support it
+                if (connection.reader.end > connection.reader.seek) {
+                    break;
+                }
+
+                _ = arena.reset(.retain_capacity);
+
+                // Allocate fresh buffer for keepalive wait (previous buffer was freed by arena reset)
+                connection.reader.buffer = request.arena.alloc(u8, server.config.request.buffer_size + 1024) catch |err| {
+                    log.err("Failed to allocate read buffer: {}", .{err});
+                    return err;
+                };
+                connection.reader.seek = 0;
+                connection.reader.end = 0;
+
+                if (server.config.timeout.keepalive) |duration| {
+                    // TODO(zio): drop with the one above, same reason.
+                    timeout.clear();
+                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                }
+
+                // Fill some data here, under the keepalive timeout
+                connection.reader.fillMore() catch |err| switch (err) {
+                    error.EndOfStream => {
+                        needs_shutdown.* = false;
+                        return;
+                    },
+                    error.ReadFailed => {
+                        const e = connection.getReadError() orelse error.ReadFailed;
+                        // Nothing is in flight between requests, so a peer
+                        // that went away here has cost us nothing. The socket
+                        // is already gone, so skip the shutdown syscall too.
+                        if (Connection.isPeerGone(e)) {
+                            needs_shutdown.* = false;
+                            return;
+                        }
+                        return e;
+                    },
+                };
+            }
+        }
+    };
+}
+
+test {
+    _ = RequestParser;
+}


### PR DESCRIPTION
Behavior-preserving reorganization to prepare for an HTTP/2 engine and for parking idle keep-alive connections (#136).

- **src/server/connection.zig** — `Connection`, the shared transport (plain/TLS reader-writer pair, error descent, `isPeerGone`), moved verbatim with its tests. The h1 engine drives it pull-based (blocking reads/writes); a future h2 engine drives the same reader/writer buffers push-based from an event loop, the way #136's parking driver already feeds `tcp_reader.buffer` directly.
- **src/server/h1.zig** — the request/keepalive loop as `Engine(Ctx).serve`, including the arena-nesting decision that used to live in `handleConnection` (TLS → per-request arena nested on the connection arena, plain → connection arena), now keyed on `tls_conn` being set, which is equivalent since only `initTls` sets it.
- **src/server.zig** — keeps the protocol-neutral core: accept loop + backoff, TLS certificate loading and the per-connection handshake (connection setup is engine-independent, and the handshake is where ALPN will later branch), graceful shutdown drain, connection counting. All h1 imports (parser, request, response, executor) are gone from it.

The tail of `handleConnection` is now the engine seam: transport setup, then hand the connection to an engine. That is where ALPN dispatch (h1 vs h2) and the #136 parking engine will slot in without touching the h1 loop.

No public API change — `Connection` was never exported from root.zig; server.zig re-exports it for internal use and response.zig/middleware.zig import the new path directly.

Tested: `./check.sh` (265/265, TLS on by default) and `zig build test -Duse_tls=false` for the stub build.
