### PR TITLE
Add mutual TLS support to the client and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ All notable changes to this project will be documented in this file.
 - Added default `User-Agent` header to HTTP client.
 - Fix connection pool corruption when a `Client` is shared by tasks running in parallel. `ConnectionPool` list and counter updates are now guarded by a mutex.
 - `ConnectionPool.init` now takes an `std.Io`, and `ConnectionPool.acquire` no longer does.
+- HTTP client TLS settings are now grouped under `ClientConfig.tls`. **Breaking:** this replaces
+  `ClientConfig.use_system_ca_bundle`; the equivalent of the old default is `.tls = .{ .ca = .system }`.
+- Added mutual TLS (mTLS) to the HTTP client: set `ClientConfig.tls.client_certificate` to present a
+  certificate and key when the server requests client authentication.
+- The HTTP client can now verify servers against a custom CA (`tls.ca = .{ .file = ... }` or
+  `.{ .dir = ... }`), trust nothing (`.none`), or skip verification entirely (`tls.insecure_skip_verify`).
+- Added mutual TLS to the server: `ServerConfig.tls.client_auth` requests (or requires) a client
+  certificate and verifies it against the configured CAs.
+- `TlsCa`/`TlsPath` describe where certificate authorities are loaded from (`.system`, `.file`,
+  `.dir`, `.none`) and are shared by `ClientConfig.tls.ca` and `ServerConfig.tls.client_auth.ca`.
+- Fix memory leak when a client connection fails to initialize (e.g. a rejected TLS handshake): the
+  connection arena was not released.
 
 ## [0.2.0] - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ pub fn main(init: std.process.Init) !void {
 }
 ```
 
+### HTTPS and Client Certificates
+
+By default the client verifies servers against the system trust store. `ClientConfig.tls`
+overrides that, and adds a client certificate for servers that require mutual TLS:
+
+```zig
+var client = http.Client.init(init.gpa, init.io, .{
+    .tls = .{
+        // .system (default), .{ .file = ... }, .{ .dir = ... }, or .none
+        .ca = .{ .file = .{ .path = "ca.pem" } },
+        // Presented when the server asks the client to authenticate itself.
+        .client_certificate = .{ .cert_path = "client.pem", .key_path = "client.key" },
+    },
+});
+```
+
+The key must be an unencrypted PKCS#8 (`BEGIN PRIVATE KEY`) or SEC1 (`BEGIN EC PRIVATE KEY`) PEM file.
+
+These settings apply to every connection a client makes; connections are pooled and reused
+across requests, so they cannot be varied per request. Use a separate `Client` per identity.
+
+The server side is symmetric — `client_auth` makes it ask connecting clients for a certificate:
+
+```zig
+var server = http.Server(void).init(gpa, io, .{
+    .tls = .{
+        .cert_path = "server.pem",
+        .key_path = "server.key",
+        .client_auth = .{
+            .ca = .{ .file = .{ .path = "client-ca.pem" } },
+            // .require (default) rejects a client that sends no certificate;
+            // .request asks for one but accepts an empty reply.
+            .mode = .require,
+        },
+    },
+}, {});
+```
+
 ### Unix Socket Client Example
 
 For communicating with services like Docker Engine:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .tls = .{
-            .url = "git+https://github.com/lalinsky/tls.zig#bd94b5f7ac10d3b1e38ff2e5ea031e0f9d0e8eec",
-            .hash = "tls-0.1.0-ER2e0m1EBgCVgWGBNlO_sDIKKXFj8eY4MTA1SZNmCgEA",
+            .url = "git+https://github.com/lalinsky/tls.zig#e400919acc40db2635c025c07260e0e0b069e11d",
+            .hash = "tls-0.1.0-ER2e0oZ3BgBU80H1rtVl65VfzQglbK5sI2puxIlyeh24",
             .lazy = true,
         },
     },

--- a/src/client.zig
+++ b/src/client.zig
@@ -5,6 +5,8 @@ const build_options = @import("build_options");
 
 const unix_path_max = 108;
 
+const config_mod = @import("config.zig");
+
 const http = @import("http.zig");
 const Method = http.Method;
 const Status = http.Status;
@@ -78,8 +80,12 @@ pub const ClientConfig = struct {
     max_idle_connections: u8 = 8,
     /// Buffer size (bytes) for reading response headers.
     buffer_size: usize = 4096,
-    /// Use system CA bundle for HTTPS connections.
-    use_system_ca_bundle: bool = true,
+    /// TLS settings for https:// (and wss://) connections. Requires the
+    /// `use_tls` build option; with TLS compiled out any HTTPS request fails
+    /// with error.TlsNotConfigured. Applies to every connection the client
+    /// makes: connections are pooled and reused across requests, so the trust
+    /// settings and client identity cannot be varied per request.
+    tls: TlsConfig = .{},
     /// Maximum number of headers allowed in a response.
     max_response_header_count: usize = 64,
     /// User-Agent header sent with requests. Set to null to omit it.
@@ -89,6 +95,37 @@ pub const ClientConfig = struct {
     /// when the library is built with the `use_http2` build option; ignored for
     /// cleartext (http://) connections. Defaults off.
     http2: bool = false,
+};
+
+/// TLS settings for the HTTP client.
+pub const TlsConfig = struct {
+    /// Certificate authorities used to verify the server's certificate chain.
+    ca: Ca = .system,
+    /// Certificate and key to present when the server asks the client to
+    /// authenticate itself (mutual TLS). When null, a server that requires a
+    /// client certificate rejects the handshake.
+    client_certificate: ?ClientCertificate = null,
+    /// Accept any server certificate and skip host name checking. This makes
+    /// the connection trivially interceptable; for testing only.
+    insecure_skip_verify: bool = false,
+
+    /// Where the client gets the certificate authorities it trusts. `.none` is
+    /// only valid together with `insecure_skip_verify`.
+    pub const Ca = config_mod.TlsCa;
+
+    pub const ClientCertificate = struct {
+        /// PEM certificate chain, leaf first, resolved against `dir`.
+        cert_path: []const u8,
+        /// PEM private key for the leaf certificate, resolved against `dir`.
+        /// Must be PKCS#8 ("BEGIN PRIVATE KEY") or SEC1 ("BEGIN EC PRIVATE
+        /// KEY"); passphrase-protected keys are not supported.
+        key_path: []const u8,
+        /// Directory the paths are resolved against. Defaults to the current
+        /// working directory.
+        dir: ?std.Io.Dir = null,
+    };
+
+    pub const Path = config_mod.TlsPath;
 };
 
 /// Options for a single fetch request.
@@ -144,8 +181,14 @@ pub const WebSocketClient = struct {
     }
 };
 
-const CaBundleRef = struct {
-    bundle: *std.crypto.Certificate.Bundle,
+/// Borrowed view of the client-wide TLS material, handed to each HTTPS
+/// connection. The pointers reference storage owned by the `Client`, which
+/// outlives every connection it hands them to.
+const TlsRef = struct {
+    ca_bundle: *std.crypto.Certificate.Bundle,
+    /// Client certificate for mutual TLS, null when none is configured.
+    client_cert: ?*tls.config.CertKeyPair,
+    insecure_skip_verify: bool,
 };
 
 /// Parse a URL string into a std.Uri.
@@ -363,7 +406,7 @@ pub const Connection = struct {
         buffer_size: usize,
         max_response_headers: usize,
         protocol: Protocol,
-        ca_bundle: ?CaBundleRef,
+        tls_config: ?TlsRef,
         unix_socket_path: ?[]const u8,
         advertise_http2: bool,
     ) !void {
@@ -371,6 +414,7 @@ pub const Connection = struct {
         self.io = io;
         self.stream = stream;
         self.arena = std.heap.ArenaAllocator.init(allocator);
+        errdefer self.arena.deinit();
         self.pool = pool;
         self.closing = false;
         self.buffer_size = buffer_size;
@@ -406,7 +450,7 @@ pub const Connection = struct {
 
         if (protocol == .https) {
             if (!build_options.use_tls) return error.TlsNotConfigured;
-            const ca = ca_bundle orelse return error.MissingCaBundle;
+            const tls_cfg = tls_config orelse return error.MissingTlsConfig;
 
             // TCP-layer (ciphertext) buffers. tls.zig requires the input buffer to
             // fit a full TLS record; the output buffer caps the produced record size.
@@ -438,7 +482,9 @@ pub const Connection = struct {
                 &self.tcp_writer.interface,
                 .{
                     .host = remote_host,
-                    .root_ca = ca.bundle.*,
+                    .root_ca = tls_cfg.ca_bundle.*,
+                    .insecure_skip_verify = tls_cfg.insecure_skip_verify,
+                    .auth = tls_cfg.client_cert,
                     .now = std.Io.Clock.real.now(self.io),
                     .rng = self.tls_rng.interface(),
                     .alpn_protocols = alpn_protocols,
@@ -690,9 +736,17 @@ pub const Client = struct {
     io: std.Io,
     config: ClientConfig,
     pool: ConnectionPool,
-    ca_bundle: std.crypto.Certificate.Bundle,
-    ca_bundle_lock: std.Io.RwLock,
-    ca_bundle_loaded: std.atomic.Value(bool),
+    tls_state: TlsState,
+    tls_lock: std.Io.RwLock,
+    tls_loaded: std.atomic.Value(bool),
+
+    /// TLS material shared by every HTTPS connection. Reading the trust store
+    /// and deriving the client key are expensive, so both are loaded once on
+    /// the first HTTPS request and reused afterwards.
+    const TlsState = struct {
+        ca_bundle: std.crypto.Certificate.Bundle = .empty,
+        client_cert: ?tls.config.CertKeyPair = null,
+    };
 
     pub fn init(allocator: std.mem.Allocator, io: std.Io, config: ClientConfig) Client {
         return .{
@@ -700,30 +754,57 @@ pub const Client = struct {
             .io = io,
             .config = config,
             .pool = ConnectionPool.init(allocator, io, config.max_idle_connections),
-            .ca_bundle = .empty,
-            .ca_bundle_lock = .init,
-            .ca_bundle_loaded = std.atomic.Value(bool).init(false),
+            .tls_state = .{},
+            .tls_lock = .init,
+            .tls_loaded = std.atomic.Value(bool).init(false),
         };
     }
 
-    fn ensureCaBundle(self: *Client) !CaBundleRef {
-        if (!self.ca_bundle_loaded.load(.acquire)) {
-            try self.ca_bundle_lock.lock(self.io);
-            defer self.ca_bundle_lock.unlock(self.io);
-            if (!self.ca_bundle_loaded.load(.unordered)) {
-                const now = std.Io.Clock.real.now(self.io);
-                try self.ca_bundle.rescan(self.allocator, self.io, now);
-                self.ca_bundle_loaded.store(true, .release);
+    fn ensureTlsState(self: *Client) !TlsRef {
+        if (!self.tls_loaded.load(.acquire)) {
+            try self.tls_lock.lock(self.io);
+            defer self.tls_lock.unlock(self.io);
+            if (!self.tls_loaded.load(.unordered)) {
+                try self.loadTlsState();
+                self.tls_loaded.store(true, .release);
             }
         }
         return .{
-            .bundle = &self.ca_bundle,
+            .ca_bundle = &self.tls_state.ca_bundle,
+            .client_cert = if (self.tls_state.client_cert) |*pair| pair else null,
+            .insecure_skip_verify = self.config.tls.insecure_skip_verify,
         };
+    }
+
+    /// Builds the CA bundle and client certificate into locals and only commits
+    /// them once both succeed, so a failure leaves `tls_state` empty and a later
+    /// retry starts from a clean bundle instead of appending to a half-built one.
+    fn loadTlsState(self: *Client) !void {
+        const cfg = self.config.tls;
+        if (cfg.ca == .none and !cfg.insecure_skip_verify) return error.NoCertificateAuthority;
+
+        var ca_bundle = try cfg.ca.load(self.allocator, self.io);
+        errdefer ca_bundle.deinit(self.allocator);
+
+        var client_cert: ?tls.config.CertKeyPair = null;
+        errdefer if (client_cert) |*pair| pair.deinit(self.allocator);
+        if (cfg.client_certificate) |cc| {
+            client_cert = try tls.config.CertKeyPair.fromFilePath(
+                self.allocator,
+                self.io,
+                cc.dir orelse std.Io.Dir.cwd(),
+                cc.cert_path,
+                cc.key_path,
+            );
+        }
+
+        self.tls_state = .{ .ca_bundle = ca_bundle, .client_cert = client_cert };
     }
 
     pub fn deinit(self: *Client) void {
         self.pool.deinit();
-        self.ca_bundle.deinit(self.allocator);
+        self.tls_state.ca_bundle.deinit(self.allocator);
+        if (self.tls_state.client_cert) |*pair| pair.deinit(self.allocator);
     }
 
     /// Perform an HTTP request.
@@ -750,7 +831,7 @@ pub const Client = struct {
         host: []const u8,
         port: u16,
         protocol: Protocol,
-        ca_bundle: ?CaBundleRef,
+        tls_config: ?TlsRef,
         unix_socket_path: ?[]const u8,
         // Whether to offer HTTP/2 via TLS ALPN. Callers that can't speak h2
         // (e.g. the WebSocket upgrade path) must pass false.
@@ -779,7 +860,7 @@ pub const Client = struct {
                 self.config.buffer_size,
                 self.config.max_response_header_count,
                 protocol,
-                ca_bundle,
+                tls_config,
                 unix_socket_path,
                 advertise_http2,
             );
@@ -800,13 +881,10 @@ pub const Client = struct {
         var host_buffer: [255]u8 = undefined;
         const host = try uriHost(uri, &host_buffer);
 
-        // Initialize CA bundle for HTTPS
-        const ca_bundle: ?CaBundleRef = if (info.protocol == .https) blk: {
+        // Load the shared TLS material for HTTPS
+        const tls_config: ?TlsRef = if (info.protocol == .https) blk: {
             if (!build_options.use_tls) return error.TlsNotConfigured;
-            if (!self.config.use_system_ca_bundle) {
-                return error.TlsNotConfigured;
-            }
-            break :blk try self.ensureCaBundle();
+            break :blk try self.ensureTlsState();
         } else null;
 
         // Reject any CRLF/NUL smuggled in via the URL host.
@@ -814,7 +892,7 @@ pub const Client = struct {
 
         // Acquire or create a connection. WebSocket upgrades are HTTP/1.1 only,
         // so never advertise h2 here.
-        const conn = try self.acquireConnection(host, info.port, info.protocol, ca_bundle, options.unix_socket_path, false);
+        const conn = try self.acquireConnection(host, info.port, info.protocol, tls_config, options.unix_socket_path, false);
         errdefer {
             conn.deinit();
             self.allocator.destroy(conn);
@@ -894,19 +972,16 @@ pub const Client = struct {
         var host_buffer: [255]u8 = undefined;
         const host = try uriHost(state.uri, &host_buffer);
 
-        // Initialize CA bundle for HTTPS
-        const ca_bundle: ?CaBundleRef = if (state.protocol == .https) blk: {
+        // Load the shared TLS material for HTTPS
+        const tls_config: ?TlsRef = if (state.protocol == .https) blk: {
             if (!build_options.use_tls) return error.TlsNotConfigured;
-            if (!self.config.use_system_ca_bundle) {
-                return error.TlsNotConfigured;
-            }
-            break :blk try self.ensureCaBundle();
+            break :blk try self.ensureTlsState();
         } else null;
 
         // Acquire or create a connection. The redirect path releases it early
         // and continues with fallible work, so the errdefer must be disarmed
         // after that release to avoid releasing the connection twice.
-        const conn = try self.acquireConnection(host, state.port, state.protocol, ca_bundle, state.options.unix_socket_path, build_options.use_http2 and self.config.http2 and state.protocol == .https);
+        const conn = try self.acquireConnection(host, state.port, state.protocol, tls_config, state.options.unix_socket_path, build_options.use_http2 and self.config.http2 and state.protocol == .https);
         var conn_released = false;
         errdefer if (!conn_released) self.pool.release(conn);
 

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -578,3 +578,271 @@ test "Client: unix socket fetch" {
 
     try client_future.await(io);
 }
+
+const build_options = @import("build_options");
+
+// Self-signed test certificate from examples/certs. It is CA:TRUE with SANs
+// for localhost and 127.0.0.1, so the same file serves as the server
+// certificate and as the CA that validates it.
+const test_cert_path = "examples/certs/cert.pem";
+const test_key_path = "examples/certs/key.pem";
+
+test "Client: HTTPS with a custom CA file" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{ .cert_path = test_cert_path, .key_path = test_key_path },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/secure", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "over tls";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            var client = dusty.Client.init(std.testing.allocator, _io, .{
+                .tls = .{ .ca = .{ .file = .{ .path = test_cert_path } } },
+            });
+            defer client.deinit();
+
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{d}/secure", .{s.address.ip.getPort()});
+
+            var response = try client.fetch(url, .{});
+            defer response.deinit();
+
+            try std.testing.expectEqual(.ok, response.status());
+            try std.testing.expectEqualStrings("over tls", (try response.body()).?);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Client: presents a client certificate for mutual TLS" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    // The test certificate is CA:TRUE and self-signed, so the same file serves
+    // as the server certificate, the client certificate, and the CA that
+    // validates both.
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{
+            .cert_path = test_cert_path,
+            .key_path = test_key_path,
+            .client_auth = .{ .ca = .{ .file = .{ .path = test_cert_path } } },
+        },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "authed";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{d}/", .{s.address.ip.getPort()});
+
+            var client = dusty.Client.init(std.testing.allocator, _io, .{
+                .tls = .{
+                    .ca = .{ .file = .{ .path = test_cert_path } },
+                    .client_certificate = .{ .cert_path = test_cert_path, .key_path = test_key_path },
+                },
+            });
+            defer client.deinit();
+
+            var response = try client.fetch(url, .{});
+            defer response.deinit();
+
+            try std.testing.expectEqual(.ok, response.status());
+            try std.testing.expectEqualStrings("authed", (try response.body()).?);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Server: client_auth .require rejects a client with no certificate" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{
+            .cert_path = test_cert_path,
+            .key_path = test_key_path,
+            .client_auth = .{ .ca = .{ .file = .{ .path = test_cert_path } }, .mode = .require },
+        },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "unreachable";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{d}/", .{s.address.ip.getPort()});
+
+            var client = dusty.Client.init(std.testing.allocator, _io, .{
+                .tls = .{ .ca = .{ .file = .{ .path = test_cert_path } } },
+            });
+            defer client.deinit();
+
+            // In TLS 1.3 the client finishes its flight before the server can
+            // reject the missing certificate, so the refusal surfaces on the
+            // first read rather than as a handshake error.
+            try std.testing.expectError(error.ReadFailed, client.fetch(url, .{}));
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Server: client_auth .request accepts a client with no certificate" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{
+            .cert_path = test_cert_path,
+            .key_path = test_key_path,
+            .client_auth = .{ .ca = .{ .file = .{ .path = test_cert_path } }, .mode = .request },
+        },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "anonymous";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{d}/", .{s.address.ip.getPort()});
+
+            var client = dusty.Client.init(std.testing.allocator, _io, .{
+                .tls = .{ .ca = .{ .file = .{ .path = test_cert_path } } },
+            });
+            defer client.deinit();
+
+            var response = try client.fetch(url, .{});
+            defer response.deinit();
+
+            try std.testing.expectEqual(.ok, response.status());
+            try std.testing.expectEqualStrings("anonymous", (try response.body()).?);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Client: rejects a server certificate the configured CA does not cover" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{ .cert_path = test_cert_path, .key_path = test_key_path },
+    }, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "ok";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+            const port = s.address.ip.getPort();
+            var url_buf: [64]u8 = undefined;
+            const url = try std.fmt.bufPrint(&url_buf, "https://localhost:{d}/", .{port});
+
+            // The system trust store does not contain the self-signed test cert.
+            var strict = dusty.Client.init(std.testing.allocator, _io, .{});
+            defer strict.deinit();
+            try std.testing.expectError(error.TlsInitializationFailed, strict.fetch(url, .{}));
+
+            // insecure_skip_verify takes it anyway.
+            var lax = dusty.Client.init(std.testing.allocator, _io, .{
+                .tls = .{ .ca = .none, .insecure_skip_verify = true },
+            });
+            defer lax.deinit();
+            var response = try lax.fetch(url, .{});
+            defer response.deinit();
+            try std.testing.expectEqual(.ok, response.status());
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Client: ca .none without insecure_skip_verify is rejected" {
+    if (!build_options.use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{
+        .tls = .{ .ca = .none },
+    });
+    defer client.deinit();
+
+    // Fails while loading the TLS material, before any connection is attempted.
+    try std.testing.expectError(error.NoCertificateAuthority, client.fetch("https://localhost:1/", .{}));
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,5 +1,52 @@
 const std = @import("std");
 
+/// Where a TLS peer's certificate authorities are loaded from. Shared by the
+/// client (verifying server certificates) and the server (verifying client
+/// certificates under mutual TLS).
+pub const TlsCa = union(enum) {
+    /// The platform trust store.
+    system,
+    /// A single PEM file holding one or more certificates.
+    file: TlsPath,
+    /// A directory of PEM files, each holding one or more certificates.
+    dir: TlsPath,
+    /// Trust nothing. Rejected unless the side using it says otherwise.
+    none,
+
+    /// Reads the certificates into a fresh bundle owned by the caller.
+    pub fn load(self: TlsCa, allocator: std.mem.Allocator, io: std.Io) !std.crypto.Certificate.Bundle {
+        const now = std.Io.Clock.real.now(io);
+
+        var bundle: std.crypto.Certificate.Bundle = .empty;
+        errdefer bundle.deinit(allocator);
+        switch (self) {
+            .system => try bundle.rescan(allocator, io, now),
+            .file => |src| try bundle.addCertsFromFilePath(
+                allocator,
+                io,
+                now,
+                src.dir orelse std.Io.Dir.cwd(),
+                src.path,
+            ),
+            .dir => |src| try bundle.addCertsFromDirPath(
+                allocator,
+                io,
+                src.dir orelse std.Io.Dir.cwd(),
+                src.path,
+            ),
+            .none => {},
+        }
+        return bundle;
+    }
+};
+
+pub const TlsPath = struct {
+    path: []const u8,
+    /// Directory `path` is resolved against. Defaults to the current working
+    /// directory.
+    dir: ?std.Io.Dir = null,
+};
+
 pub const ServerConfig = struct {
     timeout: Timeout = .{},
     request: Request = .{},
@@ -17,6 +64,20 @@ pub const ServerConfig = struct {
         /// Directory the cert/key paths are resolved against. Defaults to the
         /// current working directory.
         dir: ?std.Io.Dir = null,
+        /// Ask connecting clients to authenticate with a certificate (mutual
+        /// TLS). Null means client certificates are never requested.
+        client_auth: ?ClientAuth = null,
+
+        pub const ClientAuth = struct {
+            /// Certificate authorities used to verify client certificates.
+            /// `.none` is rejected by listen().
+            ca: TlsCa,
+            /// `.require` rejects a client that sends no certificate;
+            /// `.request` asks for one but accepts an empty reply.
+            mode: Mode = .require,
+
+            pub const Mode = enum { request, require };
+        };
     };
 
     pub const Timeout = struct {

--- a/src/root.zig
+++ b/src/root.zig
@@ -3,6 +3,8 @@ const std = @import("std");
 pub const Server = @import("server.zig").Server;
 pub const Address = @import("server.zig").Address;
 pub const ServerConfig = @import("config.zig").ServerConfig;
+pub const TlsCa = @import("config.zig").TlsCa;
+pub const TlsPath = @import("config.zig").TlsPath;
 pub const Router = @import("router.zig").Router;
 pub const Action = @import("router.zig").Action;
 pub const Request = @import("request.zig").Request;
@@ -28,6 +30,7 @@ pub const Executor = @import("middleware.zig").Executor;
 // Client
 pub const Client = @import("client.zig").Client;
 pub const ClientConfig = @import("client.zig").ClientConfig;
+pub const TlsConfig = @import("client.zig").TlsConfig;
 pub const ClientResponse = @import("client.zig").ClientResponse;
 pub const FetchOptions = @import("client.zig").FetchOptions;
 pub const WebSocketClient = @import("client.zig").WebSocketClient;

--- a/src/server.zig
+++ b/src/server.zig
@@ -24,6 +24,13 @@ const log = std.log.scoped(.dusty);
 const min_accept_backoff_ms = 5;
 const max_accept_backoff_ms = 1000;
 
+/// Borrowed view of the client-certificate settings, handed to each accepted
+/// connection. The bundle is owned by the Server and outlives every connection.
+const ClientAuthRef = struct {
+    bundle: *std.crypto.Certificate.Bundle,
+    mode: ServerConfig.Tls.ClientAuth.Mode,
+};
+
 /// Owns the reader/writer (and, for TLS, the whole TLS + underlying TCP
 /// layer), plus the arena backing their buffers, for one accepted
 /// connection. Initialized in place: `tls_conn` stores pointers into
@@ -68,6 +75,7 @@ pub const Connection = struct {
         stream: std.Io.net.Stream,
         request_buffer_size: usize,
         auth: *tls.config.CertKeyPair,
+        client_auth: ?ClientAuthRef,
     ) !void {
         self.* = .{ .io = io, .stream = stream };
         self.arena = .init(allocator);
@@ -92,6 +100,15 @@ pub const Connection = struct {
         self.tls_rng = .{ .io = io };
         self.tls_conn = try tls.server(&self.tcp_reader.interface, &self.tcp_writer.interface, .{
             .auth = auth,
+            // Built here rather than passed in as a tls.config.ClientAuth, so
+            // tls_stub.zig does not have to mirror the type.
+            .client_auth = if (client_auth) |ca| .{
+                .root_ca = ca.bundle.*,
+                .auth_type = switch (ca.mode) {
+                    .request => .request,
+                    .require => .require,
+                },
+            } else null,
             .now = std.Io.Clock.real.now(io),
             .rng = self.tls_rng.interface(),
         });
@@ -205,6 +222,9 @@ pub fn Server(comptime Ctx: type) type {
         _middleware_registry: std.SinglyLinkedList,
         /// Server certificate/key, loaded once in listen() when config.tls is set.
         tls_auth: ?tls.config.CertKeyPair = null,
+        /// CAs for verifying client certificates, loaded alongside tls_auth
+        /// when config.tls.client_auth is set.
+        tls_client_ca: ?std.crypto.Certificate.Bundle = null,
 
         pub fn init(allocator: std.mem.Allocator, io: std.Io, config: ServerConfig, ctx: if (Ctx == void) void else *Ctx) Self {
             return .{
@@ -261,6 +281,15 @@ pub fn Server(comptime Ctx: type) type {
             // Load the server certificate/key once, shared across all connections.
             if (build_options.use_tls) {
                 if (self.config.tls) |tls_cfg| {
+                    // Checked before anything is loaded, so the early return
+                    // has nothing to clean up.
+                    if (tls_cfg.client_auth) |client_auth| {
+                        if (client_auth.ca == .none) {
+                            log.err("config.tls.client_auth.ca is .none, so no client certificate could ever verify", .{});
+                            return error.NoCertificateAuthority;
+                        }
+                    }
+
                     const dir = tls_cfg.dir orelse std.Io.Dir.cwd();
                     self.tls_auth = tls.config.CertKeyPair.fromFilePath(
                         self.allocator,
@@ -272,6 +301,17 @@ pub fn Server(comptime Ctx: type) type {
                         log.err("Failed to load TLS certificate/key: {}", .{err});
                         return err;
                     };
+                    errdefer {
+                        self.tls_auth.?.deinit(self.allocator);
+                        self.tls_auth = null;
+                    }
+
+                    if (tls_cfg.client_auth) |client_auth| {
+                        self.tls_client_ca = client_auth.ca.load(self.allocator, self.io) catch |err| {
+                            log.err("Failed to load client certificate authorities: {}", .{err});
+                            return err;
+                        };
+                    }
                 }
             } else if (self.config.tls != null) {
                 log.err("config.tls is set but the library was built with use_tls=false", .{});
@@ -281,6 +321,10 @@ pub fn Server(comptime Ctx: type) type {
                 if (self.tls_auth) |*auth| {
                     auth.deinit(self.allocator);
                     self.tls_auth = null;
+                }
+                if (self.tls_client_ca) |*bundle| {
+                    bundle.deinit(self.allocator);
+                    self.tls_client_ca = null;
                 }
             };
 
@@ -461,7 +505,12 @@ pub fn Server(comptime Ctx: type) type {
                             handshake.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
                         }
 
-                        connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth) catch |err| {
+                        const client_auth: ?ClientAuthRef = if (self.tls_client_ca) |*bundle| .{
+                            .bundle = bundle,
+                            .mode = self.config.tls.?.client_auth.?.mode,
+                        } else null;
+
+                        connection.initTls(self.allocator, self.io, stream, self.config.request.buffer_size, auth, client_auth) catch |err| {
                             // tls.zig only saw the ciphertext reader or
                             // writer fail generically, so the cause is a
                             // layer down -- and when the handshake ran out

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1120,3 +1120,20 @@ test "Server: request carries the peer address" {
     // The same connection, so the same peer both times.
     try std.testing.expect(ctx.seen[0].?.ip4.eql(ctx.seen[1].?.ip4));
 }
+
+test "Server: client_auth with ca .none is rejected by listen" {
+    if (!@import("build_options").use_tls) return error.SkipZigTest;
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{
+        .tls = .{
+            .cert_path = "examples/certs/cert.pem",
+            .key_path = "examples/certs/key.pem",
+            .client_auth = .{ .ca = .none },
+        },
+    }, {});
+    defer server.deinit();
+
+    const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+    try std.testing.expectError(error.NoCertificateAuthority, server.listen(addr));
+}


### PR DESCRIPTION
The client can now present a certificate when a server asks it to authenticate, and the server can request or require one from connecting clients.

## Client

TLS settings move under `ClientConfig.tls`:

```zig
var client = http.Client.init(gpa, io, .{
    .tls = .{
        .ca = .{ .file = .{ .path = "ca.pem" } },
        .client_certificate = .{ .cert_path = "client.pem", .key_path = "client.key" },
    },
});
```

**Breaking:** this replaces `ClientConfig.use_system_ca_bundle`. The old default is now `.tls = .{ .ca = .system }`. Setting the old flag to `false` did not select custom CAs — it made HTTPS fail outright — so nothing that worked before loses a capability.

Besides the client certificate this adds a choice of certificate authorities and `insecure_skip_verify`. Those arrive together on purpose: mTLS deployments usually run against a private CA, so a client certificate without a way to name a custom CA would be half a feature.

## Server

```zig
var server = http.Server(void).init(gpa, io, .{
    .tls = .{
        .cert_path = "server.pem",
        .key_path = "server.key",
        .client_auth = .{
            .ca = .{ .file = .{ .path = "client-ca.pem" } },
            .mode = .require,  // or .request
        },
    },
}, {});
```

The CA bundle loads once in `listen()` beside the existing server cert and frees in the same `defer`. `initTls` takes a small `ClientAuthRef` (bundle pointer + mode) and builds tls.zig's option inline at the `tls.server` call, so `tls_stub.zig` needs no new type for `-Duse_tls=false` builds.

## Shared configuration

`TlsCa`/`TlsPath` describe where authorities come from (`.system`, `.file`, `.dir`, `.none`) and are shared by `ClientConfig.tls.ca` and `ServerConfig.tls.client_auth.ca`. They live in `config.zig` so the dependency points from client to config, and so `config.zig` stays free of the tls.zig import.

`.ca = .none` is rejected up front — on the client unless `insecure_skip_verify` is set, on the server always. Otherwise it surfaces as the opaque `error.TlsInitializationFailed`, which swallows every handshake cause.

## Bug fix

`Connection.init` created its arena with no `errdefer`, so every connection that failed to initialize leaked it — the caller only destroys the struct. Pre-existing, but a rejected handshake now takes that path, and the new tests hit it immediately.

## Tests

Six new tests, all Client-to-Server through dusty's own API:

- client certificate presented and accepted
- `client_auth = .require` rejecting a client with no certificate
- `client_auth = .request` accepting one
- `client_auth.ca = .none` rejected by `listen()`
- HTTPS against a custom CA file
- untrusted server certificate rejected, then accepted under `insecure_skip_verify`

Green in all three configurations: 272 tests with TLS, 272 with `-Duse_http2=true`, 263 with `-Duse_tls=false`.

## Notes

- A rejected client certificate surfaces as `error.ReadFailed`. In TLS 1.3 the client finishes its flight before the rejection arrives, and the client never consults `tls_reader.err` the way `server.zig` does. Pre-existing for all TLS reads; left for a separate change.
- tls.zig's server is TLS 1.3 only, so TLS 1.2-only clients cannot connect at all. Also pre-existing.
- Zig's verifier matches DNS SANs but not IP SANs, so `https://127.0.0.1` against an IP-SAN certificate fails with `CertificateHostMismatch`. The tests use `localhost` for this reason.
- The tls.zig bump crosses the `split-safe-connection` merge, so the concurrent-safe `Connection` rework comes along with it.