### PR TITLE
server: demote SocketUnconnected shutdown failure to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
   `.dir`, `.none`) and are shared by `ClientConfig.tls.ca` and `ServerConfig.tls.client_auth.ca`.
 - Fix memory leak when a client connection fails to initialize (e.g. a rejected TLS handshake): the
   connection arena was not released.
+- The server no longer logs a `warn` when the deferred connection shutdown fails with
+  `error.SocketUnconnected`; that just means the peer was already gone, so it's logged at `debug`.
 
 ## [0.2.0] - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ All notable changes to this project will be documented in this file.
   `.dir`, `.none`) and are shared by `ClientConfig.tls.ca` and `ServerConfig.tls.client_auth.ca`.
 - Fix memory leak when a client connection fails to initialize (e.g. a rejected TLS handshake): the
   connection arena was not released.
-- The server no longer logs a `warn` when the deferred connection shutdown fails with
-  `error.SocketUnconnected`; that just means the peer was already gone, so it's logged at `debug`.
 
 ## [0.2.0] - 2026-04-26
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -480,7 +480,17 @@ pub fn Server(comptime Ctx: type) type {
 
             var needs_shutdown = true;
             defer if (needs_shutdown) stream.shutdown(self.io, .both) catch |err| {
-                log.warn("Failed to shutdown client connection: {}", .{err});
+                // SocketUnconnected here just means the peer was already gone
+                // by the time this deferred cleanup ran; shutdown() was only
+                // ever best-effort politeness, and stream.close() above still
+                // released the fd. Not worth a warning, unlike isPeerGone's
+                // other cases, which don't apply here since this errors from
+                // shutdown() itself, not from reading/writing the connection.
+                if (err == error.SocketUnconnected) {
+                    log.debug("Failed to shutdown client connection: {}", .{err});
+                } else {
+                    log.warn("Failed to shutdown client connection: {}", .{err});
+                }
             };
 
             var connection: Connection = undefined;

--- a/src/server.zig
+++ b/src/server.zig
@@ -480,12 +480,6 @@ pub fn Server(comptime Ctx: type) type {
 
             var needs_shutdown = true;
             defer if (needs_shutdown) stream.shutdown(self.io, .both) catch |err| {
-                // SocketUnconnected here just means the peer was already gone
-                // by the time this deferred cleanup ran; shutdown() was only
-                // ever best-effort politeness, and stream.close() above still
-                // released the fd. Not worth a warning, unlike isPeerGone's
-                // other cases, which don't apply here since this errors from
-                // shutdown() itself, not from reading/writing the connection.
                 if (err == error.SocketUnconnected) {
                     log.debug("Failed to shutdown client connection: {}", .{err});
                 } else {


### PR DESCRIPTION
Fixes #140.

When the deferred `stream.shutdown(.both)` in `handleConnection` fails with `error.SocketUnconnected`, that just means the peer was already gone by the time cleanup ran. That's not worth a `warn`: `stream.close()` still releases the fd, and `shutdown()` was only ever best-effort politeness on a socket with nothing left on the other end.

This mirrors the existing `Connection.isPeerGone` handling in `handleConnectionWrapper`, which already treats a departed peer as debug-level rather than a real failure.

The check is scoped to this one call site rather than added to `isPeerGone` itself, since that helper is also used on the request path where a "socket not connected" error may still be worth seeing.
