### PR TITLE
server: arm the zio deadline on the timeout's own clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,10 @@ Long-lived handlers can use this as an inactivity timeout by re-arming it
 before each WebSocket message or event, without disabling the resilient server
 default for ordinary requests.
 
-On zio, deadlines cancel the connection task directly. Other I/O backends use
-a watchdog task; with `std.Io.Threaded`, that means a second OS thread for each
-connection while either request or keepalive timeouts are enabled.
+On zio, deadlines cancel the connection task directly, which needs a zio new
+enough to have `AutoCancel.setClock`. Other I/O backends use a watchdog task;
+with `std.Io.Threaded`, that means a second OS thread for each connection while
+either request or keepalive timeouts are enabled.
 
 ## Selecting the I/O Backend
 
@@ -172,7 +173,7 @@ it's missing any networking functionality, so use zio for now.
 Add it as a dependency:
 
 ```sh
-zig fetch --save "git+https://github.com/lalinsky/zio#v0.10.0"
+zig fetch --save "git+https://github.com/lalinsky/zio"
 ```
 
 In `build.zig`, add the zio module:

--- a/examples/httpbin/build.zig.zon
+++ b/examples/httpbin/build.zig.zon
@@ -8,8 +8,8 @@
             .path = "../..",
         },
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio?ref=v0.17.0#a2b134a7abe35d9b29e8578fad30adc7a026fb4e",
-            .hash = "zio-0.17.0-xHbVVKr9JQBFsFjx4hcL4z3BkqyBkonICNTz5DdJxhE2",
+            .url = "git+https://github.com/lalinsky/zio#5de2c447a4b4d164aa69a549c1ce23747a519c2b",
+            .hash = "zio-0.17.0-xHbVVI7PKAAeHETyItdYdWkpva-0kdDb96vLa5vCHtuh",
         },
     },
     .paths = .{

--- a/src/server.zig
+++ b/src/server.zig
@@ -290,16 +290,10 @@ const Timer = if (have_auto_cancel) struct {
         return .{};
     }
 
-    fn set(self: *@This(), io: std.Io, timeout: std.Io.Timeout) void {
-        // TODO(zio): drop the clear once we require a zio with
-        // lalinsky/zio#657. `set` is meant to handle a re-arm itself, and
-        // stopped: it arms on the executor the task is on now, so re-arming
-        // after a migration asks one loop for a timer live in another's heap.
-        self.inner.clear();
-        const duration = timeout.toDurationFromNow(io) orelse return;
-        const raw_ms = @divFloor(duration.raw.nanoseconds, std.time.ns_per_ms);
-        const milliseconds = std.math.cast(u64, @max(raw_ms, 0)) orelse std.math.maxInt(u64);
-        self.inner.set(.fromMilliseconds(milliseconds));
+    fn set(self: *@This(), _: std.Io, timeout: std.Io.Timeout) void {
+        // `Timeout.fromStd` keeps the value clockless and `Clock.fromStdTimeout`
+        // carries the clock, which is how zio wants the two halves.
+        self.inner.setClock(.fromStd(timeout), .fromStdTimeout(timeout));
     }
 
     fn clear(self: *@This(), _: std.Io) void {

--- a/src/zio_stub.zig
+++ b/src/zio_stub.zig
@@ -7,20 +7,28 @@
 //     const dusty_mod = b.dependency("dusty", .{}).module("dusty");
 //     dusty_mod.addImport("zio", zio_dep.module("zio"));
 
-pub const Duration = struct {
-    pub fn fromMilliseconds(_: i64) Duration {
+const std = @import("std");
+
+/// dusty checks for this to select its watchdog path over `AutoCancel`.
+pub const is_stub = true;
+
+pub const Timeout = struct {
+    pub fn fromStd(_: std.Io.Timeout) Timeout {
         return .{};
     }
 };
 
-/// dusty checks for this to select its watchdog path over `AutoCancel`.
-pub const is_stub = true;
+pub const Clock = struct {
+    pub fn fromStdTimeout(_: std.Io.Timeout) Clock {
+        return .{};
+    }
+};
 
 pub const AutoCancel = struct {
     pub const init: AutoCancel = .{};
 
     /// Never armed: `is_stub` selects the watchdog path.
-    pub fn set(_: *AutoCancel, _: Duration) void {
+    pub fn setClock(_: *AutoCancel, _: Timeout, _: Clock) void {
         unreachable;
     }
 


### PR DESCRIPTION
Follow-up to lalinsky/zio#717, which added `AutoCancel.setClock`.

## Problem

`Request.setTimeout` takes a `std.Io.Timeout`, so a handler can hand it an absolute deadline on any clock. The watchdog path keeps that clock and lets the backend resolve it. The zio path could not, because `AutoCancel` only ever armed on the monotonic clock, so it had to flatten the timeout:

```zig
self.inner.clear();
const duration = timeout.toDurationFromNow(io) orelse return;
const raw_ms = @divFloor(duration.raw.nanoseconds, std.time.ns_per_ms);
const milliseconds = std.math.cast(u64, @max(raw_ms, 0)) orelse std.math.maxInt(u64);
self.inner.set(.fromMilliseconds(milliseconds));
```

`toDurationFromNow` collapsed an absolute `.real` deadline into a relative monotonic duration measured at arm time, so a settable clock stopped being settable the moment it was armed and a later wall-clock adjustment did not move it. The conversion to whole milliseconds floored anything under 1ms to zero. The same `Request.setTimeout(.{ .deadline = ... })` call therefore behaved differently depending on which runtime the application linked.

## Change

zio now takes the clock alongside the timeout, so the whole thing is a pass-through:

```zig
self.inner.setClock(.fromStd(timeout), .fromStdTimeout(timeout));
```

`Timeout.fromStd` keeps the value clockless and `Clock.fromStdTimeout` carries the clock, which is the split zio wants.

The `clear` before the arm goes with it. It worked around `set` refusing to re-arm a timer still live in another executor's heap after a migration; `AutoCancel.set` now does that itself, so the `TODO(zio)` pointing at lalinsky/zio#657 is stale.

Also repins the httpbin example on a zio with `setClock`, and refreshes `src/zio_stub.zig` to the surface dusty now calls (`Duration` had no callers left). The README's dependency snippet pinned v0.10.0, which predates every API here; it is refless now, with a note that the zio deadline path needs a zio new enough to have `AutoCancel.setClock`.

## Testing

Both backends, behaviour rather than just linkage:

- Stub/watchdog path: `./check.sh`, 308/308.
- zio path: httpbin builds, and two requests over one connection (`num_connects=0` on the second, so the keepalive is reused) exercise `setClock` for the request deadline twice plus the keepalive arm and disarm.
- The guarantee that matters: a connection held open with an unterminated request head is closed at **30.0s**, exactly `timeout.request`'s default. A wrong clock would either fire immediately or never.

## Note

The example pins a bare commit rather than a tag, because `setClock` is unreleased. Worth moving to a tag at the next zio release.