### PR TITLE
Track tls.zig upstream instead of the fork

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .tls = .{
-            .url = "git+https://github.com/lalinsky/tls.zig#e400919acc40db2635c025c07260e0e0b069e11d",
-            .hash = "tls-0.1.0-ER2e0oZ3BgBU80H1rtVl65VfzQglbK5sI2puxIlyeh24",
+            .url = "git+https://github.com/ianic/tls.zig#2dd61649046b6636d9171a16a27532c5b7887b93",
+            .hash = "tls-0.1.0-ER2e0mepBgDBLqoGW16P4WLSO0NU7DrkvCshUIYAaliF",
             .lazy = true,
         },
     },

--- a/src/client.zig
+++ b/src/client.zig
@@ -512,13 +512,8 @@ pub const Connection = struct {
                     .tcp_writer = &self.tcp_writer,
                 };
                 return switch (err) {
-                    error.TransportReadFailed => ciphertext.getReadError() orelse error.Unexpected,
-                    // A failed ciphertext write arrives either way round
-                    // depending on where in the handshake it happened; both
-                    // mean the same thing and neither names a cause.
-                    error.TransportWriteFailed,
-                    error.WriteFailed,
-                    => ciphertext.getWriteError() orelse error.Unexpected,
+                    error.ReadFailed => ciphertext.getReadError() orelse error.Unexpected,
+                    error.WriteFailed => ciphertext.getWriteError() orelse error.Unexpected,
                     else => |e| e,
                 };
             };
