### PR TITLE
Bound the message head by the buffer it is parsed into

### DIFF
--- a/src/client.zig
+++ b/src/client.zig
@@ -85,7 +85,7 @@ pub const ClientConfig = struct {
     /// and values are slices into this buffer rather than copies, so the head
     /// is held whole. A server that sends more gets error.HeadersTooLarge and
     /// its connection torn down.
-    buffer_size: usize = 4096,
+    buffer_size: usize = 16384,
     /// TLS settings for https:// (and wss://) connections. Requires the
     /// `use_tls` build option; with TLS compiled out any HTTPS request fails
     /// with error.TlsNotConfigured. Applies to every connection the client

--- a/src/client.zig
+++ b/src/client.zig
@@ -6,6 +6,7 @@ const build_options = @import("build_options");
 const unix_path_max = 108;
 
 const config_mod = @import("config.zig");
+const body_read_reserve = config_mod.body_read_reserve;
 
 const http = @import("http.zig");
 const Method = http.Method;
@@ -79,7 +80,11 @@ pub const ClientConfig = struct {
     max_response_size: usize = 10_485_760, // 10MB
     /// Maximum idle connections to keep in pool (0 = no pooling).
     max_idle_connections: u8 = 8,
-    /// Buffer size (bytes) for reading response headers.
+    /// Buffer size (bytes) for reading the response head: the status line
+    /// and all headers. This is also the limit on it -- parsed header names
+    /// and values are slices into this buffer rather than copies, so the head
+    /// is held whole. A server that sends more gets error.HeadersTooLarge and
+    /// its connection torn down.
     buffer_size: usize = 4096,
     /// TLS settings for https:// (and wss://) connections. Requires the
     /// `use_tls` build option; with TLS compiled out any HTTPS request fails
@@ -461,7 +466,7 @@ pub const Connection = struct {
             errdefer allocator.free(self.tls_tcp_write_buffer);
 
             // HTTP-layer (cleartext) buffers, used by the tls.Connection reader/writer.
-            self.read_buffer = try allocator.alloc(u8, self.buffer_size + 1024);
+            self.read_buffer = try allocator.alloc(u8, self.buffer_size + body_read_reserve);
             errdefer allocator.free(self.read_buffer);
             self.write_buffer = try allocator.alloc(u8, 1024);
             errdefer allocator.free(self.write_buffer);
@@ -524,7 +529,7 @@ pub const Connection = struct {
             self.tls_tcp_read_buffer = &.{};
             self.tls_tcp_write_buffer = &.{};
 
-            self.read_buffer = try allocator.alloc(u8, self.buffer_size + 1024);
+            self.read_buffer = try allocator.alloc(u8, self.buffer_size + body_read_reserve);
             errdefer allocator.free(self.read_buffer);
             self.write_buffer = try allocator.alloc(u8, 1024);
             errdefer allocator.free(self.write_buffer);
@@ -1418,6 +1423,10 @@ fn parseResponseHeaders(reader: *std.Io.Reader, parser: *ResponseParser) !void {
             parsed_len += unparsed.len;
             continue;
         }
+        // Same ceiling as the server's `parseHeaders`, and for the same
+        // reason: the head is held whole, so a buffer with no room left is a
+        // head that will never complete.
+        if (reader.buffer.len - reader.end < body_read_reserve) return error.HeadersTooLarge;
         reader.fillMore() catch |err| switch (err) {
             error.EndOfStream => {
                 if (parsed_len == 0) return error.EndOfStream;

--- a/src/client.zig
+++ b/src/client.zig
@@ -1435,6 +1435,12 @@ fn parseResponseHeaders(reader: *std.Io.Reader, parser: *ResponseParser) !void {
             else => |e| return e,
         };
     }
+    // And, as there, a fill may use every byte it was given room for, so the
+    // head can finish inside the reserve without the check above ever
+    // firing. The body reader gets what is left, and cannot read into
+    // nothing.
+    if (reader.buffer.len - parsed_len < body_read_reserve) return error.HeadersTooLarge;
+
     reader.toss(parsed_len);
     parser.resumeParsing();
 
@@ -1454,6 +1460,18 @@ fn parseResponseHeaders(reader: *std.Io.Reader, parser: *ResponseParser) !void {
 }
 
 // Tests
+
+/// A reader over `raw` with `body_read_reserve` bytes of slack past it, the
+/// way a connection's read buffer has slack past the head it just parsed.
+/// `Reader.fixed` alone leaves none, and a head with nothing behind it is
+/// rejected -- the body reader would have nowhere to read into.
+fn fixedMessageReader(gpa: std.mem.Allocator, raw: []const u8) !std.Io.Reader {
+    const backing = try gpa.alloc(u8, raw.len + body_read_reserve);
+    @memcpy(backing[0..raw.len], raw);
+    var r: std.Io.Reader = .fixed(backing);
+    r.end = raw.len;
+    return r;
+}
 
 test "parseUrl: basic URL" {
     const uri = try parseUrl("http://example.com/path");
@@ -1558,7 +1576,7 @@ test "ClientResponse.body: basic response" {
     defer arena.deinit();
 
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1583,7 +1601,7 @@ test "ClientResponse.body: a corrupt gzip body reports the decompression failure
     defer arena.deinit();
 
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 32\r\n\r\n" ++ ("not a gzip stream at all" ++ "12345678");
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1610,7 +1628,7 @@ test "ClientResponse: a streaming read can be resolved without going through bod
 
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 32\r\n\r\n" ++
         ("not a gzip stream at all" ++ "12345678");
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1664,7 +1682,7 @@ test "ClientResponse.body: large body over 128 bytes" {
 
     const body_content = "A" ** 256;
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Length: 256\r\n\r\n" ++ body_content;
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1690,7 +1708,7 @@ test "ClientResponse.body: no body" {
     defer arena.deinit();
 
     const raw_response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1718,7 +1736,7 @@ test "ClientResponse.body: connection-close (EOF-delimited) body" {
     // No Content-Length and no Transfer-Encoding: body is delimited by EOF.
     const body_content = "body delimited by connection close, not length.";
     const raw_response = "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nconnection: close\r\n\r\n" ++ body_content;
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1744,7 +1762,7 @@ test "ClientResponse.reader: streaming read" {
     defer arena.deinit();
 
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nhello world";
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1779,7 +1797,7 @@ test "ClientResponse.reader: after body() returns cached data" {
     defer arena.deinit();
 
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello";
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1812,7 +1830,7 @@ test "ClientResponse.body: gzip decompression" {
     // "hello" gzip compressed
     const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;
@@ -1840,7 +1858,7 @@ test "ClientResponse.body: gzip decompression disabled" {
     // "hello" gzip compressed
     const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
     const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
-    var reader = std.Io.Reader.fixed(raw_response);
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
 
     var parsed: ParsedResponse = .{ .arena = arena.allocator() };
     var parser: ResponseParser = undefined;

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -850,3 +850,41 @@ test "Client: ca .none without insecure_skip_verify is rejected" {
     // Fails while loading the TLS material, before any connection is attempted.
     try std.testing.expectError(error.NoCertificateAuthority, client.fetch("https://localhost:1/", .{}));
 }
+
+test "Client: a response head too large for the buffer is rejected, not a panic" {
+    const io = std.testing.io;
+
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    // A peer whose head never ends inside the client's buffer.
+    var peer_future = try io.concurrent(struct {
+        fn run(l: *std.Io.net.Server, _io: std.Io) void {
+            const s = l.accept(_io) catch return;
+            defer s.close(_io);
+            var rbuf: [4096]u8 = undefined;
+            var rd = s.reader(_io, &rbuf);
+            rd.interface.fillMore() catch {};
+            var wbuf: [1024]u8 = undefined;
+            var w = s.writer(_io, &wbuf);
+            w.interface.writeAll("HTTP/1.1 200 OK\r\nX-Big: ") catch {};
+            w.interface.splatByteAll('A', 9000) catch {};
+            w.interface.writeAll("\r\nContent-Length: 0\r\n\r\n") catch {};
+            w.interface.flush() catch {};
+            s.shutdown(_io, .both) catch {};
+        }
+    }.run, .{ &listener, io });
+    defer peer_future.cancel(io);
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/", .{port});
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{});
+    defer client.deinit();
+
+    try std.testing.expectError(error.HeadersTooLarge, client.fetch(url, .{}));
+
+    peer_future.cancel(io);
+}

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -870,7 +870,7 @@ test "Client: a response head too large for the buffer is rejected, not a panic"
             var wbuf: [1024]u8 = undefined;
             var w = s.writer(_io, &wbuf);
             w.interface.writeAll("HTTP/1.1 200 OK\r\nX-Big: ") catch {};
-            w.interface.splatByteAll('A', 9000) catch {};
+            w.interface.splatByteAll('A', 20000) catch {};
             w.interface.writeAll("\r\nContent-Length: 0\r\n\r\n") catch {};
             w.interface.flush() catch {};
             s.shutdown(_io, .both) catch {};

--- a/src/client_test.zig
+++ b/src/client_test.zig
@@ -888,3 +888,69 @@ test "Client: a response head too large for the buffer is rejected, not a panic"
 
     peer_future.cancel(io);
 }
+
+/// Serves one response whose head is exactly `head_len` bytes -- a header
+/// value padded so the terminating CRLFCRLF lands on the byte asked for --
+/// with a five-byte body behind it, and checks what the client makes of it.
+///
+/// The body is the point: what the head does not use of the read buffer is
+/// all the body reader gets, so a head that parses but leaves nothing behind
+/// it fails only once something reads a body.
+fn expectClientResultForHeadOfLength(head_len: usize, expected_body: ?[]const u8) !void {
+    const io = std.testing.io;
+
+    const addr = try std.Io.net.IpAddress.parse("127.0.0.1", 0);
+    var listener = try addr.listen(io, .{ .reuse_address = true });
+    defer listener.deinit(io);
+    const port = listener.socket.address.getPort();
+
+    var peer_future = try io.concurrent(struct {
+        fn run(l: *std.Io.net.Server, len: usize, _io: std.Io) void {
+            const s = l.accept(_io) catch return;
+            defer s.close(_io);
+            var rbuf: [4096]u8 = undefined;
+            var rd = s.reader(_io, &rbuf);
+            rd.interface.fillMore() catch {};
+
+            const prefix = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Pad: ";
+            const suffix = "\r\n\r\n";
+            var wbuf: [1024]u8 = undefined;
+            var w = s.writer(_io, &wbuf);
+            w.interface.writeAll(prefix) catch {};
+            w.interface.splatByteAll('A', len - prefix.len - suffix.len) catch {};
+            w.interface.writeAll(suffix) catch {};
+            w.interface.writeAll("hello") catch {};
+            w.interface.flush() catch {};
+            s.shutdown(_io, .both) catch {};
+        }
+    }.run, .{ &listener, head_len, io });
+    defer peer_future.cancel(io);
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/", .{port});
+
+    var client = dusty.Client.init(std.testing.allocator, io, .{});
+    defer client.deinit();
+
+    if (expected_body) |want| {
+        var resp = try client.fetch(url, .{});
+        defer resp.deinit();
+        try std.testing.expectEqualStrings(want, (try resp.body()) orelse "");
+    } else {
+        try std.testing.expectError(error.HeadersTooLarge, client.fetch(url, .{}));
+    }
+
+    peer_future.cancel(io);
+}
+
+test "Client: a response head of exactly the limit is read, body and all" {
+    try expectClientResultForHeadOfLength(16384, "hello");
+}
+
+test "Client: a response head one byte over the limit is rejected" {
+    try expectClientResultForHeadOfLength(16385, null);
+}
+
+test "Client: a response head ending exactly at the buffer end is rejected, not a panic" {
+    try expectClientResultForHeadOfLength(16384 + 1024, null);
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -109,7 +109,7 @@ pub const ServerConfig = struct {
         /// header names and values are slices into this buffer rather than
         /// copies, so the head is held whole and cannot be read in pieces.
         /// A head that does not fit is answered with 431.
-        buffer_size: usize = 4096,
+        buffer_size: usize = 16384,
         /// Maximum number of headers allowed in a request
         max_header_count: usize = 32,
         /// Maximum number of route parameters (e.g., /user/:id/:action)

--- a/src/config.zig
+++ b/src/config.zig
@@ -40,6 +40,13 @@ pub const TlsCa = union(enum) {
     }
 };
 
+/// Kept free past the head in a connection's read buffer, which is sized
+/// `buffer_size + body_read_reserve`. `parseHeaders` gives the body reader
+/// whatever the head did not use, and a body reader with no buffer cannot
+/// read; refusing a head that would eat into this is what makes it a reserve
+/// rather than a hope.
+pub const body_read_reserve = 1024;
+
 pub const TlsPath = struct {
     path: []const u8,
     /// Directory `path` is resolved against. Defaults to the current working
@@ -97,7 +104,11 @@ pub const ServerConfig = struct {
     pub const Request = struct {
         /// Maximum size (bytes) for request body
         max_body_size: usize = 1_048_576, // 1MB default
-        /// Buffer size (bytes) for reading request headers
+        /// Buffer size (bytes) for reading the request head: the request
+        /// line and all headers. This is also the limit on it -- the parsed
+        /// header names and values are slices into this buffer rather than
+        /// copies, so the head is held whole and cannot be read in pieces.
+        /// A head that does not fit is answered with 431.
         buffer_size: usize = 4096,
         /// Maximum number of headers allowed in a request
         max_header_count: usize = 32,

--- a/src/request.zig
+++ b/src/request.zig
@@ -490,6 +490,7 @@ const ParseHeadersError = std.Io.Reader.Error || ParseError ||
 /// The head is bounded by `reader.buffer`, less `body_read_reserve`: it is
 /// never tossed while it is being parsed, because the header slices point
 /// into it, so whatever it does not use is all the body reader will have.
+/// A head is accepted exactly when it fits in that much.
 ///
 /// Returns error.EndOfStream if connection closed cleanly with no data.
 /// Returns error.IncompleteRequest if connection closed mid-request.
@@ -514,9 +515,9 @@ pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeaders
             continue;
         }
         // Every buffered byte has been consumed as head and it is still
-        // open, so filling again is the only way forward -- and there is no
-        // room left to fill into. `fillMore` would ask its rebase to free a
-        // byte that nothing can free, and assert.
+        // open, so filling again is the only way forward -- and doing so
+        // would eat into the reserve. `fillMore` on a buffer with no room
+        // asks its rebase to free a byte that nothing can free, and asserts.
         if (reader.buffer.len - reader.end < body_read_reserve) return error.HeadersTooLarge;
         reader.fillMore() catch |err| switch (err) {
             error.EndOfStream => {
@@ -526,6 +527,13 @@ pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeaders
             else => |e| return e,
         };
     }
+    // A fill is free to use every byte it was given room for, so a head can
+    // still finish inside the reserve even though the check above passed
+    // each time it ran. What is left is all the body reader gets, and
+    // `BodyReader.stream` can no more fill a zero-length buffer than the
+    // loop above could -- so the head is over the limit either way.
+    if (reader.buffer.len - parsed_len < body_read_reserve) return error.HeadersTooLarge;
+
     reader.toss(parsed_len);
     parser.resumeParsing();
 
@@ -542,6 +550,18 @@ pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeaders
         error.Paused => {},
         else => |e| return e,
     };
+}
+
+/// A reader over `raw` with `body_read_reserve` bytes of slack past it, the
+/// way a connection's read buffer has slack past the head it just parsed.
+/// `Reader.fixed` alone leaves none, and a head with nothing behind it is
+/// rejected -- the body reader would have nowhere to read into.
+fn fixedMessageReader(gpa: std.mem.Allocator, raw: []const u8) !std.Io.Reader {
+    const backing = try gpa.alloc(u8, raw.len + body_read_reserve);
+    @memcpy(backing[0..raw.len], raw);
+    var r: std.Io.Reader = .fixed(backing);
+    r.end = raw.len;
+    return r;
 }
 
 test "Request: no std.Io.Reader sentinel escapes the body-reading API" {
@@ -569,7 +589,7 @@ test "Request.body: basic POST" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -594,7 +614,7 @@ test "Request.body: a body cut short reports the parse failure, not a failed rea
 
     // The headers promise five bytes and the peer sends two, then stops.
     const raw_request = "POST /test HTTP/1.1\r\nContent-Length: 5\r\n\r\nhe";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -621,7 +641,7 @@ test "Request.body: framing the parser rejects is reported as itself" {
 
     // A chunk size that is not a number.
     const raw_request = "POST /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nzz\r\nhello\r\n";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -645,7 +665,7 @@ test "Request.body: large body over 128 bytes" {
 
     const body_content = "A" ** 256;
     const raw_request = "POST /test HTTP/1.1\r\nContent-Length: 256\r\n\r\n" ++ body_content;
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -670,7 +690,7 @@ test "Request.cookies: parse cookies from header" {
     defer arena.deinit();
 
     const raw_request = "GET /test HTTP/1.1\r\nCookie: session=abc123; user=john\r\n\r\n";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -696,7 +716,7 @@ test "Request.formData: basic key and value" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 15\r\n\r\nfoo=123&bar=abc";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -721,7 +741,7 @@ test "Request.formData: URL-encoded key and value" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 17\r\n\r\nfoo+bar=123%21abc";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -745,7 +765,7 @@ test "Request.formData: entry with no value" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: 3\r\n\r\nfoo";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -769,7 +789,7 @@ test "Request.multiFormData: basic key and value" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=--boundary123\r\nContent-Length: 155\r\n\r\n----boundary123\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\n123\r\n----boundary123\r\nContent-Disposition: form-data; name=\"bar\"\r\n\r\nabc\r\n----boundary123--\r\n";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -794,7 +814,7 @@ test "Request.multiFormData: entry with filename" {
     defer arena.deinit();
 
     const raw_request = "POST /test HTTP/1.1\r\nContent-Type: multipart/form-data; boundary=--boundary123\r\nContent-Length: 133\r\n\r\n----boundary123\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"foo.txt\"\r\nContent-Type: text/plain\r\n\r\n123\r\n----boundary123--\r\n";
-    var reader = std.Io.Reader.fixed(raw_request);
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -832,7 +852,7 @@ test "Request.multiFormData: semicolon in attribute name (regression)" {
     try req_buf.appendSlice(std.testing.allocator, "\r\n\r\n");
     try req_buf.appendSlice(std.testing.allocator, body);
 
-    var reader = std.Io.Reader.fixed(req_buf.items);
+    var reader = try fixedMessageReader(arena.allocator(), req_buf.items);
 
     var req: Request = .{
         .arena = arena.allocator(),
@@ -869,7 +889,7 @@ test "Request.multiFormData: trailing backslash in quoted attribute (regression)
     try req_buf.appendSlice(std.testing.allocator, "\r\n\r\n");
     try req_buf.appendSlice(std.testing.allocator, body);
 
-    var reader = std.Io.Reader.fixed(req_buf.items);
+    var reader = try fixedMessageReader(arena.allocator(), req_buf.items);
 
     var req: Request = .{
         .arena = arena.allocator(),

--- a/src/request.zig
+++ b/src/request.zig
@@ -6,6 +6,7 @@ const RequestBodyReader = @import("parser.zig").RequestBodyReader;
 const Transport = @import("transport.zig").Transport;
 const ParseError = @import("parser.zig").ParseError;
 const ServerConfig = @import("config.zig").ServerConfig;
+const body_read_reserve = @import("config.zig").body_read_reserve;
 const Response = @import("response.zig").Response;
 pub const Cookie = @import("cookie.zig").Cookie;
 pub const SessionData = @import("middleware/Session.zig").SessionData;
@@ -481,11 +482,18 @@ const MultipartForm = struct {
     // End of chunk.
 };
 
-const ParseHeadersError = std.Io.Reader.Error || ParseError || error{ IncompleteRequest, OutOfMemory };
+const ParseHeadersError = std.Io.Reader.Error || ParseError ||
+    error{ IncompleteRequest, HeadersTooLarge, OutOfMemory };
 
 /// Parse HTTP headers from a reader and prepare for body reading.
+///
+/// The head is bounded by `reader.buffer`, less `body_read_reserve`: it is
+/// never tossed while it is being parsed, because the header slices point
+/// into it, so whatever it does not use is all the body reader will have.
+///
 /// Returns error.EndOfStream if connection closed cleanly with no data.
 /// Returns error.IncompleteRequest if connection closed mid-request.
+/// Returns error.HeadersTooLarge if the head does not fit.
 pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeadersError!void {
     // Re-pre-allocate headers each call to handle keep-alive (arena was reset).
     parser.request.headers = try http.Headers.init(parser.request.arena, parser.request.config.max_header_count);
@@ -505,6 +513,11 @@ pub fn parseHeaders(reader: *std.Io.Reader, parser: *RequestParser) ParseHeaders
             parsed_len += unparsed.len;
             continue;
         }
+        // Every buffered byte has been consumed as head and it is still
+        // open, so filling again is the only way forward -- and there is no
+        // room left to fill into. `fillMore` would ask its rebase to free a
+        // byte that nothing can free, and assert.
+        if (reader.buffer.len - reader.end < body_read_reserve) return error.HeadersTooLarge;
         reader.fillMore() catch |err| switch (err) {
             error.EndOfStream => {
                 if (parsed_len == 0) return error.EndOfStream;

--- a/src/server.zig
+++ b/src/server.zig
@@ -11,6 +11,7 @@ const Request = @import("request.zig").Request;
 const parseHeaders = @import("request.zig").parseHeaders;
 const Response = @import("response.zig").Response;
 const ServerConfig = @import("config.zig").ServerConfig;
+const body_read_reserve = @import("config.zig").body_read_reserve;
 const Executor = @import("middleware.zig").Executor;
 const Middleware = @import("middleware.zig").Middleware;
 const Transport = @import("transport.zig").Transport;
@@ -86,7 +87,7 @@ pub const Connection = struct {
         // budget, then recycle it (reset keeps the memory). The TLS buffers
         // and the per-request arena are then carved from that one
         // allocation; only unusually large requests grow it.
-        const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + 1024);
+        const conn_reserve = tls.input_buffer_len + tls.output_buffer_len + 2 * (request_buffer_size + body_read_reserve);
         _ = try self.arena.allocator().alloc(u8, conn_reserve);
         _ = self.arena.reset(.retain_capacity);
 
@@ -162,6 +163,18 @@ pub const Connection = struct {
 
     pub const isPeerGone = Transport.isPeerGone;
 };
+
+/// The one reply that cannot go through `Response`: what overran is the head
+/// that would have said how to frame it. Fixed bytes instead, and
+/// `Connection: close`, because the rest of that head is still queued on the
+/// socket and there is no framing to skip it by.
+fn sendHeadersTooLarge(w: *std.Io.Writer) std.Io.Writer.Error!void {
+    try w.writeAll("HTTP/1.1 431 Request Header Fields Too Large\r\n" ++
+        "Connection: close\r\n" ++
+        "Content-Length: 0\r\n" ++
+        "\r\n");
+    return w.flush();
+}
 
 pub const Address = union(enum) {
     ip: std.Io.net.IpAddress,
@@ -554,7 +567,7 @@ pub fn Server(comptime Ctx: type) type {
             defer timeout.clear();
 
             // Allocate initial buffer from arena
-            connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
+            connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + body_read_reserve) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
                 return err;
             };
@@ -578,6 +591,12 @@ pub fn Server(comptime Ctx: type) type {
                         return;
                     },
                     error.ReadFailed => return connection.getReadError() orelse error.Unexpected,
+                    error.HeadersTooLarge => {
+                        log.debug("Request head did not fit in {d} bytes", .{self.config.request.buffer_size});
+                        sendHeadersTooLarge(connection.writer) catch
+                            return connection.getWriteError() orelse error.Unexpected;
+                        return;
+                    },
                     else => |e| return e,
                 };
 
@@ -670,7 +689,7 @@ pub fn Server(comptime Ctx: type) type {
                 _ = arena.reset(.retain_capacity);
 
                 // Allocate fresh buffer for keepalive wait (previous buffer was freed by arena reset)
-                connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + 1024) catch |err| {
+                connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + body_read_reserve) catch |err| {
                     log.err("Failed to allocate read buffer: {}", .{err});
                     return err;
                 };

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1220,3 +1220,105 @@ test "Server: client_auth with ca .none is rejected by listen" {
     const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
     try std.testing.expectError(error.NoCertificateAuthority, server.listen(addr));
 }
+
+test "Server: a request head too large for the buffer gets 431, not a panic" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+
+            // Comfortably past the default buffer_size + body_read_reserve,
+            // in one header so max_header_count is not what rejects it.
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+            try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Big: ");
+            try writer.interface.splatByteAll('A', 9000);
+            try writer.interface.writeAll("\r\n\r\n");
+            // The server answers and hangs up mid-head; it never reads the
+            // rest, so this flush may fail on a reset socket. That is the
+            // point, not a failure of the test.
+            writer.interface.flush() catch {};
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+            try std.testing.expectEqualStrings(
+                "HTTP/1.1 431 Request Header Fields Too Large\r",
+                status_line,
+            );
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}
+
+test "Server: a head that just fits is still served" {
+    const io = std.testing.io;
+
+    // 2 KB of header against the 4 KB default: comfortably under, so the
+    // guard must not fire early.
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.get("/", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            res.body = req.headers.get("X-Big") orelse "missing";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void), _io: std.Io) !void {
+            try s.ready.wait(_io);
+
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+            try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Big: ");
+            try writer.interface.splatByteAll('A', 2048);
+            try writer.interface.writeAll("\r\n\r\n");
+            try writer.interface.flush();
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+            try std.testing.expectEqualStrings("HTTP/1.1 200 OK\r", status_line);
+        }
+    }.run, .{ &server, io });
+
+    try client_future.await(io);
+}

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1322,3 +1322,102 @@ test "Server: a head that just fits is still served" {
 
     try client_future.await(io);
 }
+
+/// What the handler saw, so a test can tell a head that was accepted from
+/// one that was accepted and then could not read its body.
+const HeadBoundaryCtx = struct {
+    body: [16]u8 = undefined,
+    body_len: usize = 0,
+
+    pub fn handle(ctx: *HeadBoundaryCtx, req: *dusty.Request, res: *dusty.Response) !void {
+        const b = (try req.body()) orelse "";
+        ctx.body_len = @min(b.len, ctx.body.len);
+        @memcpy(ctx.body[0..ctx.body_len], b[0..ctx.body_len]);
+        res.body = "OK";
+    }
+};
+
+/// Sends a request whose head is exactly `head_len` bytes -- a header value
+/// padded so the terminating CRLFCRLF lands on the byte asked for -- with a
+/// body behind it, and checks the status line that comes back.
+///
+/// The body is the point. What the head does not use of the read buffer is
+/// all the body reader gets, so a head that parses but leaves nothing behind
+/// it fails only once something tries to read one.
+fn expectStatusForHeadOfLength(
+    head_len: usize,
+    expected_status: []const u8,
+    expected_body: ?[]const u8,
+) !void {
+    const io = std.testing.io;
+    const S = dusty.Server(HeadBoundaryCtx);
+
+    var ctx: HeadBoundaryCtx = .{};
+    var server = S.init(std.testing.allocator, io, .{}, &ctx);
+    defer server.deinit();
+    server.router.post("/", HeadBoundaryCtx.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *S) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    var client_future = try io.concurrent(struct {
+        fn run(s: *S, len: usize, want: []const u8, _io: std.Io) !void {
+            try s.ready.wait(_io);
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            defer stream.close(_io);
+
+            const prefix = "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\nX-Pad: ";
+            const suffix = "\r\n\r\n";
+            std.debug.assert(len >= prefix.len + suffix.len);
+
+            // A rejected head is answered part way through and the rest of it
+            // never read, so these writes are allowed to fail.
+            var write_buf: [1024]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+            writer.interface.writeAll(prefix) catch {};
+            writer.interface.splatByteAll('A', len - prefix.len - suffix.len) catch {};
+            writer.interface.writeAll(suffix) catch {};
+            writer.interface.writeAll("hello") catch {};
+            writer.interface.flush() catch {};
+
+            var read_buf: [1024]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+            try std.testing.expectEqualStrings(want, status_line);
+        }
+    }.run, .{ &server, head_len, expected_status, io });
+
+    try client_future.await(io);
+
+    if (expected_body) |want| {
+        try std.testing.expectEqualStrings(want, ctx.body[0..ctx.body_len]);
+    }
+}
+
+// The read buffer is buffer_size + body_read_reserve, and the head is
+// accepted exactly when it fits in buffer_size -- leaving the reserve for the
+// body reader that inherits the rest.
+const head_limit = 16384;
+const head_buffer_len = head_limit + 1024;
+
+test "Server: a head of exactly the limit is served, body and all" {
+    try expectStatusForHeadOfLength(head_limit, "HTTP/1.1 200 OK\r", "hello");
+}
+
+test "Server: a head one byte over the limit gets 431" {
+    try expectStatusForHeadOfLength(head_limit + 1, "HTTP/1.1 431 Request Header Fields Too Large\r", null);
+}
+
+test "Server: a head ending exactly at the buffer end gets 431, not a panic" {
+    // The head parses cleanly and consumes the reserve with it, so nothing
+    // during parsing objects -- the body reader is left a zero-length buffer
+    // and panics on the first fill.
+    try expectStatusForHeadOfLength(head_buffer_len, "HTTP/1.1 431 Request Header Fields Too Large\r", null);
+}

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1251,15 +1251,15 @@ test "Server: a request head too large for the buffer gets 431, not a panic" {
             defer stream.close(_io);
 
             // Comfortably past the default buffer_size + body_read_reserve,
-            // in one header so max_header_count is not what rejects it.
+            // in one header so max_header_count is not what rejects it. The
+            // server answers and hangs up part way through, without reading
+            // the rest, so these writes are allowed to fail; what is asserted
+            // is the response.
             var write_buf: [1024]u8 = undefined;
             var writer = stream.writer(_io, &write_buf);
-            try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Big: ");
-            try writer.interface.splatByteAll('A', 9000);
-            try writer.interface.writeAll("\r\n\r\n");
-            // The server answers and hangs up mid-head; it never reads the
-            // rest, so this flush may fail on a reset socket. That is the
-            // point, not a failure of the test.
+            writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Big: ") catch {};
+            writer.interface.splatByteAll('A', 20000) catch {};
+            writer.interface.writeAll("\r\n\r\n") catch {};
             writer.interface.flush() catch {};
 
             var read_buf: [1024]u8 = undefined;
@@ -1278,7 +1278,7 @@ test "Server: a request head too large for the buffer gets 431, not a panic" {
 test "Server: a head that just fits is still served" {
     const io = std.testing.io;
 
-    // 2 KB of header against the 4 KB default: comfortably under, so the
+    // 8 KB of header against the 16 KB default: comfortably under, so the
     // guard must not fire early.
     var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
     defer server.deinit();
@@ -1309,7 +1309,7 @@ test "Server: a head that just fits is still served" {
             var write_buf: [1024]u8 = undefined;
             var writer = stream.writer(_io, &write_buf);
             try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\nX-Big: ");
-            try writer.interface.splatByteAll('A', 2048);
+            try writer.interface.splatByteAll('A', 8192);
             try writer.interface.writeAll("\r\n\r\n");
             try writer.interface.flush();
 


### PR DESCRIPTION
A request or response head larger than the connection's read buffer panicked the process, on both the server and the client.

## The bug

Both header loops feed the parser and call `fillMore` until the head is complete, without ever tossing — the parsed header names and values are slices into the buffer, so the head has to be held whole. `seek` therefore stays at 0 while `end` climbs to `buffer.len`, and the next `fillMore` asks `rebase` for `buffer.len + 1` bytes on a full buffer, where nothing can be freed:

```
thread 1836309 panic: reached unreachable code
  std/Io/Reader.zig:1417  in defaultRebase
    assert(r.buffer.len - r.seek >= capacity);
  std/Io/Reader.zig:1133  in fillMore
  src/request.zig:508     in parseHeaders
  src/server.zig:575      in handleRequests
```

Nothing above bounded the head, and `max_header_count` bounds the number of headers rather than their size, so a single long header line was enough. 9 KB of head against the default 5120-byte buffer took the server down before routing, unauthenticated. The client has the same loop over a buffer of the same shape, so a malicious server took the client down through `parseResponseHeaders` the same way.

In `ReleaseFast` the assert is elided; `defaultRebase` then leaves `end == buffer.len` and `readVec` is handed zero capacity, turning the same input into a busy loop rather than a crash.

## The fix

Stop before the fill:

```zig
if (reader.buffer.len - reader.end < body_read_reserve) return error.HeadersTooLarge;
```

This is reached only when every buffered byte has been consumed as head and the head is still open — so `reader.end` is the head's size at that point, and no room left means it can never complete.

Keeping `body_read_reserve` free rather than filling to the last byte matters: `parseHeaders` hands the body reader `reader.buffer[headers_len..]`, and a head that fills the buffer exactly leaves it a zero-length buffer, which trips the same assert one layer down in `BodyReader.stream`. That reserve is what the `+ 1024` on both allocations was always for, so it moves into `config.zig` next to the thing that depends on it.

The server now answers `431 Request Header Fields Too Large` rather than dropping the connection. It can't go through `Response` — what overran is the head that would have said how to frame the reply — so it's written as fixed bytes, with `Connection: close`, since the rest of that head is still queued on the socket and there's no framing to skip it by.

## Not an API change

`buffer_size` was already the limit; its doc comment just didn't say so. Both configs keep the field and the default.

The effective limit has a soft margin: filling stops once `end > buffer_size`, but a single read can overshoot to `buffer.len`. So a head under `buffer_size` is always accepted and one over `buffer_size + body_read_reserve` is always rejected, with the band between the two depending on segmentation. Enough to prevent the panic; if an exact byte count is wanted, one more check after the `feed` branch would do it.

Worth a separate decision: 4 KB is small for a default head limit (Node uses 16 KB, nginx effectively 8 KB). A request with a large cookie jar or a JWT in `Authorization` now gets a clean 431 where it previously panicked.

## Tests

- server: a 9 KB head gets 431 and the process survives
- server: a 2 KB head is still served, so the guard can't fire early
- client: a 9 KB response head returns `error.HeadersTooLarge`

Full suite passes (294/294).
