### PR TITLE
response: report the real error from BodyWriter.end and StreamingBodyWriter.end

### DIFF
--- a/src/response.zig
+++ b/src/response.zig
@@ -154,12 +154,14 @@ pub const BodyWriter = struct {
 
     /// Marks the body complete. It is sent with the rest of the response,
     /// once the headers have settled.
-    pub fn end(self: *BodyWriter) !void {
+    pub fn end(self: *BodyWriter) Error!void {
         // Idempotent, so `defer body.end() catch {}` alongside an explicit
         // `end` on the success path is harmless rather than a second body.
         if (!self.res.body_writer_open) return;
         self.res.body_writer_open = false;
-        try self.interface.flush();
+        self.interface.flush() catch |err| switch (err) {
+            error.WriteFailed => return self.err orelse error.OutOfMemory,
+        };
     }
 };
 
@@ -204,6 +206,14 @@ pub const StreamingBodyWriter = struct {
             else
                 e;
             return error.WriteFailed;
+        };
+    }
+
+    /// `record`, but returning the cause it stored rather than the sentinel.
+    /// Only `drain` has to return `error.WriteFailed`.
+    fn commit(self: *StreamingBodyWriter, result: HeaderError!void) Error!void {
+        self.record(result) catch |err| switch (err) {
+            error.WriteFailed => return self.err orelse err,
         };
     }
 
@@ -275,7 +285,7 @@ pub const StreamingBodyWriter = struct {
 
     /// Finishes the body: flushes what is left and, for a chunked body,
     /// writes the terminator. Must be called before the handler returns.
-    pub fn end(self: *StreamingBodyWriter) !void {
+    pub fn end(self: *StreamingBodyWriter) (Error || error{ContentLengthMismatch})!void {
         const res = self.res;
         // Idempotent: a second `end` must not write a second terminator,
         // which the peer would read as the start of the next message.
@@ -290,9 +300,9 @@ pub const StreamingBodyWriter = struct {
         // response.
         errdefer res.keepalive = false;
 
-        try self.record(self.interface.flush());
-        if (res.chunked and !res.head) try self.record(res.conn.writer.writeAll("0\r\n\r\n"));
-        try self.record(res.conn.writer.flush());
+        try self.commit(self.interface.flush());
+        if (res.chunked and !res.head) try self.commit(res.conn.writer.writeAll("0\r\n\r\n"));
+        try self.commit(res.conn.writer.flush());
         // Sending the wrong number of bytes for a declared length leaves
         // the connection out of sync and the client waiting.
         if (res.content_length) |declared| {
@@ -992,6 +1002,47 @@ test "StreamingBodyWriter: records the real error behind error.WriteFailed" {
     var body_buf: [64]u8 = undefined;
     try std.testing.expectError(error.WriteFailed, response.stream(&body_buf));
     try std.testing.expectEqual(error.ConnectionResetByPeer, connection.getWriteError().?);
+}
+
+test "StreamingBodyWriter: end reports the real error, not error.WriteFailed" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // What a successful stream puts on the wire before `end` appends the
+    // terminator. The failing pass below gets exactly that much room, so the
+    // terminator is the first write with nowhere to go.
+    const upto_end = blk: {
+        var buf: [1024]u8 = undefined;
+        var conn_writer: std.Io.Writer = .fixed(&buf);
+
+        var connection: Connection = undefined;
+        connection.initWriterForTesting(&conn_writer);
+
+        var response = try Response.init(arena.allocator(), &connection, 32);
+        var body_buf: [64]u8 = undefined;
+        var body = try response.stream(&body_buf);
+        try body.interface.writeAll("hello");
+        try body.interface.flush();
+        break :blk conn_writer.end;
+    };
+
+    var buf: [1024]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(buf[0..upto_end]);
+
+    var connection: Connection = undefined;
+    connection.initWriterForTesting(&conn_writer);
+    connection.tcp_writer.err = error.ConnectionResetByPeer;
+
+    var response = try Response.init(arena.allocator(), &connection, 32);
+    var body_buf: [64]u8 = undefined;
+    var body = try response.stream(&body_buf);
+    try body.interface.writeAll("hello");
+    try body.interface.flush();
+
+    try std.testing.expectError(error.ConnectionResetByPeer, body.end());
+    try std.testing.expectEqual(error.ConnectionResetByPeer, body.err.?);
+    // A body that could not be framed as promised cannot share the connection.
+    try std.testing.expectEqual(false, response.keepalive);
 }
 
 test "BodyWriter: end is idempotent" {


### PR DESCRIPTION
Both `end` methods return `error.WriteFailed` and leave the actual cause in `err`, so a caller that wants to know what happened has to write:

```zig
body.end() catch |err| switch (err) {
    error.WriteFailed => return body.err orelse ...,
    else => |e| return e,
};
```

In practice callers write `try body.end()` and the cause is lost. That hurts most on the streaming path: `end` writes the chunked terminator, which is the write most likely to meet a peer that has already gone away, so `ECONNRESET`/`EPIPE` is exactly the errno being discarded.

`drain` has no choice — it implements the `std.Io.Writer` vtable, whose error set is fixed at `error{WriteFailed}`. But `end` is our own method with its own error set, and it already holds `err`, so it can return the cause directly.

## Changes

- `BodyWriter.end` is now `Error!void` (`Allocator.Error`), unwrapping the sentinel to the `OutOfMemory` its `fail` already recorded.
- `StreamingBodyWriter.end` is now `(Error || error{ContentLengthMismatch})!void`.
- `StreamingBodyWriter` keeps `record` for the vtable path and gains `commit` for everything else — same bookkeeping, reports the stored cause instead of the sentinel.

Both signatures previously inferred `!void`, which resolved to exactly `error{WriteFailed}` — the type said less than the code knew.

## Compatibility

Narrowing only. `try body.end()` keeps working and now propagates something useful; an existing `catch |err| switch (err) { error.WriteFailed => ... }` still compiles, since `WriteFailed` remains in `Error` as the `orelse` fallback.

No behavioural change beyond the error value: `end` stays idempotent, writes one terminator, and still clears `keepalive` when the body could not be framed as its headers promised.

## Testing

New test `StreamingBodyWriter: end reports the real error, not error.WriteFailed` sizes the connection buffer so the terminator is the first write with nowhere to go, then asserts `end()` returns `error.ConnectionResetByPeer` and that `keepalive` is cleared. Verified it fails against the old `record`-based `end`.

`zig build test`: 265/265 pass.