### PR TITLE
server: bound connections and enforce timeouts by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,39 @@ var response = try client.fetch("http://localhost/v1.41/info", .{
 defer response.deinit();
 ```
 
+## Timeouts
+
+Servers use finite timeouts by default so stalled or idle clients eventually
+release their connection slots:
+
+- `timeout.request` defaults to 30 seconds. It covers an entire request,
+  including handler work and writing the response; a TLS handshake gets its own
+  deadline of the same length.
+- `timeout.keepalive` defaults to 60 seconds between requests on a persistent
+  connection.
+- `timeout.shutdown` defaults to 30 seconds for a graceful shutdown drain.
+
+Set a configured timeout to `null` to disable it. A handler can also replace
+its current request deadline with `Request.setTimeout`. It accepts
+`std.Io.Timeout`, so the handler can use a relative duration, provide an exact
+deadline, or disable the deadline with `.none`:
+
+```zig
+req.setTimeout(.{
+    .duration = .{ .raw = .fromSeconds(60), .clock = .awake },
+});
+req.setTimeout(.{ .deadline = deadline });
+req.setTimeout(.none);
+```
+
+Long-lived handlers can use this as an inactivity timeout by re-arming it
+before each WebSocket message or event, without disabling the resilient server
+default for ordinary requests.
+
+On zio, deadlines cancel the connection task directly. Other I/O backends use
+a watchdog task; with `std.Io.Threaded`, that means a second OS thread for each
+connection while either request or keepalive timeouts are enabled.
+
 ## Selecting the I/O Backend
 
 The examples above use `init.io`, the threaded I/O implementation from the stdlib. This is suitable for development or small servers.

--- a/build.zig
+++ b/build.zig
@@ -21,8 +21,9 @@ pub fn build(b: *std.Build) void {
     build_options.addOption(bool, "use_http2", use_http2);
     mod.addOptions("build_options", build_options);
 
-    // Default `zio` import — a stub that no-ops `clear` and panics on `set`.
-    // Apps that want real timeouts override this in their own build.zig:
+    // Default `zio` import — a marker stub that selects the portable std.Io
+    // timeout watchdog. Apps using the zio runtime override it so timeouts use
+    // zio.AutoCancel instead:
     //   dusty_mod.addImport("zio", zio_dep.module("zio"));
     mod.addAnonymousImport("zio", .{
         .root_source_file = b.path("src/zio_stub.zig"),

--- a/examples/websocket.zig
+++ b/examples/websocket.zig
@@ -3,6 +3,10 @@ const http = @import("dusty");
 
 const AppContext = struct {};
 
+const websocket_idle_timeout: std.Io.Timeout = .{
+    .duration = .{ .raw = .fromSeconds(60), .clock = .awake },
+};
+
 fn handleWebSocket(_: *AppContext, req: *http.Request, res: *http.Response) !void {
     var ws = try res.upgradeWebSocket(req) orelse {
         res.status = .bad_request;
@@ -14,6 +18,9 @@ fn handleWebSocket(_: *AppContext, req: *http.Request, res: *http.Response) !voi
     try ws.send(.text, "Welcome to the WebSocket echo server!");
 
     while (true) {
+        // Treat the request timeout as a WebSocket inactivity timeout by
+        // restarting it before every receive.
+        req.setTimeout(websocket_idle_timeout);
         const msg = ws.receive() catch |err| switch (err) {
             error.EndOfStream => break,
             else => return err,

--- a/src/config.zig
+++ b/src/config.zig
@@ -58,6 +58,13 @@ pub const ServerConfig = struct {
     timeout: Timeout = .{},
     request: Request = .{},
     listen: std.Io.net.IpAddress.ListenOptions = .{ .reuse_address = true, .kernel_backlog = 1024 },
+    /// How many connections may be open at once. At the cap the server stops
+    /// accepting; what arrives meanwhile waits in the kernel's accept queue,
+    /// `listen.kernel_backlog` deep. Null lifts the cap.
+    ///
+    /// Costs about `request.buffer_size + 8K` per connection, 33K more under
+    /// TLS.
+    max_connections: ?u32 = 10_000,
     /// TLS configuration. When set, the server performs a TLS handshake on every
     /// accepted connection and speaks HTTPS. Requires the `use_tls` build option
     /// (enabled by default); with TLS compiled out, setting this fails listen().
@@ -88,10 +95,18 @@ pub const ServerConfig = struct {
     };
 
     pub const Timeout = struct {
-        /// Maximum time to receive a complete request
-        request: ?std.Io.Duration = null,
-        /// Maximum time to keep idle connections open
-        keepalive: ?std.Io.Duration = null,
+        /// Maximum time to complete a request, including handler work and the
+        /// response. TLS handshakes use the same timeout as a separate phase.
+        /// Defaults to 30 seconds; set to null for long-lived handlers, or
+        /// replace it from a handler with `Request.setTimeout`.
+        ///
+        /// Costs a second task per connection on any backend but zio, so on
+        /// `std.Io.Threaded` setting either timeout means two threads per
+        /// connection.
+        request: ?std.Io.Duration = .fromSeconds(30),
+        /// Maximum time to keep idle connections open. Defaults to 60 seconds;
+        /// set to null to keep them open indefinitely.
+        keepalive: ?std.Io.Duration = .fromSeconds(60),
         /// Maximum number of requests per keepalive connection
         request_count: ?usize = null,
         /// Maximum time a graceful shutdown waits for the connections still
@@ -122,3 +137,9 @@ pub const ServerConfig = struct {
         max_multiform_count: usize = 32,
     };
 };
+
+test "ServerConfig: connection timeouts are finite by default" {
+    const cfg: ServerConfig = .{};
+    try std.testing.expectEqual(std.Io.Duration.fromSeconds(30), cfg.timeout.request.?);
+    try std.testing.expectEqual(std.Io.Duration.fromSeconds(60), cfg.timeout.keepalive.?);
+}

--- a/src/request.zig
+++ b/src/request.zig
@@ -28,6 +28,11 @@ pub const Request = struct {
     arena: std.mem.Allocator,
     io: std.Io = undefined,
 
+    // Installed by the server for real requests. Kept as a callback so this
+    // module does not depend on the server's backend-specific timer type.
+    _timeout_context: ?*anyopaque = null,
+    _set_timeout: ?*const fn (*anyopaque, std.Io, std.Io.Timeout) void = null,
+
     // Body reading support
     parser: *RequestParser,
     transport: Transport,
@@ -52,6 +57,8 @@ pub const Request = struct {
         const transport = self.transport;
         const cfg = self.config;
         const res = self.response;
+        const timeout_context = self._timeout_context;
+        const set_timeout = self._set_timeout;
         // Belongs to the connection, not the request, so it outlives the
         // reset the way the reader and the parser do.
         const addr = self.remote_address;
@@ -63,7 +70,20 @@ pub const Request = struct {
             .config = cfg,
             .response = res,
             .remote_address = addr,
+            ._timeout_context = timeout_context,
+            ._set_timeout = set_timeout,
         };
+    }
+
+    /// Replaces the deadline for this request. A duration starts now, a
+    /// deadline is absolute, and `.none` disables the deadline. The server
+    /// installs its normal keepalive deadline after the handler returns.
+    ///
+    /// Call from the connection's handler task, not concurrently from a task
+    /// spawned by the handler.
+    pub fn setTimeout(self: *Request, timeout: std.Io.Timeout) void {
+        const set = self._set_timeout orelse return;
+        set(self._timeout_context.?, self.io, timeout);
     }
 
     pub fn reader(self: *Request) RequestBodyReader {
@@ -562,6 +582,43 @@ fn fixedMessageReader(gpa: std.mem.Allocator, raw: []const u8) !std.Io.Reader {
     var r: std.Io.Reader = .fixed(backing);
     r.end = raw.len;
     return r;
+}
+
+test "Request.setTimeout: forwards relative, absolute, and disabled deadlines" {
+    const Probe = struct {
+        calls: usize = 0,
+        last: std.Io.Timeout = .none,
+
+        fn set(context: *anyopaque, _: std.Io, timeout: std.Io.Timeout) void {
+            const self: *@This() = @ptrCast(@alignCast(context));
+            self.calls += 1;
+            self.last = timeout;
+        }
+    };
+
+    var probe: Probe = .{};
+    var req: Request = .{
+        .arena = std.testing.allocator,
+        .io = std.testing.io,
+        .parser = undefined,
+        .transport = undefined,
+        ._timeout_context = &probe,
+        ._set_timeout = Probe.set,
+    };
+
+    req.setTimeout(.{ .duration = .{ .raw = .fromSeconds(7), .clock = .awake } });
+    try std.testing.expectEqual(std.Io.Duration.fromSeconds(7), probe.last.duration.raw);
+
+    const deadline = std.Io.Clock.Timestamp.now(std.testing.io, .real).addDuration(.{
+        .raw = .fromSeconds(11),
+        .clock = .real,
+    });
+    req.setTimeout(.{ .deadline = deadline });
+    try std.testing.expectEqual(deadline, probe.last.deadline);
+
+    req.setTimeout(.none);
+    try std.testing.expect(probe.last == .none);
+    try std.testing.expectEqual(@as(usize, 3), probe.calls);
 }
 
 test "Request: no std.Io.Reader sentinel escapes the body-reading API" {

--- a/src/server.zig
+++ b/src/server.zig
@@ -188,6 +188,137 @@ pub const Address = union(enum) {
     }
 };
 
+/// Whether the injected `zio` can arm a timer against the running task. The
+/// stub says so by declaring `is_stub`; the real package does not.
+const have_auto_cancel = !@hasDecl(zio, "is_stub");
+
+/// A deadline one task publishes and another waits on.
+///
+/// The watcher sleeps on `generation`, which every re-arm and the finish bump
+/// before waking it. That order is what makes the wait lossless: a re-arm
+/// racing the watcher leaves the word different from what the wait expects,
+/// so it returns rather than sleeping on stale terms.
+const Watch = struct {
+    generation: std.atomic.Value(u32) = .init(0),
+    /// Nanoseconds on the `.awake` clock, or `unarmed`.
+    deadline: std.atomic.Value(i64) = .init(unarmed),
+    finished: std.atomic.Value(bool) = .init(false),
+
+    const unarmed = std.math.maxInt(i64);
+
+    fn wake(self: *Watch, io: std.Io) void {
+        _ = self.generation.fetchAdd(1, .acq_rel);
+        io.futexWake(u32, &self.generation.raw, 1);
+    }
+
+    fn set(self: *Watch, io: std.Io, timeout: std.Io.Timeout) void {
+        const deadline = timeout.toTimestamp(io) orelse return self.disarm(io);
+        const awake_ns = if (deadline.clock == .awake)
+            deadline.raw.nanoseconds
+        else blk: {
+            // `Clock.Timestamp.toClock` in Zig 0.16 passes its wrapper where
+            // `Io.Timestamp.durationTo` expects the raw timestamp. Spell out
+            // the same conversion until that helper is fixed upstream.
+            const now_old = deadline.clock.now(io);
+            const now_awake = std.Io.Clock.awake.now(io);
+            const remaining = now_old.durationTo(deadline.raw);
+            break :blk now_awake.addDuration(remaining).nanoseconds;
+        };
+        const ns = std.math.cast(i64, awake_ns) orelse unarmed;
+        self.deadline.store(ns, .release);
+        self.wake(io);
+    }
+
+    fn arm(self: *Watch, io: std.Io, duration: std.Io.Duration) void {
+        self.set(io, .{ .duration = .{ .raw = duration, .clock = .awake } });
+    }
+
+    fn disarm(self: *Watch, io: std.Io) void {
+        self.deadline.store(unarmed, .release);
+        self.wake(io);
+    }
+
+    fn finish(self: *Watch, io: std.Io) void {
+        self.finished.store(true, .release);
+        self.wake(io);
+    }
+
+    /// Blocks until the connection finishes, or `error.Timeout` if it
+    /// overruns the deadline it last published.
+    fn wait(self: *Watch, io: std.Io) (std.Io.Cancelable || std.Io.Timeout.Error)!void {
+        while (true) {
+            const generation = self.generation.load(.acquire);
+            if (self.finished.load(.acquire)) return;
+            const deadline = self.deadline.load(.acquire);
+
+            const timeout: std.Io.Timeout = if (deadline == unarmed) .none else .{
+                .deadline = .{ .raw = .{ .nanoseconds = deadline }, .clock = .awake },
+            };
+            try io.futexWaitTimeout(u32, &self.generation.raw, generation, timeout);
+
+            // The wait does not report why it returned, and `generation` is
+            // only its wakeup token: `arm` publishes the deadline first, so an
+            // unchanged generation does not mean an unchanged deadline. Decide
+            // on what is published now, not on what was captured above.
+            if (self.finished.load(.acquire)) return;
+            const current = self.deadline.load(.acquire);
+            if (current == unarmed) continue;
+            if (std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds >= current) return error.Timeout;
+        }
+    }
+};
+
+/// Bounds how long a connection may spend on any one blocking step.
+///
+/// zio arms a timer against the running task. `std.Io` has no deadline for a
+/// stream read, only cancelation, so elsewhere the deadline goes to a second
+/// task that cancels this one when it passes.
+const Timer = if (have_auto_cancel) struct {
+    inner: zio.AutoCancel = .init,
+
+    fn init(_: ?*Watch) @This() {
+        return .{};
+    }
+
+    fn set(self: *@This(), io: std.Io, timeout: std.Io.Timeout) void {
+        // TODO(zio): drop the clear once we require a zio with
+        // lalinsky/zio#657. `set` is meant to handle a re-arm itself, and
+        // stopped: it arms on the executor the task is on now, so re-arming
+        // after a migration asks one loop for a timer live in another's heap.
+        self.inner.clear();
+        const duration = timeout.toDurationFromNow(io) orelse return;
+        const raw_ms = @divFloor(duration.raw.nanoseconds, std.time.ns_per_ms);
+        const milliseconds = std.math.cast(u64, @max(raw_ms, 0)) orelse std.math.maxInt(u64);
+        self.inner.set(.fromMilliseconds(milliseconds));
+    }
+
+    fn clear(self: *@This(), _: std.Io) void {
+        self.inner.clear();
+    }
+} else struct {
+    /// Null when no deadline was configured.
+    watch: ?*Watch = null,
+
+    fn init(w: ?*Watch) @This() {
+        return .{ .watch = w };
+    }
+
+    fn set(self: *@This(), io: std.Io, timeout: std.Io.Timeout) void {
+        const w = self.watch orelse return;
+        w.set(io, timeout);
+    }
+
+    fn clear(self: *@This(), io: std.Io) void {
+        const w = self.watch orelse return;
+        w.disarm(io);
+    }
+};
+
+fn setRequestTimeout(context: *anyopaque, io: std.Io, timeout: std.Io.Timeout) void {
+    const timer: *Timer = @ptrCast(@alignCast(context));
+    timer.set(io, timeout);
+}
+
 pub fn Server(comptime Ctx: type) type {
     const MiddlewareItem = struct {
         middleware: Middleware(Ctx),
@@ -315,6 +446,13 @@ pub fn Server(comptime Ctx: type) type {
                 }
             };
 
+            if (self.config.max_connections) |max| {
+                if (max == 0) {
+                    log.err("config.max_connections is 0, so no connection could ever be served", .{});
+                    return error.NoConnectionsAllowed;
+                }
+            }
+
             var server = switch (addr) {
                 .ip => |ip| try ip.listen(self.io, self.config.listen),
                 .unix => |unix| try unix.listen(self.io, .{}),
@@ -340,6 +478,11 @@ pub fn Server(comptime Ctx: type) type {
             var backoff_ms: u64 = 0;
 
             while (true) {
+                self.waitForConnectionSlot() catch |err| {
+                    self.drainConnections();
+                    return err;
+                };
+
                 const stream = server.accept(self.io) catch |err| switch (err) {
                     error.Canceled => {
                         self.drainConnections();
@@ -384,7 +527,7 @@ pub fn Server(comptime Ctx: type) type {
                 _ = self.active_connections.fetchAdd(1, .acq_rel);
                 group.concurrent(self.io, handleConnectionWrapper, .{ self, stream }) catch |err| {
                     log.err("Failed to spawn connection handler: {}", .{err});
-                    _ = self.active_connections.fetchSub(1, .acq_rel);
+                    self.releaseConnectionSlot();
                     stream.close(self.io);
                     continue;
                 };
@@ -444,9 +587,63 @@ pub fn Server(comptime Ctx: type) type {
             }
         }
 
+        /// Blocks while every connection slot is taken. Not accepting is the
+        /// backpressure: what arrives meanwhile waits in the kernel's accept
+        /// queue, `listen.kernel_backlog` deep.
+        fn waitForConnectionSlot(self: *Self) std.Io.Cancelable!void {
+            const max = self.config.max_connections orelse return;
+            while (true) {
+                const active = self.active_connections.load(.acquire);
+                if (active < max) return;
+                log.debug("At the {d} connection cap; waiting for a slot", .{max});
+                try self.io.futexWait(u32, &self.active_connections.raw, active);
+            }
+        }
+
+        /// Wakes whoever is waiting for one: the accept loop, or the drain.
+        fn releaseConnectionSlot(self: *Self) void {
+            _ = self.active_connections.fetchSub(1, .acq_rel);
+            self.io.futexWake(u32, &self.active_connections.raw, 1);
+        }
+
         fn handleConnectionWrapper(self: *Self, stream: std.Io.net.Stream) std.Io.Cancelable!void {
-            handleConnection(self, stream) catch |err| {
-                if (err == error.Canceled) return error.Canceled;
+            if (comptime have_auto_cancel) return runConnection(self, stream, null);
+
+            if (self.config.timeout.request == null and self.config.timeout.keepalive == null) {
+                return runConnection(self, stream, null);
+            }
+
+            var watch: Watch = .{};
+            var future = self.io.concurrent(runConnection, .{ self, stream, &watch }) catch |err| {
+                log.warn("No task to watch the connection deadline: {}; refusing", .{err});
+                self.releaseConnectionSlot();
+                stream.close(self.io);
+                return;
+            };
+            defer future.cancel(self.io);
+
+            watch.wait(self.io) catch |err| switch (err) {
+                error.Timeout => {
+                    log.debug("Connection exceeded its deadline", .{});
+                    return;
+                },
+                error.Canceled => return error.Canceled,
+            };
+
+            // Collected here rather than by the defer, which would put a
+            // cancelation request to a task partway through its teardown.
+            future.await(self.io);
+        }
+
+        /// Runs on this task under zio, on a task of its own otherwise.
+        fn runConnection(self: *Self, stream: std.Io.net.Stream, watch: ?*Watch) void {
+            defer if (watch) |w| w.finish(self.io);
+
+            handleConnection(self, stream, watch) catch |err| {
+                if (err == error.Canceled) {
+                    log.debug("Connection canceled", .{});
+                    return;
+                }
                 // A peer disappearing mid-request is ordinary and would drown
                 // out the failures worth looking at.
                 if (Connection.isPeerGone(err)) {
@@ -457,11 +654,8 @@ pub fn Server(comptime Ctx: type) type {
             };
         }
 
-        pub fn handleConnection(self: *Self, stream: std.Io.net.Stream) !void {
-            defer {
-                _ = self.active_connections.fetchSub(1, .acq_rel);
-                self.io.futexWake(u32, &self.active_connections.raw, 1);
-            }
+        pub fn handleConnection(self: *Self, stream: std.Io.net.Stream, watch: ?*Watch) !void {
+            defer self.releaseConnectionSlot();
 
             defer stream.close(self.io);
 
@@ -477,6 +671,9 @@ pub fn Server(comptime Ctx: type) type {
             var connection: Connection = undefined;
             defer connection.deinit();
 
+            var timer: Timer = .init(watch);
+            defer timer.clear(self.io);
+
             // When TLS is configured, upgrade the accepted stream and run the
             // request loop over the cleartext reader/writer. Otherwise run it
             // directly over the raw stream.
@@ -490,10 +687,9 @@ pub fn Server(comptime Ctx: type) type {
                     // for as long as it likes -- cheaper for it than a
                     // slow request, which is bounded.
                     {
-                        var handshake: zio.AutoCancel = .init;
-                        defer handshake.clear();
+                        defer timer.clear(self.io);
                         if (self.config.timeout.request) |duration| {
-                            handshake.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                            timer.set(self.io, .{ .duration = .{ .raw = duration, .clock = .awake } });
                         }
 
                         const client_auth: ?ClientAuthRef = if (self.tls_client_ca) |*bundle| .{
@@ -531,12 +727,12 @@ pub fn Server(comptime Ctx: type) type {
                     // between keepalive requests reuses the connection's memory
                     // without touching the TLS buffers carved above.
                     var request_arena = std.heap.ArenaAllocator.init(connection.arena.allocator());
-                    return self.handleRequests(&connection, &request_arena, &needs_shutdown);
+                    return self.handleRequests(&connection, &request_arena, &needs_shutdown, &timer);
                 }
             }
 
             connection.initPlain(self.allocator, self.io, stream);
-            return self.handleRequests(&connection, &connection.arena, &needs_shutdown);
+            return self.handleRequests(&connection, &connection.arena, &needs_shutdown, &timer);
         }
 
         /// Runs the HTTP request/keepalive loop over a connection.
@@ -545,6 +741,7 @@ pub fn Server(comptime Ctx: type) type {
             connection: *Connection,
             arena: *std.heap.ArenaAllocator,
             needs_shutdown: *bool,
+            timer: *Timer,
         ) !void {
             var request: Request = .{
                 .arena = arena.allocator(),
@@ -553,6 +750,8 @@ pub fn Server(comptime Ctx: type) type {
                 .parser = undefined,
                 .config = self.config.request,
                 .remote_address = connection.stream.socket.address,
+                ._timeout_context = timer,
+                ._set_timeout = setRequestTimeout,
             };
 
             var parser: RequestParser = undefined;
@@ -563,9 +762,6 @@ pub fn Server(comptime Ctx: type) type {
 
             var request_count: usize = 0;
 
-            var timeout: zio.AutoCancel = .init;
-            defer timeout.clear();
-
             // Allocate initial buffer from arena
             connection.reader.buffer = request.arena.alloc(u8, self.config.request.buffer_size + body_read_reserve) catch |err| {
                 log.err("Failed to allocate read buffer: {}", .{err});
@@ -575,14 +771,12 @@ pub fn Server(comptime Ctx: type) type {
             while (true) {
                 request_count += 1;
 
+                // Cleared when unset, so a keepalive deadline does not carry
+                // into a request meant to be unbounded.
                 if (self.config.timeout.request) |duration| {
-                    // TODO(zio): drop once we require a zio with
-                    // lalinsky/zio#657. `set` is meant to handle a re-arm
-                    // itself, and stopped: it arms on the executor the task
-                    // is on now, so re-arming after a migration asks one
-                    // loop for a timer live in another's heap.
-                    timeout.clear();
-                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                    timer.set(self.io, .{ .duration = .{ .raw = duration, .clock = .awake } });
+                } else {
+                    timer.clear(self.io);
                 }
 
                 parseHeaders(connection.reader, &parser) catch |err| switch (err) {
@@ -697,9 +891,9 @@ pub fn Server(comptime Ctx: type) type {
                 connection.reader.end = 0;
 
                 if (self.config.timeout.keepalive) |duration| {
-                    // TODO(zio): drop with the one above, same reason.
-                    timeout.clear();
-                    timeout.set(.fromMilliseconds(@intCast(duration.toMilliseconds())));
+                    timer.set(self.io, .{ .duration = .{ .raw = duration, .clock = .awake } });
+                } else {
+                    timer.clear(self.io);
                 }
 
                 // Fill some data here, under the keepalive timeout
@@ -794,4 +988,47 @@ test "Connection: isPeerGone separates a departed peer from a real failure" {
     try std.testing.expect(!Connection.isPeerGone(error.TlsTruncated));
     try std.testing.expect(!Connection.isPeerGone(error.TlsBadRecordMac));
     try std.testing.expect(!Connection.isPeerGone(error.Canceled));
+}
+
+test "Watch: accepts an absolute deadline on another clock" {
+    const io = std.testing.io;
+    var watch: Watch = .{};
+    const deadline = std.Io.Clock.Timestamp.now(io, .real).addDuration(.{
+        .raw = .fromMilliseconds(50),
+        .clock = .real,
+    });
+    watch.set(io, .{ .deadline = deadline });
+    try std.testing.expectError(error.Timeout, watch.wait(io));
+}
+
+test "Watch: a deadline republished before its generation does not expire the connection" {
+    const io = std.testing.io;
+    var watch: Watch = .{};
+
+    // Leave enough room for the watcher and this test task both to be
+    // scheduled on a loaded runner before the first deadline arrives.
+    watch.arm(io, .fromMilliseconds(500));
+
+    var watcher = try io.concurrent(struct {
+        fn go(w: *Watch, i: std.Io) (std.Io.Cancelable || std.Io.Timeout.Error)!void {
+            return w.wait(i);
+        }
+    }.go, .{ &watch, io });
+    defer watcher.cancel(io) catch {};
+
+    // The watcher is now asleep holding the first deadline. Publish a later
+    // one the way `arm` does, but stop short of the generation bump -- the
+    // window between its store and its wake.
+    try io.sleep(.fromMilliseconds(25), .awake);
+    const later = std.math.cast(i64, std.Io.Timeout.toDeadline(
+        .{ .duration = .{ .raw = .fromMilliseconds(5_000), .clock = .awake } },
+        io,
+    ).deadline.raw.nanoseconds).?;
+    watch.deadline.store(later, .release);
+
+    // Well past the first deadline, and nowhere near the second.
+    try io.sleep(.fromMilliseconds(600), .awake);
+    watch.finish(io);
+
+    try watcher.await(io);
 }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -1421,3 +1421,193 @@ test "Server: a head ending exactly at the buffer end gets 431, not a panic" {
     // and panics on the first fill.
     try expectStatusForHeadOfLength(head_buffer_len, "HTTP/1.1 431 Request Header Fields Too Large\r", null);
 }
+
+/// Counts how many handlers are in flight at once, so a test can see whether
+/// the cap held.
+const ConcurrencyCtx = struct {
+    active: std.atomic.Value(u32) = .init(0),
+    peak: std.atomic.Value(u32) = .init(0),
+    served: std.atomic.Value(u32) = .init(0),
+
+    pub fn handle(ctx: *ConcurrencyCtx, req: *dusty.Request, res: *dusty.Response) !void {
+        const now = ctx.active.fetchAdd(1, .acq_rel) + 1;
+        _ = ctx.peak.fetchMax(now, .acq_rel);
+        // Long enough that the others are all waiting, so the cap is what
+        // limits overlap rather than the handlers being too brief to overlap.
+        try req.io.sleep(.fromMilliseconds(30), .awake);
+        _ = ctx.active.fetchSub(1, .acq_rel);
+        _ = ctx.served.fetchAdd(1, .acq_rel);
+        res.body = "OK";
+    }
+};
+
+test "Server: max_connections caps overlap without dropping anyone" {
+    const io = std.testing.io;
+    const S = dusty.Server(ConcurrencyCtx);
+    const clients = 8;
+    const cap = 2;
+
+    var ctx: ConcurrencyCtx = .{};
+    var server = S.init(std.testing.allocator, io, .{ .max_connections = cap }, &ctx);
+    defer server.deinit();
+    server.router.get("/", ConcurrencyCtx.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *S) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const One = struct {
+        fn run(s: *S, _io: std.Io) !void {
+            const stream = try s.address.ip.connect(_io, .{ .mode = .stream });
+            // Closing is what frees the slot.
+            defer stream.close(_io);
+
+            var write_buf: [256]u8 = undefined;
+            var writer = stream.writer(_io, &write_buf);
+            try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+            try writer.interface.flush();
+
+            var read_buf: [256]u8 = undefined;
+            var reader = stream.reader(_io, &read_buf);
+            const status_line = try reader.interface.takeDelimiterExclusive('\n');
+            try std.testing.expectEqualStrings("HTTP/1.1 200 OK\r", status_line);
+        }
+    };
+
+    const Fut = @TypeOf(try io.concurrent(One.run, .{ &server, io }));
+    var futures: [clients]Fut = undefined;
+    for (&futures) |*f| f.* = try io.concurrent(One.run, .{ &server, io });
+    var first_err: ?anyerror = null;
+    for (&futures) |*f| f.await(io) catch |err| {
+        if (first_err == null) first_err = err;
+    };
+    if (first_err) |err| return err;
+
+    try std.testing.expectEqual(@as(u32, clients), ctx.served.load(.acquire));
+    // Equality rather than <=, so this cannot pass by nothing overlapping.
+    try std.testing.expectEqual(@as(u32, cap), ctx.peak.load(.acquire));
+}
+
+test "Server: a max_connections of zero is refused at listen" {
+    const io = std.testing.io;
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{ .max_connections = 0 }, {});
+    defer server.deinit();
+    const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+    try std.testing.expectError(error.NoConnectionsAllowed, server.listen(addr));
+}
+
+/// Sends `head` and then stops, holding the connection open, and reports how
+/// long the server took to hang up on it. Returns null if the server answered
+/// instead of hanging up.
+fn millisUntilServerHangsUp(cfg: dusty.ServerConfig, head: []const u8) !?i64 {
+    const io = std.testing.io;
+    const S = dusty.Server(void);
+
+    var server = S.init(std.testing.allocator, io, cfg, {});
+    defer server.deinit();
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *S) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const stream = try server.address.ip.connect(io, .{ .mode = .stream });
+    defer stream.close(io);
+
+    var write_buf: [256]u8 = undefined;
+    var writer = stream.writer(io, &write_buf);
+    try writer.interface.writeAll(head);
+    try writer.interface.flush();
+
+    const started = std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds;
+
+    var read_buf: [256]u8 = undefined;
+    var reader = stream.reader(io, &read_buf);
+    var sink = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer sink.deinit();
+    _ = reader.interface.streamRemaining(&sink.writer) catch {};
+
+    if (sink.written().len != 0) return null;
+    const ended = std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds;
+    return @intCast(@divTrunc(ended - started, std.time.ns_per_ms));
+}
+
+test "Server: a stalled request head is cut off by timeout.request" {
+    // A head that never terminates.
+    const elapsed = try millisUntilServerHangsUp(
+        .{ .timeout = .{ .request = .fromMilliseconds(150) } },
+        "GET / HTTP/1.1\r\nHost: a\r\n",
+    ) orelse return error.ServerAnsweredInstead;
+
+    try std.testing.expect(elapsed >= 100);
+    try std.testing.expect(elapsed < 3000);
+}
+
+test "Server: an idle keepalive connection is cut off by timeout.keepalive" {
+    const io = std.testing.io;
+    const S = dusty.Server(void);
+
+    var server = S.init(std.testing.allocator, io, .{
+        .timeout = .{ .keepalive = .fromMilliseconds(150) },
+    }, {});
+    defer server.deinit();
+    server.router.get("/", struct {
+        fn handle(_: *dusty.Request, res: *dusty.Response) !void {
+            res.body = "OK";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *S) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            s.listen(addr) catch |err| {
+                if (err != error.Canceled) return err;
+            };
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const stream = try server.address.ip.connect(io, .{ .mode = .stream });
+    defer stream.close(io);
+
+    var write_buf: [256]u8 = undefined;
+    var writer = stream.writer(io, &write_buf);
+    try writer.interface.writeAll("GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+    try writer.interface.flush();
+
+    var read_buf: [256]u8 = undefined;
+    var reader = stream.reader(io, &read_buf);
+    const status_line = try reader.interface.takeDelimiterExclusive('\n');
+    try std.testing.expectEqualStrings("HTTP/1.1 200 OK\r", status_line);
+
+    const started = std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds;
+    var sink = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer sink.deinit();
+    _ = reader.interface.streamRemaining(&sink.writer) catch {};
+    const elapsed = @divTrunc(std.Io.Clock.Timestamp.now(io, .awake).raw.nanoseconds - started, std.time.ns_per_ms);
+
+    try std.testing.expect(elapsed >= 100);
+    try std.testing.expect(elapsed < 3000);
+}

--- a/src/zio_stub.zig
+++ b/src/zio_stub.zig
@@ -1,6 +1,7 @@
 // Stub `zio` module: provides the minimal API surface dusty needs to compile
-// and run without depending on the real zio package. Downstream apps that want
-// real timeouts override this import in their build.zig:
+// and run without depending on the real zio package. Downstream apps using the
+// zio runtime override this import so timeouts use zio.AutoCancel rather than
+// dusty's portable watchdog:
 //
 //     const zio_dep = b.dependency("zio", .{});
 //     const dusty_mod = b.dependency("dusty", .{}).module("dusty");
@@ -12,11 +13,15 @@ pub const Duration = struct {
     }
 };
 
+/// dusty checks for this to select its watchdog path over `AutoCancel`.
+pub const is_stub = true;
+
 pub const AutoCancel = struct {
     pub const init: AutoCancel = .{};
 
+    /// Never armed: `is_stub` selects the watchdog path.
     pub fn set(_: *AutoCancel, _: Duration) void {
-        @panic("dusty: timeout configured but no `zio` module injected; override in build.zig via `dusty_mod.addImport(\"zio\", zio_dep.module(\"zio\"))`");
+        unreachable;
     }
 
     pub fn clear(_: *AutoCancel) void {}


### PR DESCRIPTION
## Summary

Bound the resources consumed by accepted connections and make timeout protection work out of the box on both zio and standard `std.Io` backends. Handlers can also replace their active request deadline when protocols such as WebSockets need an inactivity timeout instead of one fixed request budget.

## Connection backpressure

- add `ServerConfig.max_connections`, defaulting to 10,000
- pause the accept loop at the cap so excess clients wait in the kernel accept queue instead of being accepted and dropped
- reject a zero cap and reuse the active-connection futex for slot wakeups and graceful shutdown

## Portable timeouts

- retain the existing zio `AutoCancel` implementation
- add a watchdog task for other `std.Io` backends that tracks re-armed deadlines and cancels the connection task when the current deadline expires
- apply the request timeout to TLS handshakes as a separate phase
- clear deadlines between request and keepalive phases so stale deadlines cannot leak into an unbounded phase
- refuse timed connections when the backend cannot provide the watchdog task

## Resilient defaults

- request timeout: 30 seconds, covering handler work and the response
- idle keepalive timeout: 60 seconds
- graceful shutdown timeout: 30 seconds, unchanged

On `std.Io.Threaded`, portable timeouts require a second OS thread per connection. zio arms the deadline on the connection task itself.

## Handler-controlled deadlines

`Request.setTimeout` accepts `std.Io.Timeout`, allowing a handler to:

- re-arm from now with `.duration`
- provide an exact absolute `.deadline`
- disable its deadline with `.none`

The request delegates this through a private server callback, keeping backend timer details out of the public request type. The WebSocket example re-arms a 60-second deadline before each receive, making it an inactivity timeout while leaving resilient defaults enabled for ordinary requests.

## Coverage

Adds coverage for connection limiting, finite timeout defaults, stalled request heads, idle keepalive connections, absolute deadlines, deadline re-arming, and request timeout forwarding. Documentation includes a dedicated Timeouts section and updated zio-stub guidance.

## Verification

- root build and all standard-backend examples pass
- real-zio httpbin build passes
- GitHub Actions matrix rerunning against the amended commit