### PR TITLE
Fold content decoding into the body reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The server API is inspired by Karl Seguin's [http.zig](https://github.com/karlse
 - Router with support for parameters and wildcards
 - Supports HTTP/1.0 and HTTP/1.1
 - Supports chunked transfer encoding in both request/response bodies
+- Transparent gzip/deflate decoding of request and response bodies
 - Server-Sent Events (SSE) for streaming responses
 - WebSocket support (RFC 6455)
 - HTTP/HTTPS client with connection pooling

--- a/check.sh
+++ b/check.sh
@@ -81,6 +81,12 @@ zig build "${BUILD_ARGS[@]}"
 echo "=== Building examples ==="
 zig build examples "${BUILD_ARGS[@]}"
 
+# Its own build.zig and its own zio, so the top-level build does not reach
+# it and an API change can compile everywhere else and still break it.
+# Takes no -Dzio_backend.
+echo "=== Building httpbin example ==="
+(cd examples/httpbin && zig build)
+
 echo "=== Running unit tests ==="
 if [ -n "$TEST_FILTER" ]; then
     echo "Running unit tests with filter: $TEST_FILTER"

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -40,7 +40,8 @@ fn handlePost(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {
     ctx.counter += 1;
 
     // Read the request body
-    var reader = try req.reader();
+    var read_buf: [1024]u8 = undefined;
+    var reader = try req.reader(&read_buf);
     const body = try reader.interface.allocRemaining(req.arena, .limited(1024 * 1024));
 
     if (body.len > 0) {

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -40,7 +40,7 @@ fn handlePost(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {
     ctx.counter += 1;
 
     // Read the request body
-    var reader = req.reader();
+    var reader = try req.reader();
     const body = try reader.interface.allocRemaining(req.arena, .limited(1024 * 1024));
 
     if (body.len > 0) {

--- a/examples/client.zig
+++ b/examples/client.zig
@@ -30,10 +30,10 @@ pub fn main(init: std.process.Init) !void {
 
     std.debug.print("\n", .{});
 
-    const body_reader = response.reader();
+    var body_reader = try response.reader();
     var write_buf: [8192]u8 = undefined;
     var out = std.Io.File.stdout().writer(io, &write_buf);
-    const total_bytes = try body_reader.streamRemaining(&out.interface);
+    const total_bytes = try body_reader.interface.streamRemaining(&out.interface);
     try out.interface.flush();
     std.debug.print("Total bytes: {d}\n", .{total_bytes});
 }

--- a/examples/client.zig
+++ b/examples/client.zig
@@ -30,7 +30,8 @@ pub fn main(init: std.process.Init) !void {
 
     std.debug.print("\n", .{});
 
-    var body_reader = try response.reader();
+    var read_buf: [8192]u8 = undefined;
+    var body_reader = try response.reader(&read_buf);
     var write_buf: [8192]u8 = undefined;
     var out = std.Io.File.stdout().writer(io, &write_buf);
     const total_bytes = try body_reader.interface.streamRemaining(&out.interface);

--- a/examples/httpbin/src/main.zig
+++ b/examples/httpbin/src/main.zig
@@ -316,7 +316,8 @@ fn handleSse(_: *Ctx, req: *Request, res: *Response) !void {
     const n = @min(req.params.getInt(usize, "n") orelse
         return fail(res, .bad_request, "Invalid count"), max_stream_lines);
 
-    var events = try res.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var events = try res.startEventStream(&event_buf);
     for (0..n) |i| {
         var id_buf: [24]u8 = undefined;
         var data_buf: [64]u8 = undefined;

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -28,8 +28,10 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
         if (std.ascii.eqlIgnoreCase(key, "connection") or
             std.ascii.eqlIgnoreCase(key, "keep-alive") or
             std.ascii.eqlIgnoreCase(key, "transfer-encoding") or
-            // The client decompresses transparently, so the upstream
-            // length does not describe what we are about to send.
+            // The server decoded the body on the way in, so neither what
+            // the client coded it as nor the length it measured describes
+            // what we are about to send upstream.
+            std.ascii.eqlIgnoreCase(key, "content-encoding") or
             std.ascii.eqlIgnoreCase(key, "content-length") or
             std.ascii.eqlIgnoreCase(key, "upgrade") or
             std.ascii.eqlIgnoreCase(key, "proxy-connection") or
@@ -74,8 +76,9 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
         if (std.ascii.eqlIgnoreCase(key, "connection") or
             std.ascii.eqlIgnoreCase(key, "keep-alive") or
             std.ascii.eqlIgnoreCase(key, "transfer-encoding") or
-            // The client decompresses transparently, so the upstream
-            // length does not describe what we are about to send.
+            // `Content-Encoding` is forwarded: the upstream fetch asked for
+            // no decoding, so the body still is what it says. The length is
+            // not, because the body goes out chunked.
             std.ascii.eqlIgnoreCase(key, "content-length") or
             std.ascii.eqlIgnoreCase(key, "upgrade") or
             std.ascii.eqlIgnoreCase(key, "proxy-connection"))

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -43,7 +43,7 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     upstream_req.headers = &headers;
 
     // Forward request body if present
-    var reader = req.reader();
+    var reader = try req.reader();
     const body = try reader.interface.allocRemaining(req.arena, .limited(10 * 1024 * 1024)); // 10MB limit
     if (body.len > 0) {
         upstream_req.body = body;
@@ -86,10 +86,10 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     }
 
     // Stream response body
-    const body_reader = upstream_res.reader();
+    var body_reader = try upstream_res.reader();
     var buf: [4096]u8 = undefined;
     var body_writer = try res.stream(&buf);
-    const bytes_written = try body_reader.streamRemaining(&body_writer.interface);
+    const bytes_written = try body_reader.interface.streamRemaining(&body_writer.interface);
     try body_writer.end();
 
     std.log.info("Proxied response: {d} bytes", .{bytes_written});

--- a/examples/proxy.zig
+++ b/examples/proxy.zig
@@ -43,7 +43,8 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     upstream_req.headers = &headers;
 
     // Forward request body if present
-    var reader = try req.reader();
+    var read_buf: [4096]u8 = undefined;
+    var reader = try req.reader(&read_buf);
     const body = try reader.interface.allocRemaining(req.arena, .limited(10 * 1024 * 1024)); // 10MB limit
     if (body.len > 0) {
         upstream_req.body = body;
@@ -86,7 +87,8 @@ fn handleProxy(ctx: *AppContext, req: *http.Request, res: *http.Response) !void 
     }
 
     // Stream response body
-    var body_reader = try upstream_res.reader();
+    var upstream_buf: [4096]u8 = undefined;
+    var body_reader = try upstream_res.reader(&upstream_buf);
     var buf: [4096]u8 = undefined;
     var body_writer = try res.stream(&buf);
     const bytes_written = try body_reader.interface.streamRemaining(&body_writer.interface);

--- a/examples/sse.zig
+++ b/examples/sse.zig
@@ -6,7 +6,8 @@ const AppContext = struct {
 };
 
 fn handleEvents(ctx: *AppContext, req: *http.Request, res: *http.Response) !void {
-    var stream = try res.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try res.startEventStream(&event_buf);
 
     try stream.send("connected", .{});
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -381,7 +381,12 @@ pub const Connection = struct {
     read_buffer: []u8,
     write_buffer: []u8,
 
-    // Pointers to the actual reader/writer interfaces used for HTTP I/O
+    // Pointers to the actual reader/writer interfaces used for HTTP I/O.
+    //
+    // Public, and bare interfaces, so they can only report
+    // `ReadFailed`/`WriteFailed`. That is allowed here because there is no
+    // layer above them to lose the answer: `getReadError`/`getWriteError`
+    // beside them resolve what actually failed.
     reader: *std.Io.Reader,
     writer: *std.Io.Writer,
 
@@ -1638,6 +1643,10 @@ test "Client: no std.Io sentinel escapes its public API" {
         ErrorSetOf(Client.connectWebSocket),
         ErrorSetOf(WebSocketClient.send),
         ErrorSetOf(WebSocketClient.receive),
+        // The wrapper a streaming caller resolves through, not just the
+        // functions that resolve for them.
+        ClientResponse.ReadError,
+        ResponseBodyReader.Error,
     }) |Set| {
         inline for (@typeInfo(Set).error_set.?) |e| {
             try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));

--- a/src/client.zig
+++ b/src/client.zig
@@ -684,7 +684,6 @@ pub const ClientResponse = struct {
     _body: ?[]const u8 = null,
     _body_read: bool = false,
 
-    _body_reader_buffer: [1024]u8 = undefined,
     // Set up on the first body read that calls for decoding, and kept so a
     // second `reader()` does not build a second decoder over the same body.
     _decode: ?*ResponseBodyReader.Decode = null,
@@ -733,7 +732,9 @@ pub const ClientResponse = struct {
             return self._body;
         }
 
-        var r = try self.reader();
+        // Nothing to stage: `allocRemaining` streams straight into the arena.
+        var no_buf: [0]u8 = .{};
+        var r = try self.reader(&no_buf);
         const result = r.interface.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
             error.ReadFailed => return r.err orelse error.Unexpected,
@@ -752,8 +753,14 @@ pub const ClientResponse = struct {
     /// The response body: transfer framing undone, and the content coding
     /// too unless `decompress` is off. Read through `.interface`, and
     /// `.err` says what an `error.ReadFailed` from it actually was.
-    pub fn reader(self: *ClientResponse) !ResponseBodyReader {
-        var r = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
+    ///
+    /// `buffer` is where bytes wait between the connection and the caller,
+    /// the way `Response.stream` takes one for the other direction. It is
+    /// what `peek` and the `take` family read out of, so size it for the
+    /// longest thing they need to see at once; an empty slice is fine for a
+    /// caller that only ever streams.
+    pub fn reader(self: *ClientResponse, buffer: []u8) !ResponseBodyReader {
+        var r = ResponseBodyReader.init(self.parser, self.transport, buffer);
 
         // Once the body is in memory there is nothing left on the wire, and
         // what is cached has already been decoded.
@@ -1607,7 +1614,8 @@ test "ClientResponse: a streaming read can be resolved without going through bod
 
     // Streaming the body rather than calling `body`, which is the case with
     // no other way to find out what happened.
-    var r = try response.reader();
+    var read_buf: [64]u8 = undefined;
+    var r = try response.reader(&read_buf);
     var sink: std.Io.Writer = .fixed(&[_]u8{});
     try std.testing.expectError(error.ReadFailed, r.interface.stream(&sink, .limited(64)));
 
@@ -1616,14 +1624,15 @@ test "ClientResponse: a streaming read can be resolved without going through bod
     try std.testing.expectEqual(error.BadGzipHeader, r.err.?);
 }
 
-test "ClientResponse: neither it nor its reader carries decoding state" {
+test "ClientResponse: neither it nor its reader carries a buffer or a decoder" {
     // `fetch` returns a `ClientResponse` by value and `reader` returns the
     // body reader by value, so both are copied per response whether or not
-    // anything was coded. The decoder and its 64K window are allocated when
-    // the headers call for them.
+    // anything was coded. The read buffer comes from the caller, and the
+    // decoder and its 64K window are allocated when the headers call for
+    // them -- so neither of these grows with either.
     try std.testing.expect(@sizeOf(ClientResponse) < std.compress.flate.max_window_len);
     try std.testing.expect(@sizeOf(ResponseBodyReader) < std.compress.flate.max_window_len);
-    // Which is the thing they would otherwise be carrying.
+    // Which is what they would otherwise be carrying.
     try std.testing.expect(@sizeOf(ResponseBodyReader.Decode) > std.compress.flate.max_window_len);
 }
 
@@ -1757,7 +1766,8 @@ test "ClientResponse.reader: streaming read" {
         .max_response_size = 1024,
     };
 
-    var body_reader = try response.reader();
+    var read_buf: [64]u8 = undefined;
+    var body_reader = try response.reader(&read_buf);
 
     // Read in chunks
     var buf: [5]u8 = undefined;
@@ -1797,7 +1807,8 @@ test "ClientResponse.reader: after body() returns cached data" {
     try std.testing.expectEqualStrings("hello", body.?);
 
     // Now reader should return cached body
-    var body_reader = try response.reader();
+    var read_buf: [64]u8 = undefined;
+    var body_reader = try response.reader(&read_buf);
     const cached = try body_reader.interface.allocRemaining(arena.allocator(), .unlimited);
     try std.testing.expectEqualStrings("hello", cached);
 }

--- a/src/client.zig
+++ b/src/client.zig
@@ -13,6 +13,7 @@ const Method = http.Method;
 const Status = http.Status;
 const Headers = http.Headers;
 const ContentType = http.ContentType;
+const ContentEncoding = http.ContentEncoding;
 
 const WebSocket = @import("websocket.zig").WebSocket;
 
@@ -722,6 +723,34 @@ pub const ClientResponse = struct {
         return self.parsed.content_type;
     }
 
+    /// The coding the body arrived in. Undone by the body reader unless
+    /// `decompress` is off, in which case reading the body yields what the
+    /// wire carried.
+    ///
+    /// Once it is being undone the `Content-Encoding` header is removed,
+    /// because it would describe the body a caller is about to read as
+    /// something it is not. This still says what arrived.
+    pub fn contentEncoding(self: *const ClientResponse) ContentEncoding {
+        return self.parsed.content_encoding;
+    }
+
+    /// How long the body was on the wire, when the headers said. Removed
+    /// from the headers alongside the coding for the same reason, and kept
+    /// here for the same one.
+    pub fn contentLength(self: *const ClientResponse) ?usize {
+        return self.parsed.content_length;
+    }
+
+    /// Both of these describe the body as it arrived, and it is not going
+    /// to arrive that way any more: what the caller reads is decoded, and a
+    /// longer or shorter number of bytes. Leaving them is how a proxy comes
+    /// to forward plain bytes labelled `gzip`. `contentEncoding` and
+    /// `contentLength` keep the answer for a caller that wants it.
+    fn dropEncodedBodyHeaders(self: *ClientResponse) void {
+        _ = self.parsed.headers.remove("Content-Encoding");
+        _ = self.parsed.headers.remove("Content-Length");
+    }
+
     /// What a failed body read can turn out to be, sentinels resolved. The
     /// reader `reader` hands out carries one of these in `.err`.
     pub const ReadError = ResponseBodyReader.Error;
@@ -783,6 +812,7 @@ pub const ClientResponse = struct {
             r.decode = decode;
         } else if (self.decompress) {
             try r.startDecoding(self.arena, self.parsed.content_encoding);
+            if (r.decode != null) self.dropEncodedBodyHeaders();
             self._decode = r.decode;
         }
         return r;
@@ -1859,6 +1889,43 @@ test "ClientResponse.body: gzip decompression" {
 
     const body = try response.body();
     try std.testing.expectEqualStrings("hello", body.?);
+}
+
+test "ClientResponse: decoding takes the headers that described the encoded body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
+    const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
+
+    var parsed: ParsedResponse = .{ .arena = arena.allocator() };
+    var parser: ResponseParser = undefined;
+    try parser.init(&parsed, 64);
+
+    try parseResponseHeaders(&reader, &parser);
+
+    var response = ClientResponse{
+        .arena = arena.allocator(),
+        .parser = &parser,
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parsed = &parsed,
+        .max_response_size = 1024,
+    };
+
+    try std.testing.expectEqualStrings("gzip", response.headers().get("Content-Encoding").?);
+
+    const body = try response.body();
+    try std.testing.expectEqualStrings("hello", body.?);
+
+    // A proxy forwarding these would send five plain bytes labelled as
+    // twenty-five gzipped ones.
+    try std.testing.expectEqual(@as(?[]const u8, null), response.headers().get("Content-Encoding"));
+    try std.testing.expectEqual(@as(?[]const u8, null), response.headers().get("Content-Length"));
+
+    // What arrived is still answerable, just not as a header.
+    try std.testing.expectEqual(ContentEncoding.gzip, response.contentEncoding());
+    try std.testing.expectEqual(@as(?usize, 25), response.contentLength());
 }
 
 test "ClientResponse.body: gzip decompression disabled" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -679,15 +679,10 @@ pub const ClientResponse = struct {
     _body: ?[]const u8 = null,
     _body_read: bool = false,
 
-    // Body reader state (stored here for stable address needed by decompressor)
-    _body_reader: ResponseBodyReader = undefined,
     _body_reader_buffer: [1024]u8 = undefined,
-    _body_reader_init: bool = false,
-
-    // Decompression state
-    _decompressor: std.compress.flate.Decompress = undefined,
-    _decompressor_buffer: [std.compress.flate.max_window_len]u8 = undefined,
-    _decompressor_init: bool = false,
+    // Set up on the first body read that calls for decoding, and kept so a
+    // second `reader()` does not build a second decoder over the same body.
+    _decode: ?*ResponseBodyReader.Decode = null,
 
     // Connection reference for cleanup (optional for testing)
     owner: ?*Connection = null,
@@ -722,50 +717,21 @@ pub const ClientResponse = struct {
         return self.parsed.content_type;
     }
 
+    /// What a failed body read can turn out to be, sentinels resolved. The
+    /// reader `reader` hands out carries one of these in `.err`.
+    pub const ReadError = ResponseBodyReader.Error;
+
     /// Read the entire response body into memory.
     /// Result is cached for subsequent calls.
-    /// Walks down from the topmost layer that ran to whichever one recorded
-    /// what went wrong. Which layers those are depends on what `reader`
-    /// handed out: a corrupt gzip stream fails in the decompressor, above a
-    /// body reader that saw nothing wrong.
-    ///
-    /// Errors rather than returning one, so its set can be inferred; the same
-    /// shape `Connection.checkReadError` has.
-    fn checkRead(self: *ClientResponse) !void {
-        if (self._decompressor_init) {
-            if (self._decompressor.err) |e| switch (e) {
-                // The decompressor stores whatever it was handed, and what
-                // the body reader hands it on failure is the sentinel. So
-                // this means "the layer below failed, keep descending" --
-                // the same thing tls.zig's `TransportReadFailed` means, and
-                // it leaves the inferred error set the same way.
-                error.ReadFailed => {},
-                else => |cause| return cause,
-            };
-        }
-        if (self._body_reader.err) |e| return e;
-    }
-
-    /// The error type `getReadError` yields.
-    pub const ReadError = @typeInfo(@TypeOf(checkRead(undefined))).error_union.error_set;
-
-    /// The real error behind an `error.ReadFailed` from `reader`, if any
-    /// layer recorded one. `body` resolves for you; a caller streaming the
-    /// body itself has to ask, since the interface it reads through cannot
-    /// say more than that a read failed.
-    pub fn getReadError(self: *ClientResponse) ?ReadError {
-        if (checkRead(self)) |_| return null else |e| return e;
-    }
-
     pub fn body(self: *ClientResponse) !?[]const u8 {
         if (self._body_read) {
             return self._body;
         }
 
-        const r = self.reader();
-        const result = r.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
+        var r = try self.reader();
+        const result = r.interface.allocRemaining(self.arena, .limited(self.max_response_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.ResponseTooLarge,
-            error.ReadFailed => return self.getReadError() orelse error.Unexpected,
+            error.ReadFailed => return r.err orelse error.Unexpected,
             else => |e| return e,
         };
 
@@ -778,38 +744,26 @@ pub const ClientResponse = struct {
         return result;
     }
 
-    /// Get a streaming body reader. Returns decompressed data if server sent
-    /// compressed response and decompress option was enabled.
-    pub fn reader(self: *ClientResponse) *std.Io.Reader {
-        // If body has already been read, return a reader for the cached body
+    /// The response body: transfer framing undone, and the content coding
+    /// too unless `decompress` is off. Read through `.interface`, and
+    /// `.err` says what an `error.ReadFailed` from it actually was.
+    pub fn reader(self: *ClientResponse) !ResponseBodyReader {
+        var r = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
+
+        // Once the body is in memory there is nothing left on the wire, and
+        // what is cached has already been decoded.
         if (self._body_read) {
-            const cached_body = self._body orelse &.{};
-            self._body_reader = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
-            self._body_reader.interface = std.Io.Reader.fixed(cached_body);
-            return &self._body_reader.interface;
+            r.interface = .fixed(self._body orelse &.{});
+            return r;
         }
 
-        // Initialize body reader if not already done
-        if (!self._body_reader_init) {
-            self._body_reader = ResponseBodyReader.init(self.parser, self.transport, &self._body_reader_buffer);
-            self._body_reader_init = true;
+        if (self._decode) |decode| {
+            r.decode = decode;
+        } else if (self.decompress) {
+            try r.startDecoding(self.arena, self.parsed.content_encoding);
+            self._decode = r.decode;
         }
-
-        // If decompression enabled and response is compressed, wrap with decompressor
-        if (self.decompress and self.parsed.content_encoding != .identity and !self._decompressor_init) {
-            self._decompressor = std.compress.flate.Decompress.init(
-                &self._body_reader.interface,
-                if (self.parsed.content_encoding == .gzip) .gzip else .zlib,
-                &self._decompressor_buffer,
-            );
-            self._decompressor_init = true;
-        }
-
-        if (self._decompressor_init) {
-            return &self._decompressor.reader;
-        }
-
-        return &self._body_reader.interface;
+        return r;
     }
 };
 
@@ -1138,6 +1092,8 @@ pub const Client = struct {
                 if (!conn.parser.isBodyComplete()) {
                     const max_drain = 2048;
                     var drain_buf: [1024]u8 = undefined;
+                    // No decoding: this is throwing the body away to keep the
+                    // connection, so what it would decode to does not matter.
                     var body_reader = ResponseBodyReader.init(&conn.parser, conn.transport(), &drain_buf);
                     _ = body_reader.interface.discardShort(max_drain + 1) catch |err| switch (err) {
                         error.ReadFailed => {
@@ -1646,10 +1602,24 @@ test "ClientResponse: a streaming read can be resolved without going through bod
 
     // Streaming the body rather than calling `body`, which is the case with
     // no other way to find out what happened.
-    const r = response.reader();
+    var r = try response.reader();
     var sink: std.Io.Writer = .fixed(&[_]u8{});
-    try std.testing.expectError(error.ReadFailed, r.stream(&sink, .limited(64)));
-    try std.testing.expectEqual(error.BadGzipHeader, response.getReadError().?);
+    try std.testing.expectError(error.ReadFailed, r.interface.stream(&sink, .limited(64)));
+
+    // Asked of the reader that was handed out, which is the point: a caller
+    // holding it needs nothing else to find out what a failed read was.
+    try std.testing.expectEqual(error.BadGzipHeader, r.err.?);
+}
+
+test "ClientResponse: neither it nor its reader carries decoding state" {
+    // `fetch` returns a `ClientResponse` by value and `reader` returns the
+    // body reader by value, so both are copied per response whether or not
+    // anything was coded. The decoder and its 64K window are allocated when
+    // the headers call for them.
+    try std.testing.expect(@sizeOf(ClientResponse) < std.compress.flate.max_window_len);
+    try std.testing.expect(@sizeOf(ResponseBodyReader) < std.compress.flate.max_window_len);
+    // Which is the thing they would otherwise be carrying.
+    try std.testing.expect(@sizeOf(ResponseBodyReader.Decode) > std.compress.flate.max_window_len);
 }
 
 test "Client: no std.Io sentinel escapes its public API" {
@@ -1778,17 +1748,17 @@ test "ClientResponse.reader: streaming read" {
         .max_response_size = 1024,
     };
 
-    const body_reader = response.reader();
+    var body_reader = try response.reader();
 
     // Read in chunks
     var buf: [5]u8 = undefined;
-    var n = try body_reader.readSliceShort(&buf);
+    var n = try body_reader.interface.readSliceShort(&buf);
     try std.testing.expectEqualStrings("hello", buf[0..n]);
 
-    n = try body_reader.readSliceShort(&buf);
+    n = try body_reader.interface.readSliceShort(&buf);
     try std.testing.expectEqualStrings(" worl", buf[0..n]);
 
-    n = try body_reader.readSliceShort(&buf);
+    n = try body_reader.interface.readSliceShort(&buf);
     try std.testing.expectEqualStrings("d", buf[0..n]);
 }
 
@@ -1818,8 +1788,8 @@ test "ClientResponse.reader: after body() returns cached data" {
     try std.testing.expectEqualStrings("hello", body.?);
 
     // Now reader should return cached body
-    const body_reader = response.reader();
-    const cached = try body_reader.allocRemaining(arena.allocator(), .unlimited);
+    var body_reader = try response.reader();
+    const cached = try body_reader.interface.allocRemaining(arena.allocator(), .unlimited);
     try std.testing.expectEqualStrings("hello", cached);
 }
 

--- a/src/client.zig
+++ b/src/client.zig
@@ -806,7 +806,6 @@ pub const ClientResponse = struct {
         // and whatever the first one had buffered is unreachable -- bytes off
         // the body, with nothing to say they went missing.
         std.debug.assert(!self._body_reader_taken); // one body reader per response
-        self._body_reader_taken = true;
 
         if (self._decode) |decode| {
             r.decode = decode;
@@ -815,6 +814,11 @@ pub const ClientResponse = struct {
             if (r.decode != null) self.dropEncodedBodyHeaders();
             self._decode = r.decode;
         }
+
+        // Claimed only once there is a reader to claim it for. A coding we
+        // cannot undo fails above, and nothing was read; a caller that
+        // handles that error has to be able to ask again.
+        self._body_reader_taken = true;
         return r;
     }
 };
@@ -1662,6 +1666,33 @@ test "ClientResponse: a streaming read can be resolved without going through bod
     // Asked of the reader that was handed out, which is the point: a caller
     // holding it needs nothing else to find out what a failed read was.
     try std.testing.expectEqual(error.BadGzipHeader, r.err.?);
+}
+
+test "ClientResponse.body: a body read that failed before it started can be asked for again" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_response = "HTTP/1.1 200 OK\r\nContent-Encoding: br\r\nContent-Length: 5\r\n\r\nhello";
+    var reader = try fixedMessageReader(arena.allocator(), raw_response);
+
+    var parsed: ParsedResponse = .{ .arena = arena.allocator() };
+    var parser: ResponseParser = undefined;
+    try parser.init(&parsed, 64);
+
+    try parseResponseHeaders(&reader, &parser);
+
+    var response = ClientResponse{
+        .arena = arena.allocator(),
+        .parser = &parser,
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parsed = &parsed,
+        .max_response_size = 1024,
+    };
+
+    // Nothing was read, so nothing was taken -- the server picked the
+    // encoding, and asking twice must not trip the one-reader assert.
+    try std.testing.expectError(error.UnsupportedContentEncoding, response.body());
+    try std.testing.expectError(error.UnsupportedContentEncoding, response.body());
 }
 
 test "ClientResponse: neither it nor its reader carries a buffer or a decoder" {

--- a/src/client.zig
+++ b/src/client.zig
@@ -687,6 +687,7 @@ pub const ClientResponse = struct {
     // Set up on the first body read that calls for decoding, and kept so a
     // second `reader()` does not build a second decoder over the same body.
     _decode: ?*ResponseBodyReader.Decode = null,
+    _body_reader_taken: bool = false,
 
     // Connection reference for cleanup (optional for testing)
     owner: ?*Connection = null,
@@ -759,6 +760,9 @@ pub const ClientResponse = struct {
     /// what `peek` and the `take` family read out of, so size it for the
     /// longest thing they need to see at once; an empty slice is fine for a
     /// caller that only ever streams.
+    ///
+    /// One per response. `body` takes it if you have not, so a caller that
+    /// streams cannot then ask for the body whole.
     pub fn reader(self: *ClientResponse, buffer: []u8) !ResponseBodyReader {
         var r = ResponseBodyReader.init(self.parser, self.transport, buffer);
 
@@ -768,6 +772,12 @@ pub const ClientResponse = struct {
             r.interface = .fixed(self._body orelse &.{});
             return r;
         }
+
+        // The buffer belongs to the caller, so a second reader starts empty
+        // and whatever the first one had buffered is unreachable -- bytes off
+        // the body, with nothing to say they went missing.
+        std.debug.assert(!self._body_reader_taken); // one body reader per response
+        self._body_reader_taken = true;
 
         if (self._decode) |decode| {
             r.decode = decode;
@@ -1660,6 +1670,16 @@ test "Client: no std.Io sentinel escapes its public API" {
         inline for (@typeInfo(Set).error_set.?) |e| {
             try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
             try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
+        }
+    }
+
+    // Not a sentinel, but not a cause either: reading a body, a stream that
+    // stopped early is `IncompleteBody`, and `EndOfStream` here would be
+    // read as the peer having hung up. `fetch` is excluded because a
+    // connection-close-delimited response can end that way for real.
+    inline for (.{ ClientResponse.ReadError, ResponseBodyReader.Error }) |Set| {
+        inline for (@typeInfo(Set).error_set.?) |e| {
+            try std.testing.expect(!std.mem.eql(u8, e.name, "EndOfStream"));
         }
     }
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -63,7 +63,8 @@ pub const ServerConfig = struct {
     /// `listen.kernel_backlog` deep. Null lifts the cap.
     ///
     /// Costs about `request.buffer_size + 8K` per connection, 33K more under
-    /// TLS.
+    /// TLS, and 70K more for a connection that receives a body with a
+    /// `Content-Encoding` while `request.decompress` is on.
     max_connections: ?u32 = 10_000,
     /// TLS configuration. When set, the server performs a TLS handshake on every
     /// accepted connection and speaks HTTPS. Requires the `use_tls` build option
@@ -121,13 +122,16 @@ pub const ServerConfig = struct {
         /// handler sees, so for a compressed request it bounds what was
         /// decoded rather than what arrived.
         max_body_size: usize = 1_048_576, // 1MB default
-        /// Undo `Content-Encoding` on request bodies. Turn off to read what
-        /// the wire carried; `Request.content_encoding` says what that is.
-        /// A coding we cannot undo fails the read with
-        /// `error.UnsupportedContentEncoding` either way.
+        /// Undo `Content-Encoding` on request bodies. A coding we cannot
+        /// undo fails the read with `error.UnsupportedContentEncoding`
+        /// rather than handing the handler bytes it would misread.
         ///
-        /// Costs a 64K sliding window from the connection's arena, on the
-        /// connections that actually receive a coded body and only once each.
+        /// Turn off to read what the wire carried, whatever it is;
+        /// `Request.content_encoding` says what that was.
+        ///
+        /// Costs about 70K from the connection's arena -- a 64K sliding
+        /// window and the decoder -- on the connections that actually
+        /// receive a coded body, and only once each.
         decompress: bool = true,
         /// Buffer size (bytes) for reading the request head: the request
         /// line and all headers. This is also the limit on it -- the parsed

--- a/src/config.zig
+++ b/src/config.zig
@@ -121,6 +121,12 @@ pub const ServerConfig = struct {
         /// Maximum size (bytes) for request body. Applies to the body a
         /// handler sees, so for a compressed request it bounds what was
         /// decoded rather than what arrived.
+        ///
+        /// Which is the limit worth enforcing, but note what it costs: a
+        /// connection can hold this much in its arena, and a compressed
+        /// request reaches it for a fraction of the bytes on the wire. Size
+        /// memory for `max_connections` of these, not for what a peer has
+        /// to send to get one.
         max_body_size: usize = 1_048_576, // 1MB default
         /// Undo `Content-Encoding` on request bodies. A coding we cannot
         /// undo fails the read with `error.UnsupportedContentEncoding`

--- a/src/config.zig
+++ b/src/config.zig
@@ -117,8 +117,18 @@ pub const ServerConfig = struct {
     };
 
     pub const Request = struct {
-        /// Maximum size (bytes) for request body
+        /// Maximum size (bytes) for request body. Applies to the body a
+        /// handler sees, so for a compressed request it bounds what was
+        /// decoded rather than what arrived.
         max_body_size: usize = 1_048_576, // 1MB default
+        /// Undo `Content-Encoding` on request bodies. Turn off to read what
+        /// the wire carried; `Request.content_encoding` says what that is.
+        /// A coding we cannot undo fails the read with
+        /// `error.UnsupportedContentEncoding` either way.
+        ///
+        /// Costs a 64K sliding window from the connection's arena, on the
+        /// connections that actually receive a coded body and only once each.
+        decompress: bool = true,
         /// Buffer size (bytes) for reading the request head: the request
         /// line and all headers. This is also the limit on it -- the parsed
         /// header names and values are slices into this buffer rather than

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -229,6 +229,10 @@ pub const RequestParser = struct {
             self.request.content_encoding = ContentEncoding.fromString(content_encoding);
         }
 
+        if (self.request.headers.get("Content-Length")) |content_length| {
+            self.request.content_length = std.fmt.parseInt(usize, content_length, 10) catch null;
+        }
+
         self.state.headers_complete = true;
         return c.HPE_PAUSED; // Always pause so we can track consumed bytes
     }
@@ -264,6 +268,7 @@ pub const ParsedResponse = struct {
     headers: Headers = .{},
     content_type: ?ContentType = null,
     content_encoding: ContentEncoding = .identity,
+    content_length: ?usize = null,
     arena: std.mem.Allocator,
 };
 
@@ -445,6 +450,10 @@ pub const ResponseParser = struct {
 
         if (self.response.headers.get("Content-Encoding")) |content_encoding| {
             self.response.content_encoding = ContentEncoding.fromString(content_encoding);
+        }
+
+        if (self.response.headers.get("Content-Length")) |content_length| {
+            self.response.content_length = std.fmt.parseInt(usize, content_length, 10) catch null;
         }
 
         self.state.headers_complete = true;

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -527,15 +527,22 @@ pub fn BodyReader(comptime Parser: type) type {
             assertFailsWithin(@TypeOf(Parser.finish), ParseError);
         }
 
-        /// `std.compress.flate.Decompress` records `error.ReadFailed` when
-        /// the reader below it failed, because that is all it saw. So that
-        /// one means "keep descending" and must not reach a caller. Switched
-        /// on rather than compared so it drops out of the inferred set as
-        /// well as out of the answer, the same way tls.zig's
-        /// `TransportReadFailed` does in `Transport`.
+        /// What the decoder recorded, said in terms a caller can act on.
+        /// Switched on rather than compared so what it rewrites drops out of
+        /// the inferred error set as well as out of the answer, the same way
+        /// tls.zig's `TransportReadFailed` does in `Transport`.
         fn decodeCause(e: std.compress.flate.Decompress.Error) !void {
             switch (e) {
+                // Records whatever the reader below it handed over, and on
+                // failure that is the sentinel: keep descending.
                 error.ReadFailed => {},
+                // The compressed stream stopped early -- the same condition
+                // the framing half reports as `IncompleteBody`, and the same
+                // name is what it needs. `EndOfStream` is how a peer that
+                // hung up is spelled, which `Transport.isPeerGone` believes:
+                // it would tear the connection down instead of answering,
+                // for a peer that is still there and sent a whole message.
+                error.EndOfStream => return error.IncompleteBody,
                 else => |cause| return cause,
             }
         }
@@ -588,8 +595,9 @@ pub fn BodyReader(comptime Parser: type) type {
         /// shipped in. `.identity` is a no-op, and an encoding we cannot
         /// undo is refused rather than guessed at.
         ///
-        /// Call on a reader that has not been read from yet: what it is now
-        /// becomes the reader underneath, and it becomes the one above.
+        /// Call once, on a reader that has not been read from: what it is
+        /// now is copied down to become the reader underneath, and its
+        /// buffer position is copied with it.
         ///
         /// Allocated rather than inline because it is 64K of sliding window
         /// and a few more of Huffman tables, and a body reader is embedded
@@ -609,6 +617,13 @@ pub fn BodyReader(comptime Parser: type) type {
                 .deflate => .zlib,
                 .unknown => return error.UnsupportedContentEncoding,
             };
+            // Stated above, checked here. A reader that has been read from
+            // would carry positions into the caller's buffer down into a
+            // copy whose buffer is `source_buffer`, and they would mean
+            // something else there.
+            std.debug.assert(self.decode == null);
+            std.debug.assert(self.interface.seek == self.interface.end);
+
             const decode = try allocator.create(Decode);
             decode.source = self.*;
             decode.source.interface.buffer = &decode.source_buffer;
@@ -635,6 +650,7 @@ pub fn BodyReader(comptime Parser: type) type {
                 else => |e| return e,
             };
         }
+
         fn stream(io_r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
             const self: *Self = @alignCast(@fieldParentPtr("interface", io_r));
             if (self.decode) |decode| return self.streamDecoded(decode, w, limit);

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -225,6 +225,10 @@ pub const RequestParser = struct {
             self.request.content_type = ContentType.fromContentType(content_type);
         }
 
+        if (self.request.headers.get("Content-Encoding")) |content_encoding| {
+            self.request.content_encoding = ContentEncoding.fromString(content_encoding);
+        }
+
         self.state.headers_complete = true;
         return c.HPE_PAUSED; // Always pause so we can track consumed bytes
     }
@@ -483,20 +487,35 @@ pub const ResponseParser = struct {
 /// body read. A parser free to invent its own errors would put its internals
 /// in that set -- `Paused` included, which is signalling between the parser
 /// and this loop and means nothing to a caller.
+///
+/// Read through `interface` and find out what a failed read was from `err`,
+/// the same way the response body writers work. Passed around by value: it
+/// holds an interface and pointers, and nothing points back at it.
+///
+/// Both transforms between wire bytes and the body a caller asked for are
+/// this type's job. It undoes the transfer framing itself; for a content
+/// coding it stacks, because `std.compress.flate.Decompress` reads from a
+/// `std.Io.Reader` and so needs one underneath it handing over raw framed
+/// bytes. That one is another `BodyReader` -- same type, lower role -- and
+/// `startDecoding` puts it and the decoder in one allocation.
 pub fn BodyReader(comptime Parser: type) type {
     return struct {
         parser: *Parser,
         transport: Transport,
-        interface: std.Io.Reader,
         request: ?*Request = null,
+        /// Set when the headers called for a content coding. Null both when
+        /// nothing is coded and on the lower reader that feeds the decoder.
+        decode: ?*Decode = null,
+        interface: std.Io.Reader,
         /// The real cause behind the generic `error.ReadFailed` that the
         /// `std.Io.Reader` interface has to return. `stream` is the one path
         /// that cannot hand a cause back, its error set being fixed by the
         /// vtable, so it is the one place this is written.
         ///
         /// Not every cause is the transport's. A body that stops mid-chunk,
-        /// or framing the parser rejects, fails the read just as surely and
-        /// the connection has nothing to say about it.
+        /// framing the parser rejects, or a corrupt deflate stream fails the
+        /// read just as surely and the connection has nothing to say about
+        /// it.
         err: ?Error = null,
 
         const Self = @This();
@@ -508,9 +527,23 @@ pub fn BodyReader(comptime Parser: type) type {
             assertFailsWithin(@TypeOf(Parser.finish), ParseError);
         }
 
+        /// `std.compress.flate.Decompress` records `error.ReadFailed` when
+        /// the reader below it failed, because that is all it saw. So that
+        /// one means "keep descending" and must not reach a caller. Switched
+        /// on rather than compared so it drops out of the inferred set as
+        /// well as out of the answer, the same way tls.zig's
+        /// `TransportReadFailed` does in `Transport`.
+        fn decodeCause(e: std.compress.flate.Decompress.Error) !void {
+            switch (e) {
+                error.ReadFailed => {},
+                else => |cause| return cause,
+            }
+        }
+
         /// What reading a body can fail with, once the sentinel is resolved.
         pub const Error = Transport.ReadError || Transport.WriteError ||
-            ParseError || error{ IncompleteBody, Unexpected };
+            ParseError || @typeInfo(@TypeOf(decodeCause(undefined))).error_union.error_set ||
+            error{ IncompleteBody, Unexpected };
 
         /// Stores what actually went wrong and reports the sentinel the
         /// vtable requires. Mirrors `fail` on the buffered body writer.
@@ -532,8 +565,83 @@ pub fn BodyReader(comptime Parser: type) type {
             };
         }
 
+        /// The decoder and the reader handing it raw framed bytes, in one
+        /// allocation so the pointers between them stay put while the body
+        /// reader above is copied around by value.
+        pub const Decode = struct {
+            source: Self,
+            source_buffer: [source_buffer_len]u8,
+            decoder: std.compress.flate.Decompress,
+            window: [std.compress.flate.max_window_len]u8,
+
+            /// What the decoder pulls raw framed bytes in. It reads its
+            /// input a few bytes at a time, so this is about how often that
+            /// goes back through the parser, not about correctness.
+            const source_buffer_len = 1024;
+        };
+
+        pub const StartDecodingError = std.mem.Allocator.Error ||
+            error{UnsupportedContentEncoding};
+
+        /// Undo `encoding` as the body is read, so `interface` yields the
+        /// representation the message was about rather than the one it was
+        /// shipped in. `.identity` is a no-op, and an encoding we cannot
+        /// undo is refused rather than guessed at.
+        ///
+        /// Call on a reader that has not been read from yet: what it is now
+        /// becomes the reader underneath, and it becomes the one above.
+        ///
+        /// Allocated rather than inline because it is 64K of sliding window
+        /// and a few more of Huffman tables, and a body reader is embedded
+        /// in `Request` and in `ClientResponse` -- neither can carry that
+        /// per message when most messages are not coded at all. It lives as
+        /// long as the reader does; both callers hand over a per-message
+        /// arena.
+        pub fn startDecoding(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            encoding: ContentEncoding,
+        ) StartDecodingError!void {
+            const container: std.compress.flate.Container = switch (encoding) {
+                .identity => return,
+                .gzip => .gzip,
+                // HTTP's "deflate" is zlib-wrapped, whatever the name says.
+                .deflate => .zlib,
+                .unknown => return error.UnsupportedContentEncoding,
+            };
+            const decode = try allocator.create(Decode);
+            decode.source = self.*;
+            decode.source.interface.buffer = &decode.source_buffer;
+            decode.decoder = .init(&decode.source.interface, container, &decode.window);
+            self.decode = decode;
+        }
+
+        /// Pulls decoded bytes from the decoder, and on failure descends to
+        /// whichever layer knows why: the decoder itself, then the reader
+        /// under it, which has already resolved through the transport.
+        fn streamDecoded(
+            self: *Self,
+            decode: *Decode,
+            w: *std.Io.Writer,
+            limit: std.Io.Limit,
+        ) std.Io.Reader.StreamError!usize {
+            return decode.decoder.reader.stream(w, limit) catch |err| switch (err) {
+                error.ReadFailed => {
+                    if (decode.decoder.err) |e| {
+                        if (decodeCause(e)) |_| {} else |cause| return self.fail(cause);
+                    }
+                    return self.fail(decode.source.err orelse error.Unexpected);
+                },
+                else => |e| return e,
+            };
+        }
         fn stream(io_r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
             const self: *Self = @alignCast(@fieldParentPtr("interface", io_r));
+            if (self.decode) |decode| return self.streamDecoded(decode, w, limit);
+            return self.streamFramed(w, limit);
+        }
+
+        fn streamFramed(self: *Self, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
             const parser = self.parser;
             const conn = self.transport.reader;
 

--- a/src/request.zig
+++ b/src/request.zig
@@ -649,6 +649,9 @@ test "Request: no std.Io.Reader sentinel escapes the body-reading API" {
         ErrorSetOf(Request.jsonValue),
         ErrorSetOf(Request.formData),
         ErrorSetOf(Request.multiFormData),
+        // The wrapper a streaming caller resolves through, not just the
+        // functions that resolve for them.
+        RequestBodyReader.Error,
     }) |Set| {
         inline for (@typeInfo(Set).error_set.?) |e| {
             try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));

--- a/src/request.zig
+++ b/src/request.zig
@@ -40,7 +40,6 @@ pub const Request = struct {
     // Body reading support
     parser: *RequestParser,
     transport: Transport,
-    body_reader_buffer: [1024]u8 = undefined,
     config: ServerConfig.Request = .{},
     _body: ?[]const u8 = null,
     _body_read: bool = false,
@@ -96,8 +95,14 @@ pub const Request = struct {
     /// The request body: transfer framing undone, and the content coding
     /// too unless `config.decompress` is off. Read through `.interface`,
     /// and `.err` says what an `error.ReadFailed` from it actually was.
-    pub fn reader(self: *Request) !RequestBodyReader {
-        var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
+    ///
+    /// `buffer` is where bytes wait between the connection and the caller,
+    /// the way `Response.stream` takes one for the other direction. It is
+    /// what `peek` and the `take` family read out of, so size it for the
+    /// longest thing they need to see at once; an empty slice is fine for a
+    /// caller that only ever streams.
+    pub fn reader(self: *Request, buffer: []u8) !RequestBodyReader {
+        var r = RequestBodyReader.init(self.parser, self.transport, buffer);
 
         // Once the body is in memory there is nothing left on the wire, and
         // what is cached has already been decoded.
@@ -122,7 +127,9 @@ pub const Request = struct {
             return self._body;
         }
 
-        var r = try self.reader();
+        // Nothing to stage: `allocRemaining` streams straight into the arena.
+        var no_buf: [0]u8 = .{};
+        var r = try self.reader(&no_buf);
         const result = r.interface.allocRemaining(self.arena, .limited(self.config.max_body_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.BodyTooBig,
             // The interface can only say that a read failed; the reader
@@ -815,7 +822,8 @@ test "Request: a streaming read resolves through the reader it hands out" {
 
     // A handler streaming the body never calls `body`, so the reader itself
     // has to answer -- including for a failure in the layer it added.
-    var r = try req.reader();
+    var read_buf: [64]u8 = undefined;
+    var r = try req.reader(&read_buf);
     var sink: std.Io.Writer = .fixed(&[_]u8{});
     try std.testing.expectError(error.ReadFailed, r.interface.stream(&sink, .limited(64)));
     try std.testing.expectEqual(error.BadGzipHeader, r.err.?);

--- a/src/request.zig
+++ b/src/request.zig
@@ -46,6 +46,7 @@ pub const Request = struct {
     // Set up on the first body read that calls for decoding, and kept so a
     // second `reader()` does not build a second decoder over the same body.
     _decode: ?*RequestBodyReader.Decode = null,
+    _body_reader_taken: bool = false,
     _fd: std.StringHashMapUnmanaged([]const u8) = .{},
     _fd_read: bool = false,
     _mfd: std.StringHashMapUnmanaged(MultipartForm.Entry) = .{},
@@ -101,6 +102,9 @@ pub const Request = struct {
     /// what `peek` and the `take` family read out of, so size it for the
     /// longest thing they need to see at once; an empty slice is fine for a
     /// caller that only ever streams.
+    ///
+    /// One per body. `body` takes it if you have not, so a handler that
+    /// streams cannot then ask for the body whole.
     pub fn reader(self: *Request, buffer: []u8) !RequestBodyReader {
         var r = RequestBodyReader.init(self.parser, self.transport, buffer);
 
@@ -110,6 +114,12 @@ pub const Request = struct {
             r.interface = .fixed(self._body orelse &.{});
             return r;
         }
+
+        // The buffer belongs to the caller, so a second reader starts empty
+        // and whatever the first one had buffered is unreachable -- bytes off
+        // the body, with nothing to say they went missing.
+        std.debug.assert(!self._body_reader_taken); // one body reader per request
+        self._body_reader_taken = true;
 
         r.request = self;
         if (self._decode) |decode| {
@@ -662,6 +672,10 @@ test "Request: no std.Io.Reader sentinel escapes the body-reading API" {
     }) |Set| {
         inline for (@typeInfo(Set).error_set.?) |e| {
             try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
+            // Not a sentinel, but not a cause either: the body layer calls a
+            // stream that stopped early `IncompleteBody`, and `EndOfStream`
+            // here would be read as the peer having hung up.
+            try std.testing.expect(!std.mem.eql(u8, e.name, "EndOfStream"));
         }
     }
 }
@@ -772,6 +786,37 @@ test "Request.body: decoding off yields what the wire carried" {
 
     const body = try req.body();
     try std.testing.expectEqualStrings(gzip_hello, body.?);
+}
+
+test "Request.body: a compressed body cut short is a bad body, not a departed peer" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // A valid gzip stream, truncated. The peer is still there and the HTTP
+    // message is whole; it is the compressed stream inside that stops early.
+    const cut_gzip = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\xcb\x48\xcd\xc9\xc9";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 15\r\n\r\n" ++ cut_gzip;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // The decoder calls this `EndOfStream`, which is how a peer that hung up
+    // is spelled -- `Transport.isPeerGone` would believe it and tear the
+    // connection down rather than answering. The framing half already calls
+    // the same condition `IncompleteBody`, and so must this one.
+    try std.testing.expectError(error.IncompleteBody, req.body());
+    try std.testing.expect(!Transport.isPeerGone(error.IncompleteBody));
 }
 
 test "Request.body: a coding we cannot undo is refused rather than guessed at" {

--- a/src/request.zig
+++ b/src/request.zig
@@ -18,6 +18,10 @@ pub const Request = struct {
     version_minor: u8 = 0,
     headers: http.Headers = .{},
     content_type: ?http.ContentType = null,
+    /// The coding the body arrived in. Undone by the body reader unless
+    /// `config.decompress` is off, in which case reading the body yields
+    /// what the wire carried.
+    content_encoding: http.ContentEncoding = .identity,
     params: http.Params = .{},
     query: http.Params = .{},
     /// The peer this request arrived from. A Unix socket peer has no
@@ -40,6 +44,9 @@ pub const Request = struct {
     config: ServerConfig.Request = .{},
     _body: ?[]const u8 = null,
     _body_read: bool = false,
+    // Set up on the first body read that calls for decoding, and kept so a
+    // second `reader()` does not build a second decoder over the same body.
+    _decode: ?*RequestBodyReader.Decode = null,
     _fd: std.StringHashMapUnmanaged([]const u8) = .{},
     _fd_read: bool = false,
     _mfd: std.StringHashMapUnmanaged(MultipartForm.Entry) = .{},
@@ -86,18 +93,26 @@ pub const Request = struct {
         set(self._timeout_context.?, self.io, timeout);
     }
 
-    pub fn reader(self: *Request) RequestBodyReader {
-        // If body has already been read, return a reader for the cached body
+    /// The request body: transfer framing undone, and the content coding
+    /// too unless `config.decompress` is off. Read through `.interface`,
+    /// and `.err` says what an `error.ReadFailed` from it actually was.
+    pub fn reader(self: *Request) !RequestBodyReader {
+        var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
+
+        // Once the body is in memory there is nothing left on the wire, and
+        // what is cached has already been decoded.
         if (self._body_read) {
-            const cached_body = self._body orelse &.{};
-            var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
-            r.interface = std.Io.Reader.fixed(cached_body);
+            r.interface = .fixed(self._body orelse &.{});
             return r;
         }
 
-        // Return the streaming body reader
-        var r = RequestBodyReader.init(self.parser, self.transport, &self.body_reader_buffer);
         r.request = self;
+        if (self._decode) |decode| {
+            r.decode = decode;
+        } else if (self.config.decompress) {
+            try r.startDecoding(self.arena, self.content_encoding);
+            self._decode = r.decode;
+        }
         return r;
     }
 
@@ -107,7 +122,7 @@ pub const Request = struct {
             return self._body;
         }
 
-        var r = self.reader();
+        var r = try self.reader();
         const result = r.interface.allocRemaining(self.arena, .limited(self.config.max_body_size)) catch |err| switch (err) {
             error.StreamTooLong => return error.BodyTooBig,
             // The interface can only say that a read failed; the reader
@@ -663,6 +678,113 @@ test "Request.body: basic POST" {
 
     const body = try req.body();
     try std.testing.expectEqualStrings("hello", body.?);
+}
+
+test "Request.body: a gzip request body is decoded" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // "hello", gzip compressed.
+    const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    try std.testing.expectEqual(http.ContentEncoding.gzip, req.content_encoding);
+    const body = try req.body();
+    try std.testing.expectEqualStrings("hello", body.?);
+}
+
+test "Request.body: decoding off yields what the wire carried" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+        .config = .{ .decompress = false },
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    const body = try req.body();
+    try std.testing.expectEqualStrings(gzip_hello, body.?);
+}
+
+test "Request.body: a coding we cannot undo is refused rather than guessed at" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: br\r\nContent-Length: 5\r\n\r\nhello";
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // Handing the handler brotli bytes it would read as the body is worse
+    // than saying we cannot.
+    try std.testing.expectError(error.UnsupportedContentEncoding, req.body());
+}
+
+test "Request: a streaming read resolves through the reader it hands out" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 32\r\n\r\n" ++
+        ("not a gzip stream at all" ++ "12345678");
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // A handler streaming the body never calls `body`, so the reader itself
+    // has to answer -- including for a failure in the layer it added.
+    var r = try req.reader();
+    var sink: std.Io.Writer = .fixed(&[_]u8{});
+    try std.testing.expectError(error.ReadFailed, r.interface.stream(&sink, .limited(64)));
+    try std.testing.expectEqual(error.BadGzipHeader, r.err.?);
 }
 
 test "Request.body: a body cut short reports the parse failure, not a failed read" {

--- a/src/request.zig
+++ b/src/request.zig
@@ -21,7 +21,15 @@ pub const Request = struct {
     /// The coding the body arrived in. Undone by the body reader unless
     /// `config.decompress` is off, in which case reading the body yields
     /// what the wire carried.
+    ///
+    /// Once it is being undone the `Content-Encoding` header is removed,
+    /// because it would describe the body a handler is about to read as
+    /// something it is not. This still says what arrived.
     content_encoding: http.ContentEncoding = .identity,
+    /// How long the body was on the wire, when the headers said. Removed
+    /// from the headers alongside the coding for the same reason, and kept
+    /// here for the same one.
+    content_length: ?usize = null,
     params: http.Params = .{},
     query: http.Params = .{},
     /// The peer this request arrived from. A Unix socket peer has no
@@ -126,9 +134,20 @@ pub const Request = struct {
             r.decode = decode;
         } else if (self.config.decompress) {
             try r.startDecoding(self.arena, self.content_encoding);
+            if (r.decode != null) self.dropEncodedBodyHeaders();
             self._decode = r.decode;
         }
         return r;
+    }
+
+    /// Both of these describe the body as it arrived, and it is not going
+    /// to arrive that way any more: what the handler reads is decoded, and
+    /// a longer or shorter number of bytes. Leaving them is how a proxy
+    /// comes to forward plain bytes labelled `gzip`. `content_encoding` and
+    /// `content_length` keep the answer for a handler that wants it.
+    fn dropEncodedBodyHeaders(self: *Request) void {
+        _ = self.headers.remove("Content-Encoding");
+        _ = self.headers.remove("Content-Length");
     }
 
     /// Read the entire body into memory. Result is cached for subsequent calls.
@@ -760,6 +779,72 @@ test "Request.body: a chunked gzip body is unwrapped by both layers" {
 
     const body = try req.body();
     try std.testing.expectEqualStrings("Hello from test!", body.?);
+}
+
+test "Request: decoding takes the headers that described the encoded body" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // Both are true of the body until the moment it is decoded.
+    try std.testing.expectEqualStrings("gzip", req.headers.get("Content-Encoding").?);
+    try std.testing.expectEqualStrings("25", req.headers.get("Content-Length").?);
+
+    const body = try req.body();
+    try std.testing.expectEqualStrings("hello", body.?);
+
+    // A handler forwarding these would send five plain bytes labelled as
+    // twenty-five gzipped ones.
+    try std.testing.expectEqual(@as(?[]const u8, null), req.headers.get("Content-Encoding"));
+    try std.testing.expectEqual(@as(?[]const u8, null), req.headers.get("Content-Length"));
+
+    // What arrived is still answerable, just not as a header.
+    try std.testing.expectEqual(http.ContentEncoding.gzip, req.content_encoding);
+    try std.testing.expectEqual(@as(?usize, 25), req.content_length);
+}
+
+test "Request: decoding off leaves the headers alone" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\nContent-Length: 25\r\n\r\n" ++ gzip_hello;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+        .config = .{ .decompress = false },
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+    _ = try req.body();
+
+    // Nothing was undone, so both still describe what the handler has.
+    try std.testing.expectEqualStrings("gzip", req.headers.get("Content-Encoding").?);
+    try std.testing.expectEqualStrings("25", req.headers.get("Content-Length").?);
 }
 
 test "Request.body: decoding off yields what the wire carried" {

--- a/src/request.zig
+++ b/src/request.zig
@@ -710,6 +710,37 @@ test "Request.body: a gzip request body is decoded" {
     try std.testing.expectEqualStrings("hello", body.?);
 }
 
+test "Request.body: a chunked gzip body is unwrapped by both layers" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // "Hello from test!" gzipped, then cut across three chunks -- so the
+    // decoder is fed from a stream whose framing it cannot see.
+    const chunked_gzip = "6\r\n\x1f\x8b\x08\x00\x00\x00\r\n" ++
+        "e\r\n\x00\x00\x02\x03\xf3\x48\xcd\xc9\xc9\x57\x48\x2b\xca\xcf\r\n" ++
+        "10\r\n\x55\x28\x49\x2d\x2e\x51\x04\x00\x7c\xe6\xd9\x99\x10\x00\x00\x00\r\n" ++
+        "0\r\n\r\n";
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: gzip\r\n" ++
+        "Transfer-Encoding: chunked\r\n\r\n" ++ chunked_gzip;
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    const body = try req.body();
+    try std.testing.expectEqualStrings("Hello from test!", body.?);
+}
+
 test "Request.body: decoding off yields what the wire carried" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/src/request.zig
+++ b/src/request.zig
@@ -127,7 +127,6 @@ pub const Request = struct {
         // and whatever the first one had buffered is unreachable -- bytes off
         // the body, with nothing to say they went missing.
         std.debug.assert(!self._body_reader_taken); // one body reader per request
-        self._body_reader_taken = true;
 
         r.request = self;
         if (self._decode) |decode| {
@@ -137,6 +136,11 @@ pub const Request = struct {
             if (r.decode != null) self.dropEncodedBodyHeaders();
             self._decode = r.decode;
         }
+
+        // Claimed only once there is a reader to claim it for. A coding we
+        // cannot undo fails above, and nothing was read; a caller that
+        // handles that error has to be able to ask again.
+        self._body_reader_taken = true;
         return r;
     }
 
@@ -927,6 +931,35 @@ test "Request.body: a coding we cannot undo is refused rather than guessed at" {
     // Handing the handler brotli bytes it would read as the body is worse
     // than saying we cannot.
     try std.testing.expectError(error.UnsupportedContentEncoding, req.body());
+}
+
+test "Request.body: a body read that failed before it started can be asked for again" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const raw_request = "POST /test HTTP/1.1\r\nContent-Encoding: br\r\nContent-Length: 5\r\n\r\nhello";
+    var reader = try fixedMessageReader(arena.allocator(), raw_request);
+
+    var req: Request = .{
+        .arena = arena.allocator(),
+        .transport = .{ .reader = &reader, .writer = undefined },
+        .parser = undefined,
+    };
+
+    var parser: RequestParser = undefined;
+    try parser.init(&req);
+    defer parser.deinit();
+    req.parser = &parser;
+
+    try parseHeaders(&reader, &parser);
+
+    // Nothing was read, so nothing was taken. A handler that answers 415 by
+    // way of an error handler that logs the body -- or one that just tries
+    // again -- gets the same answer rather than tripping the one-reader
+    // assert on a request a peer chose the encoding for.
+    try std.testing.expectError(error.UnsupportedContentEncoding, req.body());
+    try std.testing.expectError(error.UnsupportedContentEncoding, req.body());
+    try std.testing.expectError(error.UnsupportedContentEncoding, req.jsonValue());
 }
 
 test "Request: a streaming read resolves through the reader it hands out" {

--- a/src/response.zig
+++ b/src/response.zig
@@ -493,12 +493,13 @@ pub const Response = struct {
         try self.headers.add("Set-Cookie", serialized);
     }
 
-    /// How much of an event the stream holds before pushing it at the
-    /// connection. One write per event is the point, so this only has to
-    /// be large enough that an ordinary event does not split across two.
-    const event_stream_buffer = 4096;
-
-    pub fn startEventStream(self: *Response) !EventStream {
+    /// Opens a Server-Sent Events body.
+    ///
+    /// `buf` is what an event is assembled in before it goes at the
+    /// connection, and since the body is chunked it is also the chunk size.
+    /// One write per event is the point, so size it so an ordinary event
+    /// does not split across two.
+    pub fn startEventStream(self: *Response, buf: []u8) !EventStream {
         try self.header("Content-Type", "text/event-stream");
         try self.header("Cache-Control", "no-cache");
         // Chunked, like any other body of unknown length. An event stream
@@ -509,7 +510,6 @@ pub const Response = struct {
         // A HEAD gets the headers an event stream would have opened with
         // and none of the events; the body writer already drops what it is
         // given for a HEAD, so no send has to ask.
-        const buf = try self.arena.alloc(u8, event_stream_buffer);
         return .{ .body = try self.stream(buf) };
     }
 
@@ -1491,13 +1491,14 @@ const TestEventStream = struct {
     stream: EventStream,
     header_end: usize,
     decoded: [1024]u8,
+    event_buf: [4096]u8 = undefined,
 
     fn init(self: *TestEventStream, buf: []u8) !void {
         self.arena = .init(std.testing.allocator);
         self.conn_writer = .fixed(buf);
         self.connection.initWriterForTesting(&self.conn_writer);
         self.response = try Response.init(self.arena.allocator(), &self.connection, 32);
-        self.stream = try self.response.startEventStream();
+        self.stream = try self.response.startEventStream(&self.event_buf);
         self.header_end = self.conn_writer.end;
     }
 
@@ -1590,7 +1591,8 @@ test "Response: startEventStream" {
     connection.initWriterForTesting(&conn_writer);
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    var stream = try response.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try response.startEventStream(&event_buf);
 
     try stream.send("connected", .{});
 
@@ -1637,7 +1639,8 @@ test "EventStream: send reports the real error, not error.WriteFailed" {
         var probe_conn: Connection = undefined;
         probe_conn.initWriterForTesting(&probe_writer);
         var probe_res = try Response.init(arena.allocator(), &probe_conn, 32);
-        _ = try probe_res.startEventStream();
+        var event_buf: [4096]u8 = undefined;
+        _ = try probe_res.startEventStream(&event_buf);
         break :blk probe_writer.end;
     };
 
@@ -1648,7 +1651,8 @@ test "EventStream: send reports the real error, not error.WriteFailed" {
     connection.tcp_writer.err = error.ConnectionResetByPeer;
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    var stream = try response.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try response.startEventStream(&event_buf);
 
     try std.testing.expectError(error.ConnectionResetByPeer, stream.send("hello", .{}));
     try std.testing.expectEqual(error.ConnectionResetByPeer, stream.body.err.?);
@@ -1664,7 +1668,8 @@ test "EventWriter: end reports the real error, not error.WriteFailed" {
         var probe_conn: Connection = undefined;
         probe_conn.initWriterForTesting(&probe_writer);
         var probe_res = try Response.init(arena.allocator(), &probe_conn, 32);
-        _ = try probe_res.startEventStream();
+        var event_buf: [4096]u8 = undefined;
+        _ = try probe_res.startEventStream(&event_buf);
         break :blk probe_writer.end;
     };
 
@@ -1675,7 +1680,8 @@ test "EventWriter: end reports the real error, not error.WriteFailed" {
     connection.tcp_writer.err = error.ConnectionResetByPeer;
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    var stream = try response.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try response.startEventStream(&event_buf);
 
     // The event is held in the stream's buffer, so nothing reaches the
     // connection until `end` closes it.
@@ -1694,7 +1700,8 @@ test "EventWriter: an event too long for the buffer reports the real error" {
         var probe_conn: Connection = undefined;
         probe_conn.initWriterForTesting(&probe_writer);
         var probe_res = try Response.init(arena.allocator(), &probe_conn, 32);
-        _ = try probe_res.startEventStream();
+        var event_buf: [4096]u8 = undefined;
+        _ = try probe_res.startEventStream(&event_buf);
         break :blk probe_writer.end;
     };
 
@@ -1705,14 +1712,15 @@ test "EventWriter: an event too long for the buffer reports the real error" {
     connection.tcp_writer.err = error.ConnectionResetByPeer;
 
     var response = try Response.init(arena.allocator(), &connection, 32);
-    var stream = try response.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try response.startEventStream(&event_buf);
     var w = try stream.startSend(.{});
 
     // Longer than the stream holds, so it reaches the connection while it
     // is still being written rather than at `end`. That is what a caller
     // filling an event from a template does, and the interface can only
     // tell them the sentinel.
-    const long = try arena.allocator().alloc(u8, Response.event_stream_buffer + 1);
+    const long = try arena.allocator().alloc(u8, event_buf.len + 1);
     @memset(long, 'x');
 
     try std.testing.expectError(error.WriteFailed, w.interface.writeAll(long));
@@ -2121,7 +2129,8 @@ test "Response: a HEAD event stream sends the headers and no events" {
     var response = try Response.init(arena.allocator(), &connection, 32);
     response.head = true;
 
-    var stream = try response.startEventStream();
+    var event_buf: [4096]u8 = undefined;
+    var stream = try response.startEventStream(&event_buf);
     try stream.send("hello", .{});
     var w = try stream.startSend(.{ .event = "tick" });
     try w.interface.writeAll("more");

--- a/src/server.zig
+++ b/src/server.zig
@@ -852,6 +852,9 @@ pub fn Server(comptime Ctx: type) type {
                     };
                     if (drainable) {
                         var scratch: [4096]u8 = undefined;
+                        // No decoding: this is throwing the body away to get
+                        // back to the connection, and `max` bounds what the
+                        // peer sent rather than what it would decode to.
                         var body_reader = RequestBodyReader.init(&parser, connection.transport(), &scratch);
                         if (body_reader.interface.discardShort(max + 1)) |consumed| {
                             if (consumed > max) response.keepalive = false;

--- a/src/server.zig
+++ b/src/server.zig
@@ -851,8 +851,10 @@ pub fn Server(comptime Ctx: type) type {
                 if (!parser.isBodyComplete()) {
                     const max = self.config.request.max_body_size;
                     const drainable = blk: {
-                        const cl = request.headers.get("Content-Length") orelse break :blk false;
-                        const n = std.fmt.parseInt(usize, cl, 10) catch break :blk false;
+                        // What the wire carried, which is what there is left
+                        // to throw away -- and still readable after decoding
+                        // took the header off.
+                        const n = request.content_length orelse break :blk false;
                         break :blk n <= max;
                     };
                     if (drainable) {

--- a/src/server.zig
+++ b/src/server.zig
@@ -58,6 +58,11 @@ pub const Connection = struct {
     tls_writer: tls.Connection.Writer = undefined,
 
     // Active reader/writer, whichever path is in use.
+    //
+    // Public, and bare interfaces, so they can only report
+    // `ReadFailed`/`WriteFailed`. That is allowed here because there is no
+    // layer above them to lose the answer: `getReadError`/`getWriteError`
+    // beside them resolve what actually failed.
     reader: *std.Io.Reader = undefined,
     writer: *std.Io.Writer = undefined,
 

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -63,7 +63,7 @@ test "Server: POST with body" {
         }
 
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = req.reader();
+            var reader = try req.reader();
 
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
@@ -81,6 +81,45 @@ test "Server: POST with body" {
     try testClientServer(TestContext, &ctx);
 
     try std.testing.expect(ctx.body_received);
+    try std.testing.expectEqualStrings("Hello from test!", ctx.received_body[0..ctx.received_len]);
+}
+
+test "Server: a gzip request body reaches the handler decoded" {
+    const TestContext = struct {
+        const Self = @This();
+
+        // "Hello from test!", gzip compressed.
+        const gzip_body = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\xf3\x48\xcd\xc9\xc9\x57" ++
+            "\x48\x2b\xca\xcf\x55\x28\x49\x2d\x2e\x51\x04\x00\x7c\xe6\xd9\x99\x10\x00\x00\x00";
+
+        received_body: [256]u8 = undefined,
+        received_len: usize = 0,
+
+        pub fn setup(ctx: *Self, server: *dusty.Server(Self)) !void {
+            _ = ctx;
+            server.router.post("/gzip", handlePost);
+        }
+
+        pub fn makeRequest(ctx: *Self, writer: *std.Io.Writer) !void {
+            _ = ctx;
+            try writer.print(
+                "POST /gzip HTTP/1.1\r\nHost: localhost\r\nContent-Encoding: gzip\r\nContent-Length: {d}\r\n\r\n{s}",
+                .{ gzip_body.len, gzip_body },
+            );
+            try writer.flush();
+        }
+
+        fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
+            var reader = try req.reader();
+            var writer = std.Io.Writer.fixed(&ctx.received_body);
+            ctx.received_len = try reader.interface.streamRemaining(&writer);
+            res.body = "OK\n";
+        }
+    };
+
+    var ctx: TestContext = .{};
+    try testClientServer(TestContext, &ctx);
+
     try std.testing.expectEqualStrings("Hello from test!", ctx.received_body[0..ctx.received_len]);
 }
 
@@ -123,7 +162,7 @@ test "Server: POST with chunked encoding" {
         }
 
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = req.reader();
+            var reader = try req.reader();
 
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
@@ -163,7 +202,7 @@ test "Server: GET with no body" {
         }
 
         fn handleGet(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = req.reader();
+            var reader = try req.reader();
 
             var body_buf: [256]u8 = undefined;
             var writer = std.Io.Writer.fixed(&body_buf);
@@ -404,7 +443,7 @@ test "Server: void context handlers" {
 
     server.router.post("/echo", struct {
         fn handle(req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = req.reader();
+            var reader = try req.reader();
             const body = try reader.interface.allocRemaining(req.arena, .limited(1024));
             res.body = try std.fmt.allocPrint(res.arena, "Echo: {s}\n", .{body});
         }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -63,7 +63,8 @@ test "Server: POST with body" {
         }
 
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = try req.reader();
+            var read_buf: [1024]u8 = undefined;
+            var reader = try req.reader(&read_buf);
 
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
@@ -110,7 +111,8 @@ test "Server: a gzip request body reaches the handler decoded" {
         }
 
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = try req.reader();
+            var read_buf: [1024]u8 = undefined;
+            var reader = try req.reader(&read_buf);
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             ctx.received_len = try reader.interface.streamRemaining(&writer);
             res.body = "OK\n";
@@ -162,7 +164,8 @@ test "Server: POST with chunked encoding" {
         }
 
         fn handlePost(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = try req.reader();
+            var read_buf: [1024]u8 = undefined;
+            var reader = try req.reader(&read_buf);
 
             var writer = std.Io.Writer.fixed(&ctx.received_body);
             const n = try reader.interface.streamRemaining(&writer);
@@ -202,7 +205,8 @@ test "Server: GET with no body" {
         }
 
         fn handleGet(ctx: *Self, req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = try req.reader();
+            var read_buf: [1024]u8 = undefined;
+            var reader = try req.reader(&read_buf);
 
             var body_buf: [256]u8 = undefined;
             var writer = std.Io.Writer.fixed(&body_buf);
@@ -443,7 +447,8 @@ test "Server: void context handlers" {
 
     server.router.post("/echo", struct {
         fn handle(req: *dusty.Request, res: *dusty.Response) !void {
-            var reader = try req.reader();
+            var read_buf: [1024]u8 = undefined;
+            var reader = try req.reader(&read_buf);
             const body = try reader.interface.allocRemaining(req.arena, .limited(1024));
             res.body = try std.fmt.allocPrint(res.arena, "Echo: {s}\n", .{body});
         }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -798,7 +798,8 @@ test "Server: an event stream is chunked and leaves the connection reusable" {
     server.router.get("/events", struct {
         fn handle(req: *dusty.Request, res: *dusty.Response) !void {
             _ = req;
-            var events = try res.startEventStream();
+            var event_buf: [4096]u8 = undefined;
+            var events = try res.startEventStream(&event_buf);
             try events.send("first", .{ .event = "tick", .id = "1" });
             try events.send("second", .{});
         }

--- a/src/server_test.zig
+++ b/src/server_test.zig
@@ -946,6 +946,75 @@ test "Server: handler error after streaming started aborts the connection" {
     return error.TestExpectedConnectionToBeClosed;
 }
 
+test "Server: keepalive after handler ignores a compressed request body" {
+    const io = std.testing.io;
+
+    var server = dusty.Server(void).init(std.testing.allocator, io, .{}, {});
+    defer server.deinit();
+
+    server.router.post("/ignore", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "first";
+        }
+    }.handle);
+
+    server.router.get("/ping", struct {
+        fn handle(req: *dusty.Request, res: *dusty.Response) !void {
+            _ = req;
+            res.body = "second";
+        }
+    }.handle);
+
+    var server_future = try io.concurrent(struct {
+        fn run(s: *dusty.Server(void)) !void {
+            const addr: dusty.Address = .{ .ip = try std.Io.net.IpAddress.parse("127.0.0.1", 0) };
+            try s.listen(addr);
+        }
+    }.run, .{&server});
+    defer server_future.cancel(io) catch {};
+
+    try server.ready.wait(io);
+
+    const stream = try server.address.ip.connect(io, .{ .mode = .stream });
+    defer stream.close(io);
+    defer stream.shutdown(io, .both) catch {};
+
+    var write_buf: [1024]u8 = undefined;
+    var writer = stream.writer(io, &write_buf);
+    const w = &writer.interface;
+
+    var read_buf: [1024]u8 = undefined;
+    var reader = stream.reader(io, &read_buf);
+    const r = &reader.interface;
+
+    // The handler never reads it, so the drain has to throw away the wire
+    // bytes -- and the header saying how many there are is one decoding
+    // would have removed, had anything asked it to.
+    const gzip_body = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\x2b\xc9\xc8\x2c\x56\x48" ++
+        "\xca\x4f\xa9\x54\x00\xd2\x99\xe9\x79\xf9\x45\xa9\x29\x00\x79\xf5\xd8\x44\x14\x00\x00\x00";
+    try w.print(
+        "POST /ignore HTTP/1.1\r\nHost: localhost\r\nContent-Encoding: gzip\r\nContent-Length: {d}\r\n\r\n{s}",
+        .{ gzip_body.len, gzip_body },
+    );
+    try w.flush();
+
+    var status1: [64]u8 = undefined;
+    var body1: [32]u8 = undefined;
+    const resp1 = try readResponse(r, &status1, &body1);
+    try std.testing.expect(std.mem.indexOf(u8, resp1.status, "200") != null);
+    try std.testing.expectEqualStrings("first", resp1.body);
+
+    try w.writeAll("GET /ping HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    try w.flush();
+
+    var status2: [64]u8 = undefined;
+    var body2: [32]u8 = undefined;
+    const resp2 = try readResponse(r, &status2, &body2);
+    try std.testing.expect(std.mem.indexOf(u8, resp2.status, "200") != null);
+    try std.testing.expectEqualStrings("second", resp2.body);
+}
+
 test "Server: closes connection when unread body exceeds max_body_size" {
     const io = std.testing.io;
 

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -20,9 +20,11 @@
 //!
 //! None of them carries its own buffer. Where bytes have to wait between
 //! the caller and the connection, the caller passes the buffer in --
-//! `Request.reader`, `ClientResponse.reader`, `Response.stream` -- and
-//! where they do not, because the response arena or the stream below is
-//! already the buffer, there is none at all.
+//! `Request.reader`, `ClientResponse.reader`, `Response.stream`,
+//! `Response.startEventStream` -- and where they do not, because the
+//! response arena or the stream below is already the buffer, there is none
+//! at all. On a chunked body that buffer is also the chunk size, which is
+//! another reason it is not ours to pick.
 //!
 //! `BodyReader` (`parser.zig`) and `BodyWriter`, `StreamingBodyWriter` and
 //! `EventWriter` (`response.zig`) are all this. `WebSocket` and

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -27,11 +27,13 @@
 //! another reason it is not ours to pick.
 //!
 //! `BodyReader` (`parser.zig`) and `BodyWriter`, `StreamingBodyWriter` and
-//! `EventWriter` (`response.zig`) are all this. `WebSocket` and
-//! `EventStream` hand out no interface at all and resolve inside `send` /
-//! `receive`, which is the same promise kept a different way. `Transport`
-//! and `Connection` expose a bare interface with accessors beside it, which
-//! is allowed only because nothing sits above them to lose the answer.
+//! `EventWriter` (`response.zig`) are all this -- `EventStream.startSend`
+//! hands out the last of them, and `EventStream.send` resolves inside
+//! itself for a caller who does not want one. `WebSocket` hands out no
+//! interface at all and resolves inside `send` / `receive`, which is the
+//! same promise kept a different way. `Transport` and `Connection` expose a
+//! bare interface with accessors beside it, which is allowed only because
+//! nothing sits above them to lose the answer.
 //!
 //! "Resolved" is the load-bearing word. An `err` holding a sentinel is no
 //! better than the sentinel, and layers do record sentinels: tls.zig stores

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -1,3 +1,44 @@
+//! The rule every layer in this library follows, stated once here because
+//! Zig will not enforce it and because this is where the descent it
+//! describes is implemented:
+//!
+//!   A `std.Io.Reader` or `std.Io.Writer` the public API hands out must be
+//!   reachable *through* something that also gives the caller the real
+//!   cause.
+//!
+//! The interfaces themselves cannot carry one: their error sets are fixed at
+//! `ReadFailed`/`WriteFailed` by the vtable, and those name nothing a caller
+//! can act on.
+//!
+//! In practice that is one shape, everywhere -- a small wrapper, passed
+//! around by value, with the interface to use and the cause beside it:
+//!
+//!   pub const X = struct {
+//!       interface: std.Io.Reader,  // or Writer
+//!       err: ?Error = null,        // what a failed read or write was
+//!   };
+//!
+//! `BodyReader` (`parser.zig`) and `BodyWriter`, `StreamingBodyWriter` and
+//! `EventWriter` (`response.zig`) are all this. `WebSocket` and
+//! `EventStream` hand out no interface at all and resolve inside `send` /
+//! `receive`, which is the same promise kept a different way. `Transport`
+//! and `Connection` expose a bare interface with accessors beside it, which
+//! is allowed only because nothing sits above them to lose the answer.
+//!
+//! "Resolved" is the load-bearing word. An `err` holding a sentinel is no
+//! better than the sentinel, and layers do record sentinels: tls.zig stores
+//! `TransportReadFailed` when the layer below it failed, and
+//! `std.compress.flate.Decompress` stores `error.ReadFailed` for the same
+//! reason. Both mean "keep descending". So the code that reads them switches
+//! past them rather than comparing, which drops them from the inferred error
+//! set as well as from the answer -- making it true by construction that
+//! what a caller is handed names a cause.
+//!
+//! A new layer added above an existing one inherits the obligation: resolve
+//! through everything below it, or the answer stops at the wrapper. The
+//! guard tests spread across these files walk every wrapper's `Error` and
+//! fail at compile time if a sentinel is in one.
+
 const std = @import("std");
 const tls = @import("tls");
 const build_options = @import("build_options");
@@ -111,3 +152,19 @@ pub const Transport = struct {
         };
     }
 };
+
+test "Transport: no std.Io sentinel escapes a resolved error set" {
+    // The rule at the top of this file, checked. Everything above the
+    // transport resolves through these two, so a sentinel surviving here
+    // would survive everywhere.
+    inline for (.{ Transport.ReadError, Transport.WriteError }) |Set| {
+        inline for (@typeInfo(Set).error_set.?) |e| {
+            try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
+            try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
+            // The sentinels tls.zig stands in for them with, which mean
+            // "keep descending" and are equally useless to a caller.
+            try std.testing.expect(!std.mem.eql(u8, e.name, "TransportReadFailed"));
+            try std.testing.expect(!std.mem.eql(u8, e.name, "TransportWriteFailed"));
+        }
+    }
+}

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -18,6 +18,12 @@
 //!       err: ?Error = null,        // what a failed read or write was
 //!   };
 //!
+//! None of them carries its own buffer. Where bytes have to wait between
+//! the caller and the connection, the caller passes the buffer in --
+//! `Request.reader`, `ClientResponse.reader`, `Response.stream` -- and
+//! where they do not, because the response arena or the stream below is
+//! already the buffer, there is none at all.
+//!
 //! `BodyReader` (`parser.zig`) and `BodyWriter`, `StreamingBodyWriter` and
 //! `EventWriter` (`response.zig`) are all this. `WebSocket` and
 //! `EventStream` hand out no interface at all and resolve inside `send` /


### PR DESCRIPTION
Closes #150. Closes #149.

## Decoding moves into `BodyReader`

Decompression sat *above* the body reader, owned by `ClientResponse`, so "read a body" was assembled from two pieces by whoever held them and anyone resolving a failure had to walk both in the right order. #147 hid that behind `ClientResponse.getReadError`, but the hiding was the point.

`BodyReader` already owned the other transform between wire bytes and the body a caller wants — chunked and content-length framing. Content coding is the second half of the same job. It undoes the framing itself; for a coding it stacks, because `std.compress.flate.Decompress` reads from a `std.Io.Reader` and so needs one under it handing over raw framed bytes. That one is another `BodyReader` — same type, lower role — and `startDecoding` puts it and the decoder in a single allocation so the pointers between them stay put while the wrapper above is copied by value.

Nothing coded costs nothing: one reader, one buffer, no forwarding.

## One shape for everything we hand out

```zig
pub const X = struct {
    interface: std.Io.Reader,  // or Writer, by value
    err: ?Error = null,        // resolved cause, never a sentinel
};
```

`BodyWriter`, `StreamingBodyWriter` and `EventWriter` already were this; the two body readers now are too. `WebSocket` hands out no interface and resolves inside `send`/`receive`. `Transport` and `Connection` expose a bare interface with accessors beside it, which is allowed only because nothing sits above them to lose the answer. `transport.zig`'s module doc states the rule and names both exceptions, since Zig will not enforce it.

Buffers come from the caller wherever bytes wait between your code and the connection — `reader`, `stream`, `startEventStream` — and nowhere else, because the response arena or the stream below is already the buffer. On a chunked body that buffer is also the chunk size, which is another reason it is not ours to pick.

## Server request bodies now decode

A `Content-Encoding: gzip` request body reached the handler still compressed. It doesn't now; `ServerConfig.Request.decompress` turns it off. `max_body_size` bounds the decoded body, so a 1 KB gzip bomb expanding past the limit gets a 413 with the connection intact. The drain path deliberately does not decode — it throws away wire bytes to get the connection back.

Both ends drop `Content-Encoding` and `Content-Length` once decoding starts, the way Go's client does: neither describes what the caller reads, and leaving them is how a proxy forwards plain bytes labelled `gzip`. What arrived is still answerable via `Request.content_encoding`/`content_length` and `ClientResponse.contentEncoding()`/`contentLength()`.

## Memory

`ClientResponse` is returned by value from `fetch` and carried a 64K decompression window inline, compressed or not.

| | before | after |
|---|---|---|
| `ClientResponse` | 70184 B | **128 B** |
| the reader it hands out | — | 120 B |
| `Decode` — allocated only when the headers call for it | inline | 70064 B |

## Review findings

A review of the branch turned up one remotely-triggerable bug, now fixed and tested: `Decompress` records `error.EndOfStream` for a *truncated* compressed stream, `Transport.isPeerGone` reads that as the peer hanging up, and `Executor.run` answers a peer-gone error by tearing the connection down. Fifteen bytes of a gzip body got no response at all, logged at `debug`. The framing half already named the identical condition `IncompleteBody`; both halves agree now, and the guard tests know the name.

Also from review: one body reader per message is asserted (the buffer is the caller's, so a second reader silently abandoned whatever the first had buffered), `startDecoding` asserts the precondition its doc states, and two doc claims that contradicted the code are fixed.

## Breaking

- `Request.reader()` and `ClientResponse.reader()` take a buffer and return an error union; `ClientResponse.reader()` returns the wrapper rather than a bare `*std.Io.Reader`
- `Response.startEventStream()` takes a buffer
- `ClientResponse.getReadError()` removed — `body()` resolves for you, streaming callers read `.err`
- One body reader per message, asserted
- `Content-Encoding`/`Content-Length` removed from headers when decoding
- Server request bodies decode by default
- An unsupported coding is `error.UnsupportedContentEncoding` rather than a guess; the client used to feed anything non-gzip to zlib

321 tests pass.