### PR TITLE
Resolve read errors on both ends, through one shared transport

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -697,6 +697,39 @@ pub const ClientResponse = struct {
 
     /// Read the entire response body into memory.
     /// Result is cached for subsequent calls.
+    /// Walks down from the topmost layer that ran to whichever one recorded
+    /// what went wrong. Which layers those are depends on what `reader`
+    /// handed out: a corrupt gzip stream fails in the decompressor, above a
+    /// body reader that saw nothing wrong.
+    ///
+    /// Errors rather than returning one, so its set can be inferred; the same
+    /// shape `Connection.checkReadError` has.
+    fn checkRead(self: *ClientResponse) !void {
+        if (self._decompressor_init) {
+            if (self._decompressor.err) |e| switch (e) {
+                // The decompressor stores whatever it was handed, and what
+                // the body reader hands it on failure is the sentinel. So
+                // this means "the layer below failed, keep descending" --
+                // the same thing tls.zig's `TransportReadFailed` means, and
+                // it leaves the inferred error set the same way.
+                error.ReadFailed => {},
+                else => |cause| return cause,
+            };
+        }
+        if (self._body_reader.err) |e| return e;
+    }
+
+    /// The error type `getReadError` yields.
+    pub const ReadError = @typeInfo(@TypeOf(checkRead(undefined))).error_union.error_set;
+
+    /// The real error behind an `error.ReadFailed` from `reader`, if any
+    /// layer recorded one. `body` resolves for you; a caller streaming the
+    /// body itself has to ask, since the interface it reads through cannot
+    /// say more than that a read failed.
+    pub fn getReadError(self: *ClientResponse) ?ReadError {
+        if (checkRead(self)) |_| return null else |e| return e;
+    }
+
     pub fn body(self: *ClientResponse) !?[]const u8 {
         if (self._body_read) {
             return self._body;
@@ -705,25 +738,7 @@ pub const ClientResponse = struct {
         const r = self.reader();
         const result = r.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
-            // The interface can only say that a read failed. Which layer
-            // holds the answer depends on which reader `reader` handed out:
-            // a corrupt gzip stream fails in the decompressor, above a body
-            // reader that saw nothing wrong.
-            error.ReadFailed => {
-                if (self._decompressor_init) {
-                    if (self._decompressor.err) |e| switch (e) {
-                        // The decompressor stores whatever it was handed, and
-                        // what the body reader hands it on failure is the
-                        // sentinel. So this means "the layer below failed,
-                        // keep descending" -- the same thing tls.zig's
-                        // `TransportReadFailed` means, and it leaves the
-                        // inferred error set the same way.
-                        error.ReadFailed => {},
-                        else => |cause| return cause,
-                    };
-                }
-                return self._body_reader.err orelse error.Unexpected;
-            },
+            error.ReadFailed => return self.getReadError() orelse error.Unexpected,
             else => |e| return e,
         };
 
@@ -1513,6 +1528,36 @@ test "ClientResponse.body: a corrupt gzip body reports the decompression failure
     // The bytes arrived intact; it is the layer above the body reader that
     // could not make sense of them, so that is where the answer is.
     try std.testing.expectError(error.BadGzipHeader, response.body());
+}
+
+test "ClientResponse: a streaming read can be resolved without going through body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 32\r\n\r\n" ++
+        ("not a gzip stream at all" ++ "12345678");
+    var reader = std.Io.Reader.fixed(raw_response);
+
+    var parsed: ParsedResponse = .{ .arena = arena.allocator() };
+    var parser: ResponseParser = undefined;
+    try parser.init(&parsed, 64);
+
+    try parseResponseHeaders(&reader, &parser);
+
+    var response = ClientResponse{
+        .arena = arena.allocator(),
+        .parser = &parser,
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parsed = &parsed,
+        .max_response_size = 1024,
+    };
+
+    // Streaming the body rather than calling `body`, which is the case with
+    // no other way to find out what happened.
+    const r = response.reader();
+    var sink: std.Io.Writer = .fixed(&[_]u8{});
+    try std.testing.expectError(error.ReadFailed, r.stream(&sink, .limited(64)));
+    try std.testing.expectEqual(error.BadGzipHeader, response.getReadError().?);
 }
 
 test "Client: no std.Io.Reader sentinel escapes the response API" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -994,7 +994,7 @@ pub const Client = struct {
 
         var seed: u64 = undefined;
         self.io.random(std.mem.asBytes(&seed));
-        var ws = WebSocket.init(self.io, conn.writer, conn.reader, conn.allocator, seed);
+        var ws = WebSocket.init(self.io, conn.transport(), conn.allocator, seed);
         ws.is_client = true;
         return .{ .ws = ws, .conn = conn };
     }

--- a/src/client.zig
+++ b/src/client.zig
@@ -18,6 +18,7 @@ const WebSocket = @import("websocket.zig").WebSocket;
 const ResponseParser = @import("parser.zig").ResponseParser;
 const ParsedResponse = @import("parser.zig").ParsedResponse;
 const ResponseBodyReader = @import("parser.zig").ResponseBodyReader;
+const Transport = @import("transport.zig").Transport;
 const KeepAliveParams = @import("parser.zig").KeepAliveParams;
 const parseKeepAliveHeader = @import("parser.zig").parseKeepAliveHeader;
 
@@ -516,6 +517,36 @@ pub const Connection = struct {
         }
     }
 