@@ -891,22 +886,13 @@ pub const Client = struct {
         var client_cert: ?tls.config.CertKeyPair = null;
         errdefer if (client_cert) |*pair| pair.deinit(self.allocator);
         if (cfg.client_certificate) |cc| {
-            client_cert = tls.config.CertKeyPair.fromFilePath(
+            client_cert = try tls.config.CertKeyPair.fromFilePath(
                 self.allocator,
                 self.io,
                 cc.dir orelse std.Io.Dir.cwd(),
                 cc.cert_path,
                 cc.key_path,
-                // Reads the certificate and key off disk through readers
-                // that belong to tls.zig, which keeps their causes to
-                // itself -- all that comes back is `error.ReadFailed`.
-                // Named here rather than passed on: in the error set of a
-                // request a bare read failure cannot be told from the socket
-                // failing, and this one is about a file the caller named.
-            ) catch |err| switch (err) {
-                error.ReadFailed => return error.TlsConfigUnreadable,
-                else => |e| return e,
-            };
+            );
         }
 
         self.tls_state = .{ .ca_bundle = ca_bundle, .client_cert = client_cert };

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -539,7 +539,7 @@ pub fn BodyReader(comptime Parser: type) type {
         /// What the decoder recorded, said in terms a caller can act on.
         /// Switched on rather than compared so what it rewrites drops out of
         /// the inferred error set as well as out of the answer, the same way
-        /// tls.zig's `TransportReadFailed` does in `Transport`.
+        /// tls.zig's `ReadFailed` does in `Transport`.
         fn decodeCause(e: std.compress.flate.Decompress.Error) !void {
             switch (e) {
                 // Records whatever the reader below it handed over, and on

--- a/src/server.zig
+++ b/src/server.zig
@@ -712,8 +712,8 @@ pub fn Server(comptime Ctx: type) type {
                             // layer down -- and when the handshake ran out
                             // of time, that cause is the cancel.
                             const cause = switch (err) {
-                                error.TransportReadFailed => connection.getReadError() orelse err,
-                                error.TransportWriteFailed => connection.getWriteError() orelse err,
+                                error.ReadFailed => connection.getReadError() orelse err,
+                                error.WriteFailed => connection.getWriteError() orelse err,
                                 else => err,
                             };
                             // Nothing was negotiated, so there is no TLS
@@ -953,13 +953,13 @@ test "Connection: error accessors descend past the TLS layer's generic error" {
 
     { // a transport write failure: TLS records WriteFailed, TCP has the cause
         var conn = testTlsConnection();
-        conn.tls_writer.err = error.TransportWriteFailed;
+        conn.tls_writer.err = error.WriteFailed;
         conn.tcp_writer.err = error.ConnectionResetByPeer;
         try std.testing.expectEqual(error.ConnectionResetByPeer, conn.getWriteError().?);
     }
     { // same on the read side
         var conn = testTlsConnection();
-        conn.tls_reader.err = error.TransportReadFailed;
+        conn.tls_reader.err = error.ReadFailed;
         conn.tcp_reader.err = error.Canceled;
         try std.testing.expectEqual(error.Canceled, conn.getReadError().?);
     }
@@ -981,25 +981,22 @@ test "Connection: a TLS-level failure is reported as itself" {
 }
 
 test "Connection: the placeholders it descends past stay out of its error sets" {
-    // `TransportReadFailed`/`TransportWriteFailed` mean only "the layer
-    // below failed", which is what the accessors exist to look past. They
-    // must not survive into what a caller can be handed, any more than the
-    // `ReadFailed`/`WriteFailed` they stand in for.
+    // `ReadFailed`/`WriteFailed` mean only "the layer below failed", which
+    // is what the accessors exist to look past. They must not survive into
+    // what a caller can be handed.
     inline for (@typeInfo(Connection.ReadError).error_set.?) |e| {
-        try std.testing.expect(!std.mem.eql(u8, e.name, "TransportReadFailed"));
+        try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
     }
     inline for (@typeInfo(Connection.WriteError).error_set.?) |e| {
-        try std.testing.expect(!std.mem.eql(u8, e.name, "TransportWriteFailed"));
+        try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
     }
 }
 
 test "Connection: isPeerGone separates a departed peer from a real failure" {
     try std.testing.expect(Connection.isPeerGone(error.EndOfStream));
     try std.testing.expect(Connection.isPeerGone(error.ConnectionResetByPeer));
-    // Closed between records: nothing was in flight, nothing was lost.
-    try std.testing.expect(Connection.isPeerGone(error.TlsUnexpectedEof));
     // Closed mid-record: a record was cut, which is worth hearing about.
-    try std.testing.expect(!Connection.isPeerGone(error.TlsTruncated));
+    try std.testing.expect(!Connection.isPeerGone(error.TlsConnectionTruncated));
     try std.testing.expect(!Connection.isPeerGone(error.TlsBadRecordMac));
     try std.testing.expect(!Connection.isPeerGone(error.Canceled));
 }

--- a/src/transport.zig
+++ b/src/transport.zig
@@ -36,10 +36,10 @@
 //! nothing sits above them to lose the answer.
 //!
 //! "Resolved" is the load-bearing word. An `err` holding a sentinel is no
-//! better than the sentinel, and layers do record sentinels: tls.zig stores
-//! `TransportReadFailed` when the layer below it failed, and
-//! `std.compress.flate.Decompress` stores `error.ReadFailed` for the same
-//! reason. Both mean "keep descending". So the code that reads them switches
+//! better than the sentinel, and layers do record sentinels: both tls.zig
+//! and `std.compress.flate.Decompress` store `error.ReadFailed` when the
+//! layer below them failed, because that is all they were handed.
+//! It means "keep descending". So the code that reads them switches
 //! past them rather than comparing, which drops them from the inferred error
 //! set as well as from the answer -- making it true by construction that
 //! what a caller is handed names a cause.
@@ -85,23 +85,31 @@ pub const Transport = struct {
     tls_reader: ?*tls.Connection.Reader = null,
     tls_writer: ?*tls.Connection.Writer = null,
 
-    // tls.zig records `TransportReadFailed`/`TransportWriteFailed` when the
-    // layer below it failed, because all it saw was the ciphertext
-    // reader/writer's generic error; the real cause is on the TCP layer.
-    // So those two mean "keep descending". A TLS-level failure (bad record
-    // mac, bad version, ...) is recorded as itself and stops the search.
+    // tls.zig records `ReadFailed`/`WriteFailed` when the layer below it
+    // failed, because all it saw was the ciphertext reader/writer's generic
+    // error; the real cause is on the TCP layer. So those two mean "keep
+    // descending". A TLS-level failure (bad record mac, bad version, ...) is
+    // recorded as itself and stops the search.
     //
     // They are switched on rather than compared so that they drop out of
-    // the inferred error set as well as out of the answer: like the
-    // `ReadFailed`/`WriteFailed` they stand in for, they name no cause a
-    // caller could act on, and nothing that descends past them can return one.
+    // the inferred error set as well as out of the answer: they name no
+    // cause a caller could act on, and nothing that descends past them can
+    // return one.
 
     fn checkReadError(self: Transport) !void {
         if (build_options.use_tls) {
             if (self.tls_reader) |tls_reader| {
                 if (tls_reader.err) |e| switch (e) {
                     // Keep descending: the cause is on the TCP layer below.
-                    error.TransportReadFailed => {},
+                    error.ReadFailed => {},
+                    // Unreachable: tls.zig's read error set is built on
+                    // `std.Io.Reader.Error`, so it carries `EndOfStream`
+                    // along with the `ReadFailed` it wanted, but the read
+                    // itself turns a clean end into zero bytes and never
+                    // returns it. Named anyway so it stays out of the
+                    // resolved set, where it would read as the peer having
+                    // hung up on a caller that asked why a read failed.
+                    error.EndOfStream => return error.Unexpected,
                     else => |cause| return cause,
                 };
             }
@@ -124,7 +132,7 @@ pub const Transport = struct {
             if (self.tls_writer) |tls_writer| {
                 if (tls_writer.err) |e| switch (e) {
                     // Keep descending: the cause is on the TCP layer below.
-                    error.TransportWriteFailed => {},
+                    error.WriteFailed => {},
                     else => |cause| return cause,
                 };
             }
@@ -148,13 +156,12 @@ pub const Transport = struct {
     /// connection is worth a log line and whether shutdown() is worth a
     /// syscall.
     pub fn isPeerGone(err: anyerror) bool {
+        // A peer that closes the transport between TLS records without
+        // close_notify is rude but routine, and tls.zig reports it as
+        // `EndOfStream` like any other clean end. `TlsConnectionTruncated`,
+        // where a record was cut in half, is deliberately not here.
         return switch (err) {
             error.EndOfStream,
-            // Peer closed the transport between TLS records without
-            // close_notify. Rude, but routine from clients that just close
-            // the socket. `TlsTruncated`, where a record was cut in half, is
-            // deliberately not here.
-            error.TlsUnexpectedEof,
             error.ConnectionResetByPeer,
             error.BrokenPipe,
             => true,
@@ -171,10 +178,6 @@ test "Transport: no std.Io sentinel escapes a resolved error set" {
         inline for (@typeInfo(Set).error_set.?) |e| {
             try std.testing.expect(!std.mem.eql(u8, e.name, "ReadFailed"));
             try std.testing.expect(!std.mem.eql(u8, e.name, "WriteFailed"));
-            // The sentinels tls.zig stands in for them with, which mean
-            // "keep descending" and are equally useless to a caller.
-            try std.testing.expect(!std.mem.eql(u8, e.name, "TransportReadFailed"));
-            try std.testing.expect(!std.mem.eql(u8, e.name, "TransportWriteFailed"));
         }
     }
 }


### PR DESCRIPTION
`ianic` merged the fork's changes, so this points the `tls` dependency at [`ianic/tls.zig`](https://github.com/ianic/tls.zig) `zig-0.16.x` (`2dd6164`).

Four API differences between the fork commit we were pinned to and what actually landed upstream:

**Transport sentinels went back to `ReadFailed`/`WriteFailed`.** Upstream keeps the std names reserved for "the layer below me failed" — `Record.Writer` discharges its own buffer-full errors specifically to hold that meaning. A rename at the four descent sites in `Transport`, the two handshake error mappings in `client.zig`/`server.zig`, and the guard tests that asserted the fork's spellings stayed out of the resolved sets.

**`TlsUnexpectedEof` is gone.** A peer that closes between records without close_notify is now a clean end by default: `read` returns 0, so it arrives as plain `EndOfStream` with nothing recorded in `err`. `isPeerGone` already accepted that, so the arm just went away. `TlsTruncated`, still the mid-record case and still not "peer gone", is now `TlsConnectionTruncated`.

**`EndOfStream` leaks into the resolved read set.** tls.zig declares `ReadError = Io.Reader.Error || error{...}`, which drags in `EndOfStream` only to get the `ReadFailed` it wanted from `c.input` — even though `Connection.read` maps a clean end to zero bytes and never returns it. Unreachable, but statically present, so `checkReadError` maps it to `Unexpected` rather than swallowing it: left in the set it would read as the peer having hung up, to a caller that asked why a read *failed*.

**`CertKeyPair.fromFilePath` no longer leaks `ReadFailed`.** `PrivateKey.fromFile` now takes the file and resolves its own read error, so the `TlsConfigUnreadable` translation in `Client.loadTlsState` is dead weight. Note this changes the error set of `fetch`: a misconfigured client certificate now fails with the real file error (`FileNotFound`, `AccessDenied`, …) instead of the placeholder.

`./check.sh` passes: build, examples, httpbin, 323/323 tests.

---

Worth a follow-up upstream: narrowing `Connection.ReadError` to `error{ReadFailed} || error{...}` would make `Reader.Error` honest and render both the `EndOfStream` arm added here and the `if (err == error.EndOfStream)` branch in `Reader.stream` provably dead.