+    /// A borrowed view of the reader/writer stack, and the one thing that
+    /// knows how to say what a failed read or write actually was. Shared with
+    /// the server rather than reimplemented, which is how the TLS layer's
+    /// errors stopped being invisible here.
+    pub fn transport(self: *Connection) Transport {
+        const has_tls = build_options.use_tls and self.tls_conn != null;
+        return .{
+            .reader = self.reader,
+            .writer = self.writer,
+            .tcp_reader = &self.tcp_reader,
+            .tcp_writer = &self.tcp_writer,
+            .tls_reader = if (has_tls) &self.tls_reader else null,
+            .tls_writer = if (has_tls) &self.tls_writer else null,
+        };
+    }
+
+    pub const ReadError = Transport.ReadError;
+    pub const WriteError = Transport.WriteError;
+
+    /// The real error behind a generic `error.ReadFailed`, if any was recorded.
+    pub fn getReadError(self: *Connection) ?ReadError {
+        return self.transport().getReadError();
+    }
+
+    /// The real error behind a generic `error.WriteFailed`, if any was
+    /// recorded.
+    pub fn getWriteError(self: *Connection) ?WriteError {
+        return self.transport().getWriteError();
+    }
+
     pub fn deinit(self: *Connection) void {
         self.stream.close(self.io);
         if (self.protocol == .https) {
@@ -943,7 +974,7 @@ pub const Client = struct {
 
         // Parse response headers
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {
-            error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
+            error.ReadFailed => return conn.getReadError() orelse error.ReadFailed,
             else => |e| return e,
         };
 
@@ -1024,7 +1055,7 @@ pub const Client = struct {
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| {
             conn.closing = true;
             switch (err) {
-                error.ReadFailed => return conn.tcp_reader.err orelse error.ReadFailed,
+                error.ReadFailed => return conn.getReadError() orelse error.ReadFailed,
                 else => |e| return e,
             }
         };
@@ -1056,7 +1087,7 @@ pub const Client = struct {
                     _ = body_reader.interface.discardShort(max_drain + 1) catch |err| switch (err) {
                         error.ReadFailed => {
                             conn.closing = true;
-                            return conn.tcp_reader.err orelse error.ReadFailed;
+                            return conn.getReadError() orelse error.ReadFailed;
                         },
                     };
                     if (!conn.parser.isBodyComplete()) conn.closing = true;

--- a/src/client.zig
+++ b/src/client.zig
@@ -643,7 +643,7 @@ pub const ClientResponse = struct {
     // Direct pointers for reading (testable without full connection)
     arena: std.mem.Allocator,
     parser: *ResponseParser,
-    conn: *std.Io.Reader,
+    transport: Transport,
     parsed: *ParsedResponse,
     max_response_size: usize,
     decompress: bool = true,
@@ -705,7 +705,10 @@ pub const ClientResponse = struct {
         const r = self.reader();
         const result = r.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
-            else => return err,
+            // The interface can only say that a read failed; the reader
+            // holds what it was.
+            error.ReadFailed => return self._body_reader.err orelse error.Unexpected,
+            else => |e| return e,
         };
 
         self._body_read = true;
@@ -723,14 +726,14 @@ pub const ClientResponse = struct {
         // If body has already been read, return a reader for the cached body
         if (self._body_read) {
             const cached_body = self._body orelse &.{};
-            self._body_reader = ResponseBodyReader.init(self.parser, self.conn, &self._body_reader_buffer);
+            self._body_reader = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
             self._body_reader.interface = std.Io.Reader.fixed(cached_body);
             return &self._body_reader.interface;
         }
 
         // Initialize body reader if not already done
         if (!self._body_reader_init) {
-            self._body_reader = ResponseBodyReader.init(self.parser, self.conn, &self._body_reader_buffer);
+            self._body_reader = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
             self._body_reader_init = true;
         }
 
@@ -1083,11 +1086,11 @@ pub const Client = struct {
                 if (!conn.parser.isBodyComplete()) {
                     const max_drain = 2048;
                     var drain_buf: [1024]u8 = undefined;
-                    var body_reader = ResponseBodyReader.init(&conn.parser, conn.reader, &drain_buf);
+                    var body_reader = ResponseBodyReader.init(&conn.parser, conn.transport(), &drain_buf);
                     _ = body_reader.interface.discardShort(max_drain + 1) catch |err| switch (err) {
                         error.ReadFailed => {
                             conn.closing = true;
-                            return conn.getReadError() orelse error.ReadFailed;
+                            return body_reader.err orelse error.Unexpected;
                         },
                     };
                     if (!conn.parser.isBodyComplete()) conn.closing = true;
@@ -1162,7 +1165,7 @@ pub const Client = struct {
         return ClientResponse{
             .arena = conn.arena.allocator(),
             .parser = &conn.parser,
-            .conn = conn.reader,
+            .transport = conn.transport(),
             .parsed = &conn.parsed_response,
             .max_response_size = self.config.max_response_size,
             .decompress = state.options.decompress,
@@ -1461,7 +1464,7 @@ test "ClientResponse.body: basic response" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1487,7 +1490,7 @@ test "ClientResponse.body: large body over 128 bytes" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1513,7 +1516,7 @@ test "ClientResponse.body: no body" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1541,7 +1544,7 @@ test "ClientResponse.body: connection-close (EOF-delimited) body" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1567,7 +1570,7 @@ test "ClientResponse.reader: streaming read" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1602,7 +1605,7 @@ test "ClientResponse.reader: after body() returns cached data" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
     };
@@ -1635,7 +1638,7 @@ test "ClientResponse.body: gzip decompression" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
         .decompress = true,
@@ -1663,7 +1666,7 @@ test "ClientResponse.body: gzip decompression disabled" {
     var response = ClientResponse{
         .arena = arena.allocator(),
         .parser = &parser,
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parsed = &parsed,
         .max_response_size = 1024,
         .decompress = false,

--- a/src/client.zig
+++ b/src/client.zig
@@ -705,9 +705,25 @@ pub const ClientResponse = struct {
         const r = self.reader();
         const result = r.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
-            // The interface can only say that a read failed; the reader
-            // holds what it was.
-            error.ReadFailed => return self._body_reader.err orelse error.Unexpected,
+            // The interface can only say that a read failed. Which layer
+            // holds the answer depends on which reader `reader` handed out:
+            // a corrupt gzip stream fails in the decompressor, above a body
+            // reader that saw nothing wrong.
+            error.ReadFailed => {
+                if (self._decompressor_init) {
+                    if (self._decompressor.err) |e| switch (e) {
+                        // The decompressor stores whatever it was handed, and
+                        // what the body reader hands it on failure is the
+                        // sentinel. So this means "the layer below failed,
+                        // keep descending" -- the same thing tls.zig's
+                        // `TransportReadFailed` means, and it leaves the
+                        // inferred error set the same way.
+                        error.ReadFailed => {},
+                        else => |cause| return cause,
+                    };
+                }
+                return self._body_reader.err orelse error.Unexpected;
+            },
             else => |e| return e,
         };
 
@@ -977,7 +993,7 @@ pub const Client = struct {
 
         // Parse response headers
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| switch (err) {
-            error.ReadFailed => return conn.getReadError() orelse error.ReadFailed,
+            error.ReadFailed => return conn.getReadError() orelse error.Unexpected,
             else => |e| return e,
         };
 
@@ -1058,7 +1074,7 @@ pub const Client = struct {
         parseResponseHeaders(conn.reader, &conn.parser) catch |err| {
             conn.closing = true;
             switch (err) {
-                error.ReadFailed => return conn.getReadError() orelse error.ReadFailed,
+                error.ReadFailed => return conn.getReadError() orelse error.Unexpected,
                 else => |e| return e,
             }
         };
@@ -1471,6 +1487,59 @@ test "ClientResponse.body: basic response" {
 
     const body = try response.body();
     try std.testing.expectEqualStrings("hello", body.?);
+}
+
+test "ClientResponse.body: a corrupt gzip body reports the decompression failure" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 32\r\n\r\n" ++ ("not a gzip stream at all" ++ "12345678");
+    var reader = std.Io.Reader.fixed(raw_response);
+
+    var parsed: ParsedResponse = .{ .arena = arena.allocator() };
+    var parser: ResponseParser = undefined;
+    try parser.init(&parsed, 64);
+
+    try parseResponseHeaders(&reader, &parser);
+
+    var response = ClientResponse{
+        .arena = arena.allocator(),
+        .parser = &parser,
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parsed = &parsed,
+        .max_response_size = 1024,
+    };
+
+    // The bytes arrived intact; it is the layer above the body reader that
+    // could not make sense of them, so that is where the answer is.
+    try std.testing.expectError(error.BadGzipHeader, response.body());
+}
+
+test "Client: no std.Io.Reader sentinel escapes the response API" {
+    // `ReadFailed` says only that a read failed, which the caller knew when
+    // it called. The response side has more layers than the server's --
+    // socket, TLS, body framing, decompression -- and any of them could drop
+    // its answer on the way up.
+    const ErrorSetOf = struct {
+        fn f(comptime func: anytype) type {
+            return @typeInfo(@typeInfo(@TypeOf(func)).@"fn".return_type.?).error_union.error_set;
+        }
+    }.f;
+    //
+    // `Client.fetch` and `Client.connectWebSocket` are deliberately absent:
+    // they also write the request and open the connection, and neither path
+    // resolves yet. That is the client's half of what #144 did for the
+    // server's responses, and it is not this change.
+    inline for (.{
+        ErrorSetOf(ClientResponse.body),
+        ErrorSetOf(WebSocketClient.send),
+        ErrorSetOf(WebSocketClient.receive),
+    }) |Set| {
+        inline for (@typeInfo(Set).error_set.?) |e| {
+            try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
+            try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
+        }
+    }
 }
 
 test "ClientResponse.body: large body over 128 bytes" {

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -728,8 +728,10 @@ test "Server: client_auth .require rejects a client with no certificate" {
 
             // In TLS 1.3 the client finishes its flight before the server can
             // reject the missing certificate, so the refusal surfaces on the
-            // first read rather than as a handshake error.
-            try std.testing.expectError(error.ReadFailed, client.fetch(url, .{}));
+            // first read rather than as a handshake error -- and as the alert
+            // the server actually sent, which is a layer below what the read
+            // itself could report.
+            try std.testing.expectError(error.TlsAlertCertificateRequired, client.fetch(url, .{}));
         }
     }.run, .{ &server, io });
 

--- a/src/middleware.zig
+++ b/src/middleware.zig
@@ -556,7 +556,7 @@ test "Executor: a handler that fails mid-body does not send the fragment" {
     var connection: Connection = undefined;
     connection.initWriterForTesting(&conn_writer);
 
-    var req: Request = .{ .arena = arena.allocator(), .conn = undefined, .parser = undefined };
+    var req: Request = .{ .arena = arena.allocator(), .transport = undefined, .parser = undefined };
     var res = try Response.init(arena.allocator(), &connection, 32);
 
     var executor = Executor(void){
@@ -602,7 +602,7 @@ test "Executor: a middleware that wrote a body does not supply the 404" {
     var connection: Connection = undefined;
     connection.initWriterForTesting(&conn_writer);
 
-    var req: Request = .{ .arena = arena.allocator(), .conn = undefined, .parser = undefined };
+    var req: Request = .{ .arena = arena.allocator(), .transport = undefined, .parser = undefined };
     var res = try Response.init(arena.allocator(), &connection, 32);
 
     var mw = WritingMiddleware{};

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Transport = @import("transport.zig").Transport;
 
 const c = @import("llhttp");
 
@@ -479,16 +480,36 @@ pub const ResponseParser = struct {
 pub fn BodyReader(comptime Parser: type) type {
     return struct {
         parser: *Parser,
-        conn: *std.Io.Reader,
+        transport: Transport,
         interface: std.Io.Reader,
         request: ?*Request = null,
+        /// The real cause behind the generic `error.ReadFailed` that the
+        /// `std.Io.Reader` interface has to return. `stream` is the one path
+        /// that cannot hand a cause back, its error set being fixed by the
+        /// vtable, so it is the one place this is written.
+        ///
+        /// Not every cause is the transport's. A body that stops mid-chunk,
+        /// or framing the parser rejects, fails the read just as surely and
+        /// the connection has nothing to say about it.
+        err: ?Error = null,
 
         const Self = @This();
 
-        pub fn init(parser: *Parser, conn: *std.Io.Reader, buffer: []u8) Self {
+        /// What reading a body can fail with, once the sentinel is resolved.
+        pub const Error = Transport.ReadError || Transport.WriteError ||
+            ParseError || error{ IncompleteBody, Unexpected };
+
+        /// Stores what actually went wrong and reports the sentinel the
+        /// vtable requires. Mirrors `fail` on the buffered body writer.
+        fn fail(self: *Self, cause: Error) std.Io.Reader.StreamError {
+            self.err = cause;
+            return error.ReadFailed;
+        }
+
+        pub fn init(parser: *Parser, transport: Transport, buffer: []u8) Self {
             return .{
                 .parser = parser,
-                .conn = conn,
+                .transport = transport,
                 .interface = .{
                     .vtable = &.{ .stream = stream },
                     .buffer = buffer,
@@ -501,15 +522,17 @@ pub fn BodyReader(comptime Parser: type) type {
         fn stream(io_r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
             const self: *Self = @alignCast(@fieldParentPtr("interface", io_r));
             const parser = self.parser;
-            const conn = self.conn;
+            const conn = self.transport.reader;
 
             // Send 100 Continue on first body read if client expects it
             if (self.request) |req| {
                 if (req.expects_continue) {
                     req.expects_continue = false;
                     if (req.response) |res| {
-                        try res.conn.writer.writeAll("HTTP/1.1 100 Continue\r\n\r\n");
-                        try res.conn.writer.flush();
+                        // A write, on a read: the caller asked for the body
+                        // and this is what unblocks the peer from sending it.
+                        sendContinue(res.conn.writer) catch
+                            return self.fail(self.transport.getWriteError() orelse error.Unexpected);
                     }
                 }
             }
@@ -545,20 +568,20 @@ pub fn BodyReader(comptime Parser: type) type {
                     conn.fillMore() catch |err| switch (err) {
                         error.EndOfStream => {
                             // Connection closed - call finish() to complete the message
-                            parser.finish() catch {
-                                // finish() failed - message was not complete
-                                return error.ReadFailed;
-                            };
+                            parser.finish() catch |e| return self.fail(e);
 
                             // Check if body is now complete after finish()
                             if (parser.isBodyComplete()) {
                                 return error.EndOfStream;
                             }
 
-                            // Message not complete despite EOF
-                            return error.ReadFailed;
+                            // The peer stopped mid-body. Nothing is wrong with
+                            // the connection, so it has no cause to offer.
+                            return self.fail(error.IncompleteBody);
                         },
-                        else => return error.ReadFailed,
+                        error.ReadFailed => return self.fail(
+                            self.transport.getReadError() orelse error.Unexpected,
+                        ),
                     };
                 }
 
@@ -583,7 +606,9 @@ pub fn BodyReader(comptime Parser: type) type {
                             const consumed = parser.getConsumedBytes(buffered.ptr);
                             conn.toss(consumed);
                         },
-                        else => return error.ReadFailed,
+                        // Framing the parser rejected: the bytes arrived, they
+                        // just were not a body.
+                        else => |e| return self.fail(e),
                     }
                 }
 
@@ -594,6 +619,11 @@ pub fn BodyReader(comptime Parser: type) type {
 }
 
 /// BodyReader specialized for HTTP requests.
+fn sendContinue(w: *std.Io.Writer) std.Io.Writer.Error!void {
+    try w.writeAll("HTTP/1.1 100 Continue\r\n\r\n");
+    return w.flush();
+}
+
 pub const RequestBodyReader = BodyReader(RequestParser);
 
 /// BodyReader specialized for HTTP responses.
@@ -666,7 +696,7 @@ test "RequestParser: basic" {
     var req: Request = .{
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     var parser: RequestParser = undefined;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -474,9 +474,15 @@ pub const ResponseParser = struct {
 /// - `state.body_dest_pos: usize`
 /// - `isBodyComplete() bool`
 /// - `prepareBodyRead(dest: []u8) void`
-/// - `feed(data: []const u8) !void`
-/// - `finish() !void`
+/// - `feed(data: []const u8) (ParseError || error{Paused})!void`
+/// - `finish() ParseError!void`
 /// - `getConsumedBytes(ptr: [*c]const u8) usize`
+///
+/// `feed` and `finish` must fail within `ParseError`, because what they
+/// return ends up in `err` and from there in the error set of every public
+/// body read. A parser free to invent its own errors would put its internals
+/// in that set -- `Paused` included, which is signalling between the parser
+/// and this loop and means nothing to a caller.
 pub fn BodyReader(comptime Parser: type) type {
     return struct {
         parser: *Parser,
@@ -494,6 +500,13 @@ pub fn BodyReader(comptime Parser: type) type {
         err: ?Error = null,
 
         const Self = @This();
+
+        comptime {
+            // Stated above, checked here: a parser outside `ParseError` would
+            // otherwise fail somewhere inside `stream` with no hint as to why.
+            assertFailsWithin(@TypeOf(Parser.feed), ParseError || error{Paused});
+            assertFailsWithin(@TypeOf(Parser.finish), ParseError);
+        }
 
         /// What reading a body can fail with, once the sentinel is resolved.
         pub const Error = Transport.ReadError || Transport.WriteError ||
@@ -619,6 +632,17 @@ pub fn BodyReader(comptime Parser: type) type {
 }
 
 /// BodyReader specialized for HTTP requests.
+/// Fails to compile unless every error `Fn` can return is in `Allowed`.
+fn assertFailsWithin(comptime Fn: type, comptime Allowed: type) void {
+    const returned = @typeInfo(@typeInfo(Fn).@"fn".return_type.?).error_union.error_set;
+    for (@typeInfo(returned).error_set.?) |e| {
+        // A member of `Allowed` coerces; anything else is a compile error
+        // naming the offending parser and error.
+        const member: Allowed = @field(Allowed, e.name);
+        _ = &member;
+    }
+}
+
 fn sendContinue(w: *std.Io.Writer) std.Io.Writer.Error!void {
     try w.writeAll("HTTP/1.1 100 Continue\r\n\r\n");
     return w.flush();

--- a/src/request.zig
+++ b/src/request.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const http = @import("http.zig");
 const RequestParser = @import("parser.zig").RequestParser;
 const RequestBodyReader = @import("parser.zig").RequestBodyReader;
+const Transport = @import("transport.zig").Transport;
 const ParseError = @import("parser.zig").ParseError;
 const ServerConfig = @import("config.zig").ServerConfig;
 const Response = @import("response.zig").Response;
@@ -28,7 +29,7 @@ pub const Request = struct {
 
     // Body reading support
     parser: *RequestParser,
-    conn: *std.Io.Reader,
+    transport: Transport,
     body_reader_buffer: [1024]u8 = undefined,
     config: ServerConfig.Request = .{},
     _body: ?[]const u8 = null,
@@ -47,7 +48,7 @@ pub const Request = struct {
         const arena = self.arena;
         const io = self.io;
         const parser = self.parser;
-        const conn = self.conn;
+        const transport = self.transport;
         const cfg = self.config;
         const res = self.response;
         // Belongs to the connection, not the request, so it outlives the
@@ -57,7 +58,7 @@ pub const Request = struct {
             .arena = arena,
             .io = io,
             .parser = parser,
-            .conn = conn,
+            .transport = transport,
             .config = cfg,
             .response = res,
             .remote_address = addr,
@@ -68,13 +69,13 @@ pub const Request = struct {
         // If body has already been read, return a reader for the cached body
         if (self._body_read) {
             const cached_body = self._body orelse &.{};
-            var r = RequestBodyReader.init(self.parser, self.conn, &self.body_reader_buffer);
+            var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
             r.interface = std.Io.Reader.fixed(cached_body);
             return r;
         }
 
         // Return the streaming body reader
-        var r = RequestBodyReader.init(self.parser, self.conn, &self.body_reader_buffer);
+        var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
         r.request = self;
         return r;
     }
@@ -88,7 +89,10 @@ pub const Request = struct {
         var r = self.reader();
         const result = r.interface.allocRemaining(self.arena, .limited(self.config.max_body_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.BodyTooBig,
-            else => return err,
+            // The interface can only say that a read failed; the reader
+            // holds what it was.
+            error.ReadFailed => return r.err orelse error.Unexpected,
+            else => |e| return e,
         };
 
         self._body_read = true;
@@ -527,6 +531,26 @@ pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeaders
     };
 }
 
+test "Request: no std.Io.Reader sentinel escapes the body-reading API" {
+    // `ReadFailed` says only that a read failed, which the caller knew when
+    // it called. None of these may report it.
+    const ErrorSetOf = struct {
+        fn f(comptime func: anytype) type {
+            return @typeInfo(@typeInfo(@TypeOf(func)).@"fn".return_type.?).error_union.error_set;
+        }
+    }.f;
+    inline for (.{
+        ErrorSetOf(Request.body),
+        ErrorSetOf(Request.jsonValue),
+        ErrorSetOf(Request.formData),
+        ErrorSetOf(Request.multiFormData),
+    }) |Set| {
+        inline for (@typeInfo(Set).error_set.?) |e| {
+            try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
+        }
+    }
+}
+
 test "Request.body: basic POST" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -536,7 +560,7 @@ test "Request.body: basic POST" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -551,6 +575,57 @@ test "Request.body: basic POST" {
     try std.testing.expectEqualStrings("hello", body.?);
 }
 
+test "Request.body: a body cut short reports the parse failure, not a failed read" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // The headers promise five bytes and the peer sends two, then stops.
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Length: 5\r\n\r\nhe";
+    var reader = std.Io.Reader.fixed(raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // Nothing is wrong with the connection, so it has no cause to offer.
+    // The parser does: it is the layer that knows the body was short, and
+    // the reader carries its answer up.
+    try std.testing.expectError(error.ParseFailed, req.body());
+}
+
+test "Request.body: framing the parser rejects is reported as itself" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // A chunk size that is not a number.
+    const raw_request = "POST /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nzz\r\nhello\r\n";
+    var reader = std.Io.Reader.fixed(raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    try std.testing.expectError(error.InvalidChunkSize, req.body());
+}
+
 test "Request.body: large body over 128 bytes" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -561,7 +636,7 @@ test "Request.body: large body over 128 bytes" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -586,7 +661,7 @@ test "Request.cookies: parse cookies from header" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -612,7 +687,7 @@ test "Request.formData: basic key and value" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -637,7 +712,7 @@ test "Request.formData: URL-encoded key and value" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -661,7 +736,7 @@ test "Request.formData: entry with no value" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -685,7 +760,7 @@ test "Request.multiFormData: basic key and value" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -710,7 +785,7 @@ test "Request.multiFormData: entry with filename" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -748,7 +823,7 @@ test "Request.multiFormData: semicolon in attribute name (regression)" {
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 
@@ -785,7 +860,7 @@ test "Request.multiFormData: trailing backslash in quoted attribute (regression)
 
     var req: Request = .{
         .arena = arena.allocator(),
-        .conn = &reader,
+        .transport = .{ .reader = &reader, .writer = undefined },
         .parser = undefined,
     };
 

--- a/src/response.zig
+++ b/src/response.zig
@@ -542,7 +542,7 @@ pub const Response = struct {
 
         var seed: u64 = undefined;
         req.io.random(std.mem.asBytes(&seed));
-        return WebSocket.init(req.io, self.conn.writer, req.conn, self.arena, seed);
+        return WebSocket.init(req.io, self.conn.transport(), self.arena, seed);
     }
 
     /// Turns the sentinel a `std.Io.Writer` reports into the cause the

--- a/src/router.zig
+++ b/src/router.zig
@@ -436,7 +436,7 @@ test "Router: register and find GET route" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -458,7 +458,7 @@ test "Router: register and find POST route" {
         .url = "/posts",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -480,7 +480,7 @@ test "Router: method mismatch returns null" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -501,7 +501,7 @@ test "Router: path mismatch returns null" {
         .url = "/posts",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -522,7 +522,7 @@ test "Router: parameterized routes" {
         .url = "/users/123",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -547,7 +547,7 @@ test "Router: multiple routes" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const handler1 = try router.findHandler(&req1);
     try std.testing.expect(handler1 != null);
@@ -559,7 +559,7 @@ test "Router: multiple routes" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const handler2 = try router.findHandler(&req2);
     try std.testing.expect(handler2 != null);
@@ -571,7 +571,7 @@ test "Router: multiple routes" {
         .url = "/posts",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const handler3 = try router.findHandler(&req3);
     try std.testing.expect(handler3 != null);
@@ -593,7 +593,7 @@ test "Router: all HTTP methods" {
             .url = "/resource",
             .arena = arena.allocator(),
             .parser = undefined,
-            .conn = undefined,
+            .transport = undefined,
         };
         const handler = try router.findHandler(&req);
         try std.testing.expect(handler != null);
@@ -614,7 +614,7 @@ test "Router: extract single parameter" {
         .url = "/users/123",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -639,7 +639,7 @@ test "Router: extract multiple parameters" {
         .url = "/users/456/posts/789",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -668,7 +668,7 @@ test "Router: mixed static and parameter segments" {
         .url = "/api/v1/users/abc123/profile",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -696,7 +696,7 @@ test "Router: static route has precedence over param route" {
         .url = "/users/new",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -721,7 +721,7 @@ test "Router: wildcard route basic matching" {
         .url = "/files/document.txt",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -743,7 +743,7 @@ test "Router: wildcard captures remaining path" {
         .url = "/files/path/to/file.txt",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -769,7 +769,7 @@ test "Router: static route has precedence over wildcard" {
         .url = "/files/config.json",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -795,7 +795,7 @@ test "Router: param route has precedence over wildcard" {
         .url = "/api/123",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -823,7 +823,7 @@ test "Router: wildcard with multiple segments" {
         .url = "/assets/images/icons/logo.png",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -848,7 +848,7 @@ test "Router: wildcard with prefix path" {
         .url = "/api/v1/files/docs/readme.md",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -873,7 +873,7 @@ test "Router: static route with query parameters" {
         .url = "/users/profile?debug=true&page=1",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -899,7 +899,7 @@ test "Router: param route with query parameters" {
         .url = "/users/123?format=json",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -929,7 +929,7 @@ test "Router: multiple params with query parameters" {
         .url = "/users/456/posts/789?include=comments&sort=date",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -963,7 +963,7 @@ test "Router: wildcard route with query parameters" {
         .url = "/files/docs/readme.md?download=true",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -992,7 +992,7 @@ test "Router: empty query string" {
         .url = "/users/123?",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -1020,7 +1020,7 @@ test "Router: no query parameters" {
         .url = "/users/123",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -1048,7 +1048,7 @@ test "Router: URL encoded query parameters" {
         .url = "/search?q=hello+world&tag=foo%20bar&special=%21%40%23%24",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -1074,7 +1074,7 @@ test "Router: query parameter without value" {
         .url = "/items?featured&sort=name",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -1099,7 +1099,7 @@ test "Router: query with empty key-value pairs" {
         .url = "/test?a=1&&b=2&",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
 
     const handler = try router.findHandler(&req);
@@ -1141,7 +1141,7 @@ test "Group: prefix concatenation" {
         .url = "/api/v1/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route1 = try router.findHandler(&req1);
     try std.testing.expect(route1 != null);
@@ -1152,7 +1152,7 @@ test "Group: prefix concatenation" {
         .url = "/api/v1/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route2 = try router.findHandler(&req2);
     try std.testing.expect(route2 != null);
@@ -1182,7 +1182,7 @@ test "Group: routes without group middleware get global middlewares" {
         .url = "/direct",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route = try router.findHandler(&req);
     try std.testing.expect(route != null);
@@ -1213,7 +1213,7 @@ test "Group: group middlewares appended after global" {
         .url = "/api/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route = try router.findHandler(&req);
     try std.testing.expect(route != null);
@@ -1245,7 +1245,7 @@ test "Group: no global middlewares, only group middlewares" {
         .url = "/api/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route = try router.findHandler(&req);
     try std.testing.expect(route != null);
@@ -1266,7 +1266,7 @@ test "Group: direct routes have no middlewares when none set" {
         .url = "/health",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     const route = try router.findHandler(&req);
     try std.testing.expect(route != null);
@@ -1289,7 +1289,7 @@ test "Group: any method registers all methods" {
             .url = "/api/resource",
             .arena = arena.allocator(),
             .parser = undefined,
-            .conn = undefined,
+            .transport = undefined,
         };
         const route = try router.findHandler(&req);
         try std.testing.expect(route != null);
@@ -1310,7 +1310,7 @@ test "Router: a GET route answers HEAD" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     try std.testing.expectEqual(&testHandler, (try router.findHandler(&req)).?.action);
 
@@ -1337,7 +1337,7 @@ test "Router: an explicit HEAD route wins over the GET one" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     try std.testing.expectEqual(&testHandler2, (try router.findHandler(&req)).?.action);
 
@@ -1361,7 +1361,7 @@ test "Router: HEAD falls back per path, not per tree" {
         .url = "/users",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     try std.testing.expectEqual(&testHandler, (try router.findHandler(&req)).?.action);
 }
@@ -1380,7 +1380,7 @@ test "Router: HEAD falling back to GET still captures path params" {
         .url = "/users/42",
         .arena = arena.allocator(),
         .parser = undefined,
-        .conn = undefined,
+        .transport = undefined,
     };
     try std.testing.expect(try router.findHandler(&req) != null);
     try std.testing.expectEqualStrings("42", req.params.get("id").?);

--- a/src/server.zig
+++ b/src/server.zig
@@ -577,7 +577,7 @@ pub fn Server(comptime Ctx: type) type {
                         needs_shutdown.* = false;
                         return;
                     },
-                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
+                    error.ReadFailed => return connection.getReadError() orelse error.Unexpected,
                     else => |e| return e,
                 };
 
@@ -621,8 +621,8 @@ pub fn Server(comptime Ctx: type) type {
                     .middlewares = if (found) |r| r.middlewares else self.router.middlewares,
                 };
                 executor.run() catch |err| switch (err) {
-                    error.ReadFailed => return connection.getReadError() orelse error.ReadFailed,
-                    error.WriteFailed => return connection.getWriteError() orelse error.WriteFailed,
+                    error.ReadFailed => return connection.getReadError() orelse error.Unexpected,
+                    error.WriteFailed => return connection.getWriteError() orelse error.Unexpected,
                     else => |e| return e,
                 };
 
@@ -690,7 +690,7 @@ pub fn Server(comptime Ctx: type) type {
                         return;
                     },
                     error.ReadFailed => {
-                        const e = connection.getReadError() orelse error.ReadFailed;
+                        const e = connection.getReadError() orelse error.Unexpected;
                         // Nothing is in flight between requests, so a peer
                         // that went away here has cost us nothing. The socket
                         // is already gone, so skip the shutdown syscall too.

--- a/src/server.zig
+++ b/src/server.zig
@@ -536,7 +536,7 @@ pub fn Server(comptime Ctx: type) type {
             var request: Request = .{
                 .arena = arena.allocator(),
                 .io = self.io,
-                .conn = connection.reader,
+                .transport = connection.transport(),
                 .parser = undefined,
                 .config = self.config.request,
                 .remote_address = connection.stream.socket.address,
@@ -635,11 +635,13 @@ pub fn Server(comptime Ctx: type) type {
                     };
                     if (drainable) {
                         var scratch: [4096]u8 = undefined;
-                        var body_reader = RequestBodyReader.init(&parser, connection.reader, &scratch);
+                        var body_reader = RequestBodyReader.init(&parser, connection.transport(), &scratch);
                         if (body_reader.interface.discardShort(max + 1)) |consumed| {
                             if (consumed > max) response.keepalive = false;
                         } else |_| {
-                            if (connection.getReadError()) |e| if (e == error.Canceled) return error.Canceled;
+                            // A cancel is the request timing out, not a body
+                            // worth giving up on quietly.
+                            if (body_reader.err) |e| if (e == error.Canceled) return error.Canceled;
                             response.keepalive = false;
                         }
                     } else {

--- a/src/server.zig
+++ b/src/server.zig
@@ -13,6 +13,7 @@ const Response = @import("response.zig").Response;
 const ServerConfig = @import("config.zig").ServerConfig;
 const Executor = @import("middleware.zig").Executor;
 const Middleware = @import("middleware.zig").Middleware;
+const Transport = @import("transport.zig").Transport;
 const MiddlewareConfig = @import("middleware.zig").MiddlewareConfig;
 
 const log = std.log.scoped(.dusty);
@@ -131,78 +132,35 @@ pub const Connection = struct {
         self.arena.deinit();
     }
 
-    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
-    // layer below it failed, because all it saw was the ciphertext
-    // reader/writer's generic error; the real cause is on the TCP layer.
-    // So those two mean "keep descending". A TLS-level failure (bad record
-    // mac, bad version, ...) is recorded as itself and stops the search.
-    //
-    // They are switched on rather than compared so that they drop out of
-    // the inferred error set as well as out of the answer: like the
-    // `WriteFailed` they stand in for, they name no cause a caller could
-    // act on, and nothing that descends past them can return one.
-
-    fn checkReadError(self: *Connection) !void {
-        if (build_options.use_tls) {
-            if (self.tls_conn != null) {
-                if (self.tls_reader.err) |e| switch (e) {
-                    // Keep descending: the cause is on the TCP layer below.
-                    error.TransportReadFailed => {},
-                    else => |cause| return cause,
-                };
-            }
-        }
-        if (self.tcp_reader.err) |e| return e;
+    /// A borrowed view of the layers above, for the parts of the library
+    /// that are shared with the client and so can hold neither `Connection`.
+    pub fn transport(self: *Connection) Transport {
+        const has_tls = build_options.use_tls and self.tls_conn != null;
+        return .{
+            .reader = self.reader,
+            .writer = self.writer,
+            .tcp_reader = &self.tcp_reader,
+            .tcp_writer = &self.tcp_writer,
+            .tls_reader = if (has_tls) &self.tls_reader else null,
+            .tls_writer = if (has_tls) &self.tls_writer else null,
+        };
     }
 
-    /// The error type `getReadError` yields.
-    pub const ReadError = @typeInfo(@TypeOf(checkReadError(undefined))).error_union.error_set;
+    pub const ReadError = Transport.ReadError;
+    pub const WriteError = Transport.WriteError;
 
     /// The real error behind a generic `error.ReadFailed`, if any was recorded.
     pub fn getReadError(self: *Connection) ?ReadError {
-        if (checkReadError(self)) |_| return null else |e| return e;
+        return self.transport().getReadError();
     }
-
-    fn checkWriteError(self: *Connection) !void {
-        if (build_options.use_tls) {
-            if (self.tls_conn != null) {
-                if (self.tls_writer.err) |e| switch (e) {
-                    // Keep descending: the cause is on the TCP layer below.
-                    error.TransportWriteFailed => {},
-                    else => |cause| return cause,
-                };
-            }
-        }
-        if (self.tcp_writer.err) |e| return e;
-    }
-
-    /// The error type `getWriteError` yields.
-    pub const WriteError = @typeInfo(@TypeOf(checkWriteError(undefined))).error_union.error_set;
 
     /// The real error behind a generic `error.WriteFailed`, if any was
     /// recorded.
     pub fn getWriteError(self: *Connection) ?WriteError {
-        if (checkWriteError(self)) |_| return null else |e| return e;
+        return self.transport().getWriteError();
     }
 
-    /// True when `err` means the peer is gone rather than something being
-    /// wrong. Teardown is the same either way; this only decides whether the
-    /// connection is worth a log line and whether shutdown() is worth a
-    /// syscall.
-    pub fn isPeerGone(err: anyerror) bool {
-        return switch (err) {
-            error.EndOfStream,
-            // Peer closed the transport between TLS records without
-            // close_notify. Rude, but routine from clients that just close
-            // the socket. `TlsTruncated`, where a record was cut in half, is
-            // deliberately not here.
-            error.TlsUnexpectedEof,
-            error.ConnectionResetByPeer,
-            error.BrokenPipe,
-            => true,
-            else => false,
-        };
-    }
+    pub const isPeerGone = Transport.isPeerGone;
 };
 
 pub const Address = union(enum) {

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+const tls = @import("tls");
+const build_options = @import("build_options");
+
+/// A borrowed view of one connection's reader/writer stack: the interfaces
+/// HTTP is spoken over, and the concrete layers beneath them that record why
+/// a read or write failed.
+///
+/// A view rather than an owner, because the two ends of the library build the
+/// stack differently -- the server carves its buffers from a per-connection
+/// arena and runs `tls.server`, the client allocates them and runs
+/// `tls.client` with ALPN -- while "what actually failed" has one answer for
+/// both. Anything shared between the ends, such as `WebSocket`, can hold this
+/// where it could hold neither `Connection`.
+///
+/// It borrows from whatever owns the layers and must not outlive it.
+pub const Transport = struct {
+    /// What HTTP is read and written through: the socket's own interfaces on
+    /// a plain connection, the TLS layer's cleartext ones otherwise.
+    reader: *std.Io.Reader,
+    writer: *std.Io.Writer,
+
+    /// The socket. On a TLS connection it carries ciphertext, and it is where
+    /// a transport failure is recorded.
+    ///
+    /// Optional so a test can drive the layers above over a plain `.fixed`
+    /// reader and writer, with nothing beneath them to record a cause -- the
+    /// same shape as a writer that failed without one, which resolves to
+    /// `Unexpected` rather than needing a socket to fake.
+    tcp_reader: ?*std.Io.net.Stream.Reader = null,
+    tcp_writer: ?*std.Io.net.Stream.Writer = null,
+
+    /// The TLS layer, on a connection that has one.
+    tls_reader: ?*tls.Connection.Reader = null,
+    tls_writer: ?*tls.Connection.Writer = null,
+
+    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
+    // layer below it failed, because all it saw was the ciphertext
+    // reader/writer's generic error; the real cause is on the TCP layer.
+    // So those two mean "keep descending". A TLS-level failure (bad record
+    // mac, bad version, ...) is recorded as itself and stops the search.
+    //
+    // They are switched on rather than compared so that they drop out of
+    // the inferred error set as well as out of the answer: like the
+    // `ReadFailed`/`WriteFailed` they stand in for, they name no cause a
+    // caller could act on, and nothing that descends past them can return one.
+
+    fn checkReadError(self: Transport) !void {
+        if (build_options.use_tls) {
+            if (self.tls_reader) |tls_reader| {
+                if (tls_reader.err) |e| switch (e) {
+                    // Keep descending: the cause is on the TCP layer below.
+                    error.TransportReadFailed => {},
+                    else => |cause| return cause,
+                };
+            }
+        }
+        if (self.tcp_reader) |tcp_reader| {
+            if (tcp_reader.err) |e| return e;
+        }
+    }
+
+    /// The error type `getReadError` yields.
+    pub const ReadError = @typeInfo(@TypeOf(checkReadError(undefined))).error_union.error_set;
+
+    /// The real error behind a generic `error.ReadFailed`, if any was recorded.
+    pub fn getReadError(self: Transport) ?ReadError {
+        if (checkReadError(self)) |_| return null else |e| return e;
+    }
+
+    fn checkWriteError(self: Transport) !void {
+        if (build_options.use_tls) {
+            if (self.tls_writer) |tls_writer| {
+                if (tls_writer.err) |e| switch (e) {
+                    // Keep descending: the cause is on the TCP layer below.
+                    error.TransportWriteFailed => {},
+                    else => |cause| return cause,
+                };
+            }
+        }
+        if (self.tcp_writer) |tcp_writer| {
+            if (tcp_writer.err) |e| return e;
+        }
+    }
+
+    /// The error type `getWriteError` yields.
+    pub const WriteError = @typeInfo(@TypeOf(checkWriteError(undefined))).error_union.error_set;
+
+    /// The real error behind a generic `error.WriteFailed`, if any was
+    /// recorded.
+    pub fn getWriteError(self: Transport) ?WriteError {
+        if (checkWriteError(self)) |_| return null else |e| return e;
+    }
+
+    /// True when `err` means the peer is gone rather than something being
+    /// wrong. Teardown is the same either way; this only decides whether the
+    /// connection is worth a log line and whether shutdown() is worth a
+    /// syscall.
+    pub fn isPeerGone(err: anyerror) bool {
+        return switch (err) {
+            error.EndOfStream,
+            // Peer closed the transport between TLS records without
+            // close_notify. Rude, but routine from clients that just close
+            // the socket. `TlsTruncated`, where a record was cut in half, is
+            // deliberately not here.
+            error.TlsUnexpectedEof,
+            error.ConnectionResetByPeer,
+            error.BrokenPipe,
+            => true,
+            else => false,
+        };
+    }
+};

--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Transport = @import("transport.zig").Transport;
 
 /// An established WebSocket connection (RFC 6455). Obtained from
 /// `Response.upgradeWebSocket` on the server side and `Client.connectWebSocket`
@@ -7,8 +8,10 @@ const std = @import("std");
 /// One task may call `receive`; any number of tasks may send concurrently.
 pub const WebSocket = struct {
     io: std.Io,
-    conn: *std.Io.Writer,
-    reader: *std.Io.Reader,
+    /// The connection underneath, and the only thing that knows why a frame
+    /// failed to go out or come in. Shared with both ends of the library,
+    /// which hold unrelated `Connection` types.
+    transport: Transport,
     msg_arena: std.heap.ArenaAllocator,
     is_client: bool = false,
     prng: std.Random.DefaultPrng,
@@ -66,11 +69,10 @@ pub const WebSocket = struct {
 
     const GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-    pub fn init(io: std.Io, conn: *std.Io.Writer, reader: *std.Io.Reader, gpa: std.mem.Allocator, seed: u64) WebSocket {
+    pub fn init(io: std.Io, transport: Transport, gpa: std.mem.Allocator, seed: u64) WebSocket {
         return .{
             .io = io,
-            .conn = conn,
-            .reader = reader,
+            .transport = transport,
             .msg_arena = std.heap.ArenaAllocator.init(gpa),
             .prng = std.Random.DefaultPrng.init(seed),
         };
@@ -86,6 +88,15 @@ pub const WebSocket = struct {
     /// Pong frames are ignored.
     /// The returned message data is valid until the next call to receive().
     pub fn receive(self: *WebSocket) !Message {
+        return self.receiveFrame() catch |err| switch (err) {
+            // The reads inside can only report the sentinel; the transport
+            // knows what actually happened.
+            error.ReadFailed => self.transport.getReadError() orelse error.Unexpected,
+            else => |e| e,
+        };
+    }
+
+    fn receiveFrame(self: *WebSocket) !Message {
         _ = self.msg_arena.reset(.retain_capacity);
         self.fragmented_data = .empty;
         self.auto_responded = false;
@@ -187,7 +198,7 @@ pub const WebSocket = struct {
     fn readFrame(self: *WebSocket) !Frame {
         // Read first 2 bytes (header)
         var header: [2]u8 = undefined;
-        try self.reader.readSliceAll(&header);
+        try self.transport.reader.readSliceAll(&header);
 
         const fin = (header[0] & 0x80) != 0;
         // RSV1, RSV2, RSV3 must be 0 (we don't support extensions)
@@ -216,18 +227,18 @@ pub const WebSocket = struct {
         // Extended payload length
         if (payload_len == 126) {
             var len_buf: [2]u8 = undefined;
-            try self.reader.readSliceAll(&len_buf);
+            try self.transport.reader.readSliceAll(&len_buf);
             payload_len = std.mem.readInt(u16, &len_buf, .big);
         } else if (payload_len == 127) {
             var len_buf: [8]u8 = undefined;
-            try self.reader.readSliceAll(&len_buf);
+            try self.transport.reader.readSliceAll(&len_buf);
             payload_len = std.mem.readInt(u64, &len_buf, .big);
         }
 
         // Read masking key if present (client -> server messages are masked)
         var mask_key: [4]u8 = undefined;
         if (masked) {
-            try self.reader.readSliceAll(&mask_key);
+            try self.transport.reader.readSliceAll(&mask_key);
         }
 
         // Read payload
@@ -235,7 +246,7 @@ pub const WebSocket = struct {
             return Error.MessageTooLarge;
         }
         const payload = try self.msg_arena.allocator().alloc(u8, @intCast(payload_len));
-        try self.reader.readSliceAll(payload);
+        try self.transport.reader.readSliceAll(payload);
 
         // Unmask if needed
         if (masked) {
@@ -251,52 +262,60 @@ pub const WebSocket = struct {
         };
     }
 
+    /// Turns the sentinel a `std.Io.Writer` reports into the cause the
+    /// transport recorded. Every frame leaves through here.
+    fn resolveWrite(self: *WebSocket, result: std.Io.Writer.Error!void) !void {
+        result catch |err| switch (err) {
+            error.WriteFailed => return self.transport.getWriteError() orelse error.Unexpected,
+        };
+    }
+
     fn writeFrame(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) !void {
         try self.write_mutex.lock(self.io);
         defer self.write_mutex.unlock(self.io);
         if (self.closed) return error.EndOfStream;
-        return self.writeFrameLocked(opcode, data, fin);
+        return self.resolveWrite(self.writeFrameLocked(opcode, data, fin));
     }
 
-    fn writeFrameLocked(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) !void {
+    fn writeFrameLocked(self: *WebSocket, opcode: MessageType, data: []const u8, fin: bool) std.Io.Writer.Error!void {
         // A half-written frame leaves the peer unable to find the next frame
         // boundary.
         errdefer self.closed = true;
 
         // First byte: FIN + opcode
         const byte0: u8 = (@as(u8, if (fin) 0x80 else 0x00)) | @intFromEnum(opcode);
-        try self.conn.writeByte(byte0);
+        try self.transport.writer.writeByte(byte0);
 
         // Second byte: mask bit + payload length
         const mask_bit: u8 = if (self.is_client) 0x80 else 0x00;
         if (data.len < 126) {
-            try self.conn.writeByte(mask_bit | @as(u8, @intCast(data.len)));
+            try self.transport.writer.writeByte(mask_bit | @as(u8, @intCast(data.len)));
         } else if (data.len <= 65535) {
-            try self.conn.writeByte(mask_bit | 126);
+            try self.transport.writer.writeByte(mask_bit | 126);
             var len_buf: [2]u8 = undefined;
             std.mem.writeInt(u16, &len_buf, @intCast(data.len), .big);
-            try self.conn.writeAll(&len_buf);
+            try self.transport.writer.writeAll(&len_buf);
         } else {
-            try self.conn.writeByte(mask_bit | 127);
+            try self.transport.writer.writeByte(mask_bit | 127);
             var len_buf: [8]u8 = undefined;
             std.mem.writeInt(u64, &len_buf, @intCast(data.len), .big);
-            try self.conn.writeAll(&len_buf);
+            try self.transport.writer.writeAll(&len_buf);
         }
 
         if (self.is_client) {
             // Client frames must be masked (RFC 6455)
             var mask_key: [4]u8 = undefined;
             self.prng.random().bytes(&mask_key);
-            try self.conn.writeAll(&mask_key);
+            try self.transport.writer.writeAll(&mask_key);
 
             // XOR payload with mask key
             for (data, 0..) |byte, i| {
-                try self.conn.writeByte(byte ^ mask_key[i % 4]);
+                try self.transport.writer.writeByte(byte ^ mask_key[i % 4]);
             }
         } else {
-            try self.conn.writeAll(data);
+            try self.transport.writer.writeAll(data);
         }
-        try self.conn.flush();
+        try self.transport.writer.flush();
     }
 
     fn writeClose(self: *WebSocket, code: CloseCode, reason: []const u8) !void {
@@ -309,7 +328,7 @@ pub const WebSocket = struct {
         std.mem.writeInt(u16, buf[0..2], @intFromEnum(code), .big);
         const reason_len = @min(reason.len, 123);
         @memcpy(buf[2..][0..reason_len], reason[0..reason_len]);
-        try self.writeFrameLocked(.close, buf[0 .. 2 + reason_len], true);
+        try self.resolveWrite(self.writeFrameLocked(.close, buf[0 .. 2 + reason_len], true));
     }
 
     /// Compute Sec-WebSocket-Accept value from client key
@@ -335,7 +354,7 @@ test "WebSocket: writeFrame text" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeFrame(.text, "Hello", true);
 
@@ -353,7 +372,7 @@ test "WebSocket: writeFrame binary with medium length" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
 
     const payload = "x" ** 200;
@@ -373,7 +392,7 @@ test "WebSocket: writeClose" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     try ws.writeClose(.normal, "goodbye");
 
@@ -402,7 +421,7 @@ test "WebSocket: readFrame unmasked (client mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     const frame = try ws.readFrame();
@@ -418,7 +437,7 @@ test "WebSocket: readFrame rejects unmasked client frame (server mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     // is_client = false (default) — must reject unmasked input per RFC 6455 §5.1.
     try std.testing.expectError(WebSocket.Error.UnmaskedClientFrame, ws.readFrame());
@@ -434,7 +453,7 @@ test "WebSocket: readFrame rejects masked server frame (client mode)" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try std.testing.expectError(WebSocket.Error.MaskedServerFrame, ws.readFrame());
@@ -456,7 +475,7 @@ test "WebSocket: readFrame masked" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     const frame = try ws.readFrame();
 
@@ -481,7 +500,7 @@ test "WebSocket: receive handles ping automatically" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     const msg = try ws.receive();
 
@@ -510,7 +529,7 @@ test "WebSocket: readFrame rejects RSV bits" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     try std.testing.expectError(WebSocket.Error.ReservedFlags, ws.readFrame());
 }
@@ -530,7 +549,7 @@ test "WebSocket: readFrame rejects large control frame" {
     var buf: [1024]u8 = undefined;
     var conn_writer: std.Io.Writer = .fixed(&buf);
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try std.testing.expectError(WebSocket.Error.LargeControlFrame, ws.readFrame());
@@ -541,7 +560,7 @@ test "WebSocket: writeFrame masked (client mode)" {
     var conn_writer: std.Io.Writer = .fixed(&buf);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(std.testing.io, &conn_writer, &reader, std.testing.allocator, 0);
+    var ws = WebSocket.init(std.testing.io, .{ .writer = &conn_writer, .reader = &reader }, std.testing.allocator, 0);
     defer ws.deinit();
     ws.is_client = true;
     try ws.writeFrame(.text, "Hello", true);
@@ -610,7 +629,7 @@ test "WebSocket: concurrent sends do not interleave within a frame" {
     defer probe.out.deinit(gpa);
     var reader: std.Io.Reader = .fixed("");
 
-    var ws = WebSocket.init(io, &probe.interface, &reader, gpa, 0);
+    var ws = WebSocket.init(io, .{ .writer = &probe.interface, .reader = &reader }, gpa, 0);
     defer ws.deinit();
 
     const a = "a" ** 300;
@@ -639,5 +658,47 @@ test "WebSocket: concurrent sends do not interleave within a frame" {
     const ba = frame_b ++ frame_a;
     if (!std.mem.eql(u8, written, &ab) and !std.mem.eql(u8, written, &ba)) {
         return error.FrameInterleaved;
+    }
+}
+
+test "WebSocket: send reports the real error, not error.WriteFailed" {
+    // Too small to hold the frame, so the payload has nowhere to go.
+    var buf: [4]u8 = undefined;
+    var conn_writer: std.Io.Writer = .fixed(&buf);
+    var reader: std.Io.Reader = .fixed("");
+
+    // No socket, but something beneath the writer that recorded a cause --
+    // which is all the transport is consulted for.
+    var tcp_writer: std.Io.net.Stream.Writer = undefined;
+    tcp_writer.err = error.ConnectionResetByPeer;
+
+    var ws = WebSocket.init(std.testing.io, .{
+        .writer = &conn_writer,
+        .reader = &reader,
+        .tcp_writer = &tcp_writer,
+    }, std.testing.allocator, 0);
+    defer ws.deinit();
+
+    try std.testing.expectError(error.ConnectionResetByPeer, ws.send(.text, "x" ** 64));
+}
+
+test "WebSocket: no std.Io sentinel escapes its public API" {
+    // `ReadFailed`/`WriteFailed` say only that a read or write failed, which
+    // the caller knew when it called. Neither may leave these.
+    const ErrorSetOf = struct {
+        fn f(comptime func: anytype) type {
+            return @typeInfo(@typeInfo(@TypeOf(func)).@"fn".return_type.?).error_union.error_set;
+        }
+    }.f;
+    inline for (.{
+        ErrorSetOf(WebSocket.send),
+        ErrorSetOf(WebSocket.ping),
+        ErrorSetOf(WebSocket.close),
+        ErrorSetOf(WebSocket.receive),
+    }) |Set| {
+        inline for (@typeInfo(Set).error_set.?) |e| {
+            try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
+            try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
+        }
     }
 }


### PR DESCRIPTION
Closes #146.

#144 made the response write path report the error that actually failed
rather than `std.Io.Writer`'s `error.WriteFailed` sentinel. It could only do
that for `Response`, which is server-only and already held a `*Connection`.
Everything shared between the two ends of the library — `WebSocket`,
`BodyReader` — held bare `std.Io` interfaces, because there was no type both
ends could hand them.

`Transport` is that type: a borrowed view of one connection's reader/writer
stack, and now the only place either end works out what a failed read or
write was.

## Two bugs, not just tidier types

**The client never looked at its own TLS layer.** It read `tcp_reader.err`
directly in three places and stopped there, so a TLS-level failure was
invisible to it. A client rejected under mTLS for presenting no certificate
was told only that a read had failed; it now reports
`TlsAlertCertificateRequired`, which is what the server actually said.

**`BodyReader.stream` turned parser failures into the sentinel and recorded
them nowhere**, so no accessor could have recovered them — a read that failed
because the peer sent nonsense was indistinguishable from one where the
socket died. A bad chunk size now says `InvalidChunkSize`; a body that stops
short says `ParseFailed`. This is the part of #146 the transport alone could
not fix, and it needed an `err` slot on the reader in the shape the body
writers already have.

## Shape

`err` is written in exactly one place per type — the `drain`/`stream` whose
error set the vtable fixes — and every public entry point resolves. Guard
tests now walk the public error sets of `Response`, `WebSocket` and `Request`
by reflection, so the sentinel cannot creep back into any of them.

`WebSocket` takes a `Transport` rather than a writer and a reader, so both
`WebSocket.init` call sites got shorter. `Request` and `ClientResponse` carry
one instead of a bare reader.

## Drift from the issue

#146 proposed that both connections **embed** a `Transport` owning the ten
shared fields. This is a borrowed **view** instead: six pointers, handed out
by `Connection.transport()`.

Reading both `init` paths in full, the parts that would have moved are the
parts that genuinely differ — the server carves buffers from a
per-connection arena and runs `tls.server`, the client allocates them and
runs `tls.client` with ALPN — while the only thing duplicated *and* buggy was
the error resolution. The view gets all three benefits the issue listed at a
fraction of the risk: neither `Connection` changed shape, and the ~35
`conn.reader`/`conn.writer` call sites are untouched. The server side of the
first commit is a pure refactor — the whole suite passed unchanged.

What it does not do is dedupe the field *declarations*, which was not one of
the stated benefits.

## Why there are no setup helpers yet

The remaining duplication is the layer wiring: four lines for a plain socket,
seven for TLS, identical apart from where the buffers come from and whether
the handshake is `tls.server` or `tls.client`.

Helpers for that need `Transport` to own the fields, and ownership costs the
property that makes this shape work: around thirty test sites build a
transport as `.{ .reader = &r, .writer = &w }` over `.fixed` interfaces with
no socket beneath. Owned layers would put `undefined` back into all of them.
Eleven lines of duplication does not pay for that, or for the call-site churn.

What would change the balance is a third layer — HTTP/2 over TLS, or a proxy
or compression layer. Then the wiring stops being eleven obvious lines, and
pointing `reader`/`writer` at the wrong interface becomes a silent bug that
reads ciphertext. Worth revisiting alongside the HTTP/2 work.

## Testing

288 Zig tests and the 31-test httpbin suite pass; examples build. Three
commits, each green on its own